### PR TITLE
feat: add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 !.golangci.yml
 !.release.yml
 /bin/
-/package/
+/package/linux/
 /dist/
 /test/
 gl-code-quality-report.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,10 @@ builds:
     binary: "linkquisition"
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=1
     main: ./cmd/
@@ -16,6 +18,9 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commitSHA={{.FullCommit}}
       - -X main.buildDate={{.Date}}
+    ignore:
+      - goos: linux
+        goarch: arm64
 
   - id: "unwrap-plugin"
     binary: "plugins/unwrap.so"

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -14,7 +14,7 @@ tasks:
         sh: echo ${VERSION:-v0.0.0}
       OPTIONS: '{{default "" .DEVOPTIONS}}'
     cmds:
-      - CGO_ENABLED=1 GOOS={{.TARGET}} go build -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} cmd/*.go
+      - CGO_ENABLED=1 GOOS={{.TARGET}} go build -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
       - echo "bin/{{.OUTPUT}}{{exeExt}} created successfully"
     sources:
       - ./**/*.go
@@ -29,6 +29,20 @@ tasks:
         vars:
           OUTPUT: "linkquisition-linux-amd64"
           TARGET: "linux"
+
+  darwin-arm64:
+    cmds:
+      - task: binary
+        vars:
+          OUTPUT: "linkquisition-darwin-arm64"
+          TARGET: "darwin"
+
+  darwin-amd64:
+    cmds:
+      - task: binary
+        vars:
+          OUTPUT: "linkquisition-darwin-amd64"
+          TARGET: "darwin"
 
   plugins:
     cmds:

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -28,3 +28,23 @@ tasks:
       - sed -i 's/{{ "{{" }}VERSION{{ "}}" }}/{{.VERSION}}/g' package/linux/DEBIAN/control
       - sed -i 's/{{ "{{" }}ARCH{{ "}}" }}/amd64/g' package/linux/DEBIAN/control
       - dpkg-deb --build package/linux dist/linkquisition_{{.VERSION}}_linux_amd64.deb
+
+  app:
+    description: "Builds a macOS .app bundle and optionally installs it"
+    cmds:
+      - task build:darwin-arm64
+      - rm -rf dist/Linkquisition.app
+      - mkdir -p dist/Linkquisition.app/Contents/MacOS
+      - mkdir -p dist/Linkquisition.app/Contents/Resources
+      - cp bin/linkquisition-darwin-arm64 dist/Linkquisition.app/Contents/MacOS/linkquisition
+      - sed 's/${VERSION}/{{.VERSION}}/g' package/darwin/Info.plist > dist/Linkquisition.app/Contents/Info.plist
+      - sips -s format icns Icon.png --out dist/Linkquisition.app/Contents/Resources/Icon.icns 2>/dev/null || cp Icon.png dist/Linkquisition.app/Contents/Resources/Icon.icns
+      - echo "dist/Linkquisition.app created successfully"
+
+  app:install:
+    description: "Builds the .app bundle and installs it to /Applications"
+    cmds:
+      - task package:app
+      - cp -r dist/Linkquisition.app /Applications/
+      - /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -R -f /Applications/Linkquisition.app
+      - echo "Installed to /Applications/Linkquisition.app and registered with Launch Services"

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -12,10 +12,8 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/app"
 
 	"github.com/strobotti/linkquisition"
-	"github.com/strobotti/linkquisition/freedesktop"
 )
 
 const logDirPerms = 0755
