### PR TITLE
feat: embed plugins with macOS release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,6 +107,7 @@ jobs:
         if: matrix.target == 'darwin-arm64'
         run: |
           task package:app
+          task build:plugins-darwin
           codesign --force --deep --sign - dist/Linkquisition.app
           cd dist && ditto -c -k --keepParent Linkquisition.app Linkquisition_macOS_arm64.zip
         env:

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -50,6 +50,12 @@ tasks:
       - go build -buildmode=plugin -o package/linux/usr/lib/linkquisition/plugins/unwrap.so ./plugins/unwrap/unwrap.go
       - go build -buildmode=plugin -o package/linux/usr/lib/linkquisition/plugins/terminus.so ./plugins/terminus/terminus.go
 
+  plugins-darwin:
+    cmds:
+      - mkdir -p dist/Linkquisition.app/Contents/Resources/plugins
+      - go build -buildmode=plugin -o dist/Linkquisition.app/Contents/Resources/plugins/unwrap.so ./plugins/unwrap/unwrap.go
+      - go build -buildmode=plugin -o dist/Linkquisition.app/Contents/Resources/plugins/terminus.so ./plugins/terminus/terminus.go
+
   clean:
     cmds:
       - rm -rf bin/*

--- a/darwin/settings.go
+++ b/darwin/settings.go
@@ -47,6 +47,13 @@ func (s *SettingsService) GetLogFolderPath() string {
 }
 
 func (s *SettingsService) GetPluginFolderPath() string {
+	execPath, err := os.Executable()
+	if err == nil {
+		bundlePath := filepath.Join(filepath.Dir(execPath), "..", "Resources", "plugins")
+		if _, statErr := os.Stat(bundlePath); statErr == nil {
+			return bundlePath
+		}
+	}
 	homeDir, _ := os.UserHomeDir()
 	return filepath.Join(homeDir, "Library", "Application Support", "linkquisition", "plugins")
 }


### PR DESCRIPTION
- Add build:plugins-darwin task that builds plugins into the .app bundle
- Update publish.yml to run build:plugins-darwin during macOS packaging
- Update darwin GetPluginFolderPath() to prefer bundled plugins path