### PR TITLE
fix: follow symlinks when grepping for desktop entries

### DIFF
--- a/freedesktop/browser_service.go
+++ b/freedesktop/browser_service.go
@@ -30,7 +30,7 @@ func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error)
 
 	// grep all the .desktop files in the paths for the category "WebBrowser":
 	grepArgs := []string{
-		"-r",
+		"-R",
 		"-l",
 		"-E",
 		"^Categories=.*WebBrowser",

--- a/freedesktop/xdg_service.go
+++ b/freedesktop/xdg_service.go
@@ -39,7 +39,7 @@ func (x *XdgService) GetDesktopEntryPathForBinary(binary string) (string, error)
 
 	// grep all the .desktop files in the paths for the binary basename and return the first match:
 	pattern := fmt.Sprintf("^Exec=(%s|%s)", binary, filepath.Base(binary))
-	grepArgs := []string{"-r", "-l", "-m", "1", "-E", pattern, "--include", "*.desktop"}
+	grepArgs := []string{"-R", "-l", "-m", "1", "-E", pattern, "--include", "*.desktop"}
 	grepArgs = append(grepArgs, paths...)
 	cmd := exec.Command("grep", grepArgs...)
 


### PR DESCRIPTION
Thank you for writing linkquisition. It's such a great default browser
replacement for those of us that like to use different browsers and profiles
for different purposes. It does just what I need, and no more. I hope you find
this pull request acceptable. It's a small thing, but needed for those who have
symlinks within their $XDG_DATA_DIRS paths. I don't know how common that is,
but it at least affects people installing browsers with Nix home-manager.

---

When running browsers installed via the Nix home-manager, the browser
.desktop files will be found within `~/.nix-profile/share/applications/`
and `~/.nix-profile/share` will be in `$XDG_DATA_DIRS`. The
`~/.nix-profile/share` directory is a symlink, and `grep -r` will follow
that successfully, but then the `applications/firefox.desktop` within
will also be a symlink. A `grep -r` won't follow that, so we have to use
`grep -R` to follow all symlinks to actually find the desktop entries.

For example, without this fix, I see the following when running
`linkquisition https://google.com`.

    failed to call grep for determining a .desktop entry for firefox -P Personal --class=firefox-personal %U: exit status 1
    failed to call grep for determining a .desktop entry for google-chrome-stable --user-data-dir="/home/cluther/.config/google-chrome-personal" %U: exit status 1

With this change, linkquisition is able to auto-detect all of the
browser entries I have, and launch into them without error.