@@ -23,44 +21,11 @@ const logFilePerms = 0644
 
 type Application struct {
 	Fapp            fyne.App
-	XdgService      freedesktop.XdgService
 	BrowserService  linkquisition.BrowserService
 	SettingsService linkquisition.SettingsService
 
 	Logger  *slog.Logger
 	plugins []linkquisition.Plugin
-}
-
-func NewApplication() *Application {
-	fapp := app.New()
-
-	xdgService := &freedesktop.XdgService{}
-	browserService := &freedesktop.BrowserService{
-		XdgService:          xdgService,
-		DesktopEntryService: &freedesktop.DesktopEntryService{},
-		BrowserIconLoader: &freedesktop.DefaultBrowserIconLoader{
-			XdgService:          xdgService,
-			DesktopEntryService: &freedesktop.DesktopEntryService{},
-		},
-	}
-
-	settingsService := &freedesktop.SettingsService{
-		BrowserService: browserService,
-	}
-
-	logger := setupLogger(settingsService)
-
-	pluginServiceProvider := linkquisition.NewPluginServiceProvider(logger, settingsService.GetSettings())
-
-	a := &Application{
-		Fapp:            fapp,
-		BrowserService:  browserService,
-		SettingsService: settingsService,
-		Logger:          logger,
-		plugins:         setupPlugins(settingsService, pluginServiceProvider, logger),
-	}
-
-	return a
 }
 
 func setupPlugins(
@@ -170,33 +135,37 @@ func setupLogger(settingsService linkquisition.SettingsService) *slog.Logger {
 
 func (a *Application) Run(_ context.Context) error {
 	args := os.Args
-	if len(args) < 2 { //nolint:mnd
+
+	urlToOpen := ""
+
+	if len(args) >= 2 { //nolint:mnd
+		if args[1] == "--version" || args[1] == "-v" || args[1] == "version" {
+			fmt.Printf("Version: %s\n", version)
+			return nil
+		}
+		urlToOpen = args[1]
+	} else {
+		// No CLI args — check if a URL arrived via platform event (macOS Apple Events)
+		urlToOpen = getURLFromPlatformEvent()
+	}
+
+	if urlToOpen == "" {
 		configurator := NewConfigurator(a.Fapp, a.BrowserService, a.SettingsService)
 		return configurator.Run()
 	}
 
-	if args[1] == "--version" || args[1] == "-v" || args[1] == "version" {
-		fmt.Printf("Version: %s\n", version)
-		return nil
-	}
-
-	var browsers []linkquisition.Browser
-
-	var err error
-
-	a.Logger.Debug(fmt.Sprintf("Starting linkquisition with args: `%s`", strings.Join(os.Args, " ")))
-
-	urlToOpen := args[1]
-
-	if _, err = url.ParseRequestURI(urlToOpen); err != nil {
+	if _, err := url.ParseRequestURI(urlToOpen); err != nil {
 		a.Logger.Error("Invalid URL: " + urlToOpen)
-
 		return nil
 	}
+
+	a.Logger.Debug(fmt.Sprintf("Starting linkquisition with URL: `%s`", urlToOpen))
 
 	for _, plug := range a.plugins {
 		urlToOpen = plug.ModifyUrl(urlToOpen)
 	}
+
+	var browsers []linkquisition.Browser
 
 	isConfigured, configErr := a.SettingsService.IsConfigured()
 	if configErr != nil {
@@ -211,9 +180,11 @@ func (a *Application) Run(_ context.Context) error {
 			}
 		}
 		browsers = a.SettingsService.GetSettings().GetSelectableBrowsers()
-	} else if browsers, err = a.BrowserService.GetAvailableBrowsers(); err != nil {
-		return err
 	} else {
+		var err error
+		if browsers, err = a.BrowserService.GetAvailableBrowsers(); err != nil {
+			return err
+		}
 		a.Logger.Warn("browsers not configured, falling back to system settings")
 	}
 

--- a/cmd/application_darwin.go
+++ b/cmd/application_darwin.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package main
+
+import (
+	"fyne.io/fyne/v2/app"
+
+	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/darwin"
+)
+
+func newPlatformServices() (linkquisition.BrowserService, linkquisition.SettingsService) {
+	browserService := &darwin.BrowserService{}
+
+	settingsService := &darwin.SettingsService{
+		BrowserService: browserService,
+	}
+
+	return browserService, settingsService
+}
+
+// getURLFromPlatformEvent registers the Apple Event handler, briefly pumps the macOS
+// run loop to receive any pending URL event, and returns it (or empty string).
+func getURLFromPlatformEvent() string {
+	darwin.RegisterURLHandler()
+
+	// Pump the run loop to allow the Apple Event to be delivered.
+	darwin.PumpEvents(0.5)
+
+	// Check if a URL arrived
+	select {
+	case u := <-darwin.URLChannel:
+		return u
+	default:
+		return ""
+	}
+}
+
+func NewApplication() *Application {
+	fapp := app.New()
+	browserService, settingsService := newPlatformServices()
+
+	logger := setupLogger(settingsService)
+	pluginServiceProvider := linkquisition.NewPluginServiceProvider(logger, settingsService.GetSettings())
+
+	return &Application{
+		Fapp:            fapp,
+		BrowserService:  browserService,
+		SettingsService: settingsService,
+		Logger:          logger,
+		plugins:         setupPlugins(settingsService, pluginServiceProvider, logger),
+	}
+}

--- a/cmd/application_linux.go
+++ b/cmd/application_linux.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package main
+
+import (
+	"fyne.io/fyne/v2/app"
+
+	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/freedesktop"
+)
+
+func newPlatformServices() (linkquisition.BrowserService, linkquisition.SettingsService) {
+	xdgService := &freedesktop.XdgService{}
+	browserService := &freedesktop.BrowserService{
+		XdgService:          xdgService,
+		DesktopEntryService: &freedesktop.DesktopEntryService{},
+		BrowserIconLoader: &freedesktop.DefaultBrowserIconLoader{
+			XdgService:          xdgService,
+			DesktopEntryService: &freedesktop.DesktopEntryService{},
+		},
+	}
+
+	settingsService := &freedesktop.SettingsService{
+		BrowserService: browserService,
+	}
+
+	return browserService, settingsService
+}
+
+// getURLFromPlatformEvent on Linux always returns empty — URLs come via argv.
+func getURLFromPlatformEvent() string {
+	return ""
+}
+
+func NewApplication() *Application {
+	fapp := app.New()
+	browserService, settingsService := newPlatformServices()
+
+	logger := setupLogger(settingsService)
+	pluginServiceProvider := linkquisition.NewPluginServiceProvider(logger, settingsService.GetSettings())
+
+	return &Application{
+		Fapp:            fapp,
+		BrowserService:  browserService,
+		SettingsService: settingsService,
+		Logger:          logger,
+		plugins:         setupPlugins(settingsService, pluginServiceProvider, logger),
+	}
+}

--- a/darwin/browser_service.go
+++ b/darwin/browser_service.go
@@ -1,0 +1,313 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"fyne.io/fyne/v2"
+
+	"github.com/strobotti/linkquisition"
+)
+
+var _ linkquisition.BrowserService = (*BrowserService)(nil)
+
+type BrowserService struct{}
+
+type lsRegisterEntry struct {
+	BundleID   string
+	Name       string
+	Path       string
+	URLSchemes []string
+}
+
+func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error) {
+	entries, err := b.getHTTPHandlers()
+	if err != nil {
+		return nil, err
+	}
+
+	var browsers []linkquisition.Browser
+	seen := make(map[string]bool)
+
+	for _, entry := range entries {
+		if seen[entry.BundleID] {
+			continue
+		}
+		// Skip ourselves
+		if strings.Contains(entry.BundleID, "linkquisition") {
+			continue
+		}
+		seen[entry.BundleID] = true
+		browsers = append(browsers, linkquisition.Browser{
+			Name:    entry.Name,
+			Command: entry.BundleID,
+		})
+	}
+
+	return browsers, nil
+}
+
+func (b *BrowserService) getHTTPHandlers() ([]lsRegisterEntry, error) {
+	// Use the Swift helper via 'open' heuristics and system_profiler won't work cleanly.
+	// Instead, use LSCopyAllHandlersForURLScheme via a small Swift script, or parse
+	// the output of `lsregister -dump` which is too complex.
+	// Pragmatic approach: use defaults + known browser bundle IDs + check what's installed.
+	cmd := exec.Command("/usr/bin/python3", "-c", `
+import json, subprocess, plistlib, os, glob
+
+browsers = []
+app_dirs = ["/Applications", os.path.expanduser("~/Applications")]
+
+for app_dir in app_dirs:
+    if not os.path.isdir(app_dir):
+        continue
+    for app in glob.glob(os.path.join(app_dir, "*.app")):
+        plist_path = os.path.join(app, "Contents", "Info.plist")
+        if not os.path.exists(plist_path):
+            continue
+        try:
+            with open(plist_path, "rb") as f:
+                plist = plistlib.load(f)
+            url_types = plist.get("CFBundleURLTypes", [])
+            for url_type in url_types:
+                schemes = [s.lower() for s in url_type.get("CFBundleURLSchemes", [])]
+                if "http" in schemes or "https" in schemes:
+                    bundle_id = plist.get("CFBundleIdentifier", "")
+                    name = plist.get("CFBundleDisplayName") or plist.get("CFBundleName") or os.path.basename(app).replace(".app", "")
+                    browsers.append({"bundleId": bundle_id, "name": name, "path": app})
+                    break
+        except Exception:
+            pass
+
+print(json.dumps(browsers))
+`)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to discover browsers: %v", err)
+	}
+
+	var results []struct {
+		BundleID string `json:"bundleId"`
+		Name     string `json:"name"`
+		Path     string `json:"path"`
+	}
+
+	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+		return nil, fmt.Errorf("failed to parse browser list: %v", err)
+	}
+
+	var entries []lsRegisterEntry
+	for _, r := range results {
+		entries = append(entries, lsRegisterEntry{
+			BundleID: r.BundleID,
+			Name:     r.Name,
+			Path:     r.Path,
+		})
+	}
+
+	return entries, nil
+}
+
+func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
+	// Read the default HTTP handler
+	cmd := exec.Command("/usr/bin/python3", "-c", `
+import subprocess, re
+result = subprocess.run(["defaults", "read", "com.apple.LaunchServices/com.apple.launchservices.secure", "LSHandlers"], capture_output=True, text=True)
+# Fallback: use the x-scheme-handler approach
+import Foundation
+from Foundation import NSBundle
+# Actually simplest: use open command
+import subprocess as sp
+r = sp.run(["plutil", "-convert", "json", "-o", "-", "/Users/"+__import__("os").environ.get("USER","")+"//Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"], capture_output=True, text=True)
+`)
+	// The above is too fragile. Use a simpler approach:
+	cmd = exec.Command("/usr/bin/python3", "-c", `
+import json, subprocess
+# On macOS, we can get the default browser bundle ID from LaunchServices
+# Using the 'defaults' command to read the handler for https
+import plistlib, os
+
+plist_path = os.path.expanduser("~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist")
+bundle_id = "com.apple.Safari"  # default fallback
+
+try:
+    with open(plist_path, "rb") as f:
+        data = plistlib.load(f)
+    for handler in data.get("LSHandlers", []):
+        if handler.get("LSHandlerURLScheme") == "https":
+            bundle_id = handler.get("LSHandlerRoleAll", bundle_id)
+            break
+except Exception:
+    pass
+
+print(bundle_id)
+`)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		// Fallback to Safari
+		return linkquisition.Browser{Name: "Safari", Command: "com.apple.Safari"}, nil
+	}
+
+	bundleID := strings.TrimSpace(out.String())
+	if bundleID == "" {
+		bundleID = "com.apple.Safari"
+	}
+
+	name := bundleIDToName(bundleID)
+
+	return linkquisition.Browser{Name: name, Command: bundleID}, nil
+}
+
+func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
+	cmd := exec.Command("open", url)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to open URL `%s` with default browser: %v", url, err)
+	}
+	return nil
+}
+
+func (b *BrowserService) OpenUrlWithBrowser(url string, browser *linkquisition.Browser) error {
+	cmd := exec.Command("open", "-b", browser.Command, url)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to open URL `%s` with browser `%s`: %v", url, browser.Name, err)
+	}
+	return nil
+}
+
+func (b *BrowserService) AreWeTheDefaultBrowser() bool {
+	defaultBrowser, err := b.GetDefaultBrowser()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(defaultBrowser.Command), "linkquisition")
+}
+
+func (b *BrowserService) MakeUsTheDefaultBrowser() error {
+	// On macOS, setting the default browser requires the app to be a registered URL handler.
+	// The OS will show a confirmation dialog. We use LSSetDefaultHandlerForURLScheme via Swift.
+	script := `
+import Foundation
+import CoreServices
+let bundleID = "com.strobotti.linkquisition" as CFString
+LSSetDefaultHandlerForURLScheme("http" as CFString, bundleID)
+LSSetDefaultHandlerForURLScheme("https" as CFString, bundleID)
+`
+	cmd := exec.Command("swift", "-e", script)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set as default browser: %v", err)
+	}
+	return nil
+}
+
+func (b *BrowserService) GetIconForBrowser(browser linkquisition.Browser) ([]byte, error) {
+	// Find the app bundle by bundle ID and extract its icon
+	appPath, err := getAppPathForBundleID(browser.Command)
+	if err != nil {
+		return nil, err
+	}
+
+	iconPath := getIconPathFromApp(appPath)
+	if iconPath == "" {
+		return nil, fmt.Errorf("no icon found for %s", browser.Name)
+	}
+
+	// Convert .icns to PNG using sips
+	cmd := exec.Command("sips", "-s", "format", "png", iconPath, "--out", "/tmp/linkquisition-icon-tmp.png")
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to convert icon: %v", err)
+	}
+
+	icon, err := fyne.LoadResourceFromPath("/tmp/linkquisition-icon-tmp.png")
+	if err != nil {
+		return nil, err
+	}
+
+	return icon.Content(), nil
+}
+
+func getAppPathForBundleID(bundleID string) (string, error) {
+	cmd := exec.Command("mdfind", fmt.Sprintf("kMDItemCFBundleIdentifier == '%s'", bundleID))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to find app for bundle ID %s: %v", bundleID, err)
+	}
+
+	path := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if path == "" {
+		return "", fmt.Errorf("app not found for bundle ID %s", bundleID)
+	}
+
+	return path, nil
+}
+
+func getIconPathFromApp(appPath string) string {
+	// Read Info.plist to find icon file name
+	cmd := exec.Command("/usr/bin/python3", "-c", fmt.Sprintf(`
+import plistlib, os
+plist_path = "%s/Contents/Info.plist"
+try:
+    with open(plist_path, "rb") as f:
+        data = plistlib.load(f)
+    icon = data.get("CFBundleIconFile", "")
+    if icon and not icon.endswith(".icns"):
+        icon += ".icns"
+    print(icon)
+except Exception:
+    print("")
+`, appPath))
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+
+	iconFile := strings.TrimSpace(out.String())
+	if iconFile == "" {
+		return ""
+	}
+
+	return filepath.Join(appPath, "Contents", "Resources", iconFile)
+}
+
+func bundleIDToName(bundleID string) string {
+	known := map[string]string{
+		"com.apple.Safari":           "Safari",
+		"com.google.Chrome":          "Google Chrome",
+		"org.mozilla.firefox":        "Firefox",
+		"com.microsoft.edgemac":      "Microsoft Edge",
+		"com.brave.Browser":          "Brave Browser",
+		"com.operasoftware.Opera":    "Opera",
+		"com.vivaldi.Vivaldi":        "Vivaldi",
+		"company.thebrowser.Browser": "Arc",
+		"com.nickvision.Midori":      "Midori",
+	}
+
+	if name, ok := known[bundleID]; ok {
+		return name
+	}
+
+	// Try to look it up
+	appPath, err := getAppPathForBundleID(bundleID)
+	if err == nil {
+		return filepath.Base(strings.TrimSuffix(appPath, ".app"))
+	}
+
+	// Last resort: use the last part of the bundle ID
+	parts := strings.Split(bundleID, ".")
+	return parts[len(parts)-1]
+}

