### PR TITLE
fix: improve macOS .app packaging with ad-hoc codesigning and ditto

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,8 @@ jobs:
         if: matrix.target == 'darwin-arm64'
         run: |
           task package:app
-          cd dist && zip -r Linkquisition_macOS_arm64.zip Linkquisition.app
+          codesign --force --deep --sign - dist/Linkquisition.app
+          cd dist && ditto -c -k --keepParent Linkquisition.app Linkquisition_macOS_arm64.zip
         env:
           VERSION: ${{ needs.version.outputs.version }}
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![coverage](https://raw.githubusercontent.com/Strobotti/linkquisition/gh-pages/.badges/main/coverage.svg)
 
-Linkquisition is a fast, configurable browser-picker for Linux desktop written in Go.
+Linkquisition is a fast, configurable browser-picker for Linux (and experimentally macOS) written in Go.
 
 ...as nobody expects the Linkquisition!
 
@@ -34,6 +34,8 @@ Motivation behind this project is:
 
 ## Installation
 
+### Linux
+
 You can download the latest `.deb` package from
 the [releases page](https://github.com/Strobotti/linkquisition/releases).
 
@@ -41,6 +43,18 @@ The installation contains everything needed to launch the application using the 
 able to press `Super`-key in Ubuntu and type "Linkquisition" to see the launcher. To do the same in terminal just run
 `linkquisition` command. Launching the application without any arguments will show the configuration screen which allows
 you to set it as the default browser and scan for installed browsers for faster startup and easier configuration.
+
+### macOS (experimental)
+
+Download the latest `Linkquisition_macOS_arm64.zip` from
+the [releases page](https://github.com/Strobotti/linkquisition/releases), unzip it, and move
+`Linkquisition.app` to `/Applications`.
+
+Since the app is not notarized with Apple, macOS will block it on first launch. To fix this, run:
+
+```bash
+xattr -cr /Applications/Linkquisition.app
+```
 
 ## Configuration
 


### PR DESCRIPTION
Fixes the "app is damaged and can't be opened" error when downloading the macOS release from GitHub.

## Changes:
Ad-hoc codesign the  .app  bundle before zipping (passes Apple Silicon code integrity checks)
Use  ditto  instead of  zip  to preserve macOS metadata and bundle structure
Add macOS installation section to README with  xattr -cr  workaround
Update project tagline to mention experimental macOS support