--- a/darwin/settings.go
+++ b/darwin/settings.go
@@ -1,6 +1,6 @@
-//go:build linux
+//go:build darwin
 
-package freedesktop
+package darwin
 
 import (
 	"encoding/json"
@@ -26,12 +26,11 @@ func (s *SettingsService) GetConfigFilePath() string {
 }
 
 func (s *SettingsService) GetConfigFolderPath() string {
-	// get the user's home directory
 	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return ".config"
+		homeDir, _ := os.UserHomeDir()
+		return filepath.Join(homeDir, "Library", "Application Support", "linkquisition")
 	}
-
 	return filepath.Join(configDir, "linkquisition")
 }
 
@@ -40,21 +39,16 @@ func (s *SettingsService) GetLogFilePath() string {
 }
 
 func (s *SettingsService) GetLogFolderPath() string {
-	stateDir, isset := os.LookupEnv("XDG_STATE_HOME")
-	if isset {
-		return filepath.Join(stateDir, "linkquisition")
-	}
-
 	homeDir, err := os.UserHomeDir()
-	if err == nil {
-		return filepath.Join(homeDir, ".local", "state", "linkquisition")
+	if err != nil {
+		return filepath.Join(os.TempDir(), "linkquisition")
 	}
-
-	return filepath.Join(os.TempDir(), "linkquisition")
+	return filepath.Join(homeDir, "Library", "Logs", "linkquisition")
 }
 
 func (s *SettingsService) GetPluginFolderPath() string {
-	return "/usr/lib/linkquisition/plugins"
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, "Library", "Application Support", "linkquisition", "plugins")
 }
 
 func (s *SettingsService) ReadSettings() (*linkquisition.Settings, error) {
@@ -64,7 +58,6 @@ func (s *SettingsService) ReadSettings() (*linkquisition.Settings, error) {
 	}
 
 	var settings = &linkquisition.Settings{}
-
 	if err := json.Unmarshal(data, settings); err != nil {
 		return nil, fmt.Errorf("unable to parse the config-file `%s`: %v", s.GetConfigFilePath(), err)
 	}
@@ -78,7 +71,6 @@ func (s *SettingsService) WriteSettings(settings *linkquisition.Settings) error 
 		return fmt.Errorf("unable to marshal settings: %v", err)
 	}
 
-	// ensure the directory exists
 	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
 		return fmt.Errorf("failed to write settings: %v", errMkdir)
 	}
@@ -96,7 +88,6 @@ func (s *SettingsService) IsConfigured() (bool, error) {
 	}
 
 	_, err := s.ReadSettings()
-
 	return err == nil, err
 }
 
@@ -133,7 +124,6 @@ func (s *SettingsService) ScanBrowsers() error {
 
 	newSettings := oldSettings.UpdateWithBrowsers(browsers).NormalizeBrowsers()
 
-	// ensure the directory exists
 	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
 		return fmt.Errorf("failed to scan browsers: %v", errMkdir)
 	}
@@ -143,8 +133,7 @@ func (s *SettingsService) ScanBrowsers() error {
 		return fmt.Errorf("failed to scan browsers: %v", err)
 	}
 
-	//nolint:mnd
-	if err := os.WriteFile(s.GetConfigFilePath(), data, 0600); err != nil {
+	if err := os.WriteFile(s.GetConfigFilePath(), data, os.FileMode(configFilePerms)); err != nil {
 		return fmt.Errorf("failed to scan browsers: %v", err)
 	}
 

--- a/darwin/url_handler.go
+++ b/darwin/url_handler.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package darwin
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa -framework Carbon
+#include "url_handler.h"
+*/
+import "C"
+
+// URLChannel receives URLs sent to the app via macOS Apple Events.
+var URLChannel = make(chan string, 1)
+
+//export HandleURL
+func HandleURL(u *C.char) {
+	// Non-blocking send; drop if channel is full (shouldn't happen in practice)
+	select {
+	case URLChannel <- C.GoString(u):
+	default:
+	}
+}
+
+// RegisterURLHandler registers the Apple Event handler for kAEGetURL.
+// Must be called before the UI event loop starts.
+func RegisterURLHandler() {
+	C.StartURLHandler()
+}
+
+// PumpEvents runs the macOS run loop briefly to allow pending Apple Events to be delivered.
+func PumpEvents(seconds float64) {
+	C.PumpEvents(C.double(seconds))
+}

--- a/darwin/url_handler.h
+++ b/darwin/url_handler.h
@@ -1,0 +1,11 @@
+#import <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
+
+extern void HandleURL(char*);
+
+@interface GoPasser : NSObject
++ (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
+@end
+
+void StartURLHandler(void);
+void PumpEvents(double seconds);

--- a/darwin/url_handler.m
+++ b/darwin/url_handler.m
@@ -1,0 +1,38 @@
+#include "url_handler.h"
+
+@implementation GoPasser
+
++ (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
+    NSString *urlStr = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    if (urlStr != nil) {
+        HandleURL((char *)[urlStr UTF8String]);
+    }
+}
+
+@end
+
+void StartURLHandler(void) {
+    NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
+    [appleEventManager setEventHandler:[GoPasser class]
+                           andSelector:@selector(handleGetURLEvent:withReplyEvent:)
+                         forEventClass:kInternetEventClass
+                            andEventID:kAEGetURL];
+}
+
+void PumpEvents(double seconds) {
+    // Ensure NSApplication is initialized
+    [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp finishLaunching];
+
+    // Process events for the specified duration
+    NSDate *until = [NSDate dateWithTimeIntervalSinceNow:seconds];
+    while (true) {
+        NSEvent *event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                           untilDate:until
+                                              inMode:NSDefaultRunLoopMode
+                                             dequeue:YES];
+        if (event == nil) break;
+        [NSApp sendEvent:event];
+    }
+}

--- a/freedesktop/browser_icon_loader.go
+++ b/freedesktop/browser_icon_loader.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package freedesktop
 
 import (

--- a/freedesktop/browser_service.go
+++ b/freedesktop/browser_service.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package freedesktop
 
 import (

--- a/freedesktop/desktop_entry.go
+++ b/freedesktop/desktop_entry.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package freedesktop
 
 import (

--- a/freedesktop/xdg_service.go
+++ b/freedesktop/xdg_service.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package freedesktop
 
 import (

--- a/package/darwin/Info.plist
+++ b/package/darwin/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>linkquisition</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.strobotti.linkquisition</string>
+    <key>CFBundleName</key>
+    <string>Linkquisition</string>
+    <key>CFBundleDisplayName</key>
+    <string>Linkquisition</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundleIconFile</key>
+    <string>Icon.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Web URL</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>http</string>
+                <string>https</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Implement platform abstraction to run Linkquisition on macOS in addition to Linux.

- Add `darwin/` package implementing BrowserService and SettingsService for macOS (browser discovery via Info.plist scanning, URL opening via `open -b`, icon extraction via sips)
- Add Apple Event URL handler (Objective-C via cgo) so macOS can deliver URLs when Linkquisition is set as the default browser
- Split `cmd/application.go` into platform-specific files using build tags (linux/darwin) with a shared `getURLFromPlatformEvent()` hook
- Add `//go:build linux` tags to all `freedesktop/` files
- Add macOS build targets (darwin-arm64, darwin-amd64) to Taskfile
- Add `package:app` and `package:app:install` tasks for .app bundle
- Add `package/darwin/Info.plist` with http/https URL scheme registration
- Update .goreleaser.yaml with darwin targets
- Fix build command to use `./cmd/` package path instead of glob