### PR TITLE
feat: add man pages using scdoc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev scdoc
 
       - uses: arduino/setup-task@v2
         with:
@@ -137,7 +137,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev scdoc
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - uses: arduino/setup-task@v2

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ amd64, as I do not have time/access to other architectures for testing easily.
 - Taskfile (https://taskfile.dev/#/installation)
 - Build-dependencies:
   ```shell
-  sudo apt-get update && sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+  sudo apt-get update && sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev scdoc
   ```
 
 ### Building locally

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -9,11 +9,19 @@ tasks:
     cmds:
       - rm -rfv dist package
 
+  manpages:
+    description: "Builds man pages from scdoc sources"
+    cmds:
+      - mkdir -p package/linux/usr/share/man/man1 package/linux/usr/share/man/man5
+      - scdoc < doc/linkquisition.1.scd > package/linux/usr/share/man/man1/linkquisition.1
+      - scdoc < doc/linkquisition.5.scd > package/linux/usr/share/man/man5/linkquisition.5
+
   linux:
     cmds:
       - mkdir -p package/linux/usr/share/applications package/linux/usr/share/pixmaps
       - cp Icon.png package/linux/usr/share/pixmaps/linkquisition.png
       - cp templates/linkquisition.desktop package/linux/usr/share/applications/linkquisition.desktop
+      - task: manpages
 
   deb:
     description: "Builds a Debian package for local testing"

--- a/doc/linkquisition.1.scd
+++ b/doc/linkquisition.1.scd
@@ -1,0 +1,58 @@
+linkquisition(1)
+
+# NAME
+
+linkquisition - a fast, configurable browser-picker for Linux
+
+# SYNOPSIS
+
+*linkquisition* [_URL_]++
+*linkquisition* --version
+
+# DESCRIPTION
+
+Linkquisition is a browser-picker that lets you choose which browser opens a
+given URL. When configured as the default browser, it intercepts all link
+activations and either opens the URL in a matching browser automatically (based
+on configured rules) or presents a picker window.
+
+When launched without arguments, Linkquisition opens the configuration screen.
+
+# OPTIONS
+
+*--version*, *-v*
+	Print the version and exit.
+
+# KEYBOARD SHORTCUTS
+
+*Enter*
+	Open the URL in the default (first) browser.
+
+*Ctrl+C*
+	Copy the URL to clipboard and close.
+
+*1-9*
+	Select a browser by its position in the list.
+
+# CONFIGURATION
+
+The configuration file is located at
+_~/.config/linkquisition/config.json_. See *linkquisition*(5) for the file
+format.
+
+Launching *linkquisition* without arguments opens the configuration screen,
+which allows you to set it as the default browser and scan for installed
+browsers.
+
+# PLUGINS
+
+Plugins are shared-object files (_.so_) loaded at startup. They can modify URLs
+before they are opened. See the project documentation for details.
+
+# SEE ALSO
+
+*linkquisition*(5), *xdg-settings*(1)
+
+# AUTHORS
+
+Juha Jantunen <juha@strobotti.com>

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -1,0 +1,113 @@
+linkquisition(5)
+
+# NAME
+
+linkquisition - configuration file format
+
+# SYNOPSIS
+
+_~/.config/linkquisition/config.json_
+
+# DESCRIPTION
+
+The configuration file controls which browsers are available, how URLs are
+matched to browsers, and which plugins are loaded.
+
+The file is JSON and is managed either manually or via the configuration screen
+(launched by running *linkquisition* with no arguments).
+
+# TOP-LEVEL KEYS
+
+*logLevel* (string, optional)
+	Log verbosity. One of: _debug_, _info_, _warn_, _error_. Default: _info_.
+
+*browsers* (array)
+	List of browser objects. See *BROWSER OBJECT* below.
+
+*plugins* (array, optional)
+	List of plugin objects. See *PLUGIN OBJECT* below.
+
+*ui* (object, optional)
+	UI settings. See *UI OBJECT* below.
+
+# BROWSER OBJECT
+
+*name* (string)
+	Display name of the browser.
+
+*command* (string)
+	Command to execute. Use _%U_ or _%u_ as the URL placeholder.
+
+*hidden* (boolean)
+	If _true_, the browser is not shown in the picker but rules still apply.
+
+*source* (string)
+	Either _auto_ (discovered by scan) or _manual_ (user-added). Browsers with
+	source _manual_ are never removed by a re-scan.
+
+*matches* (array, optional)
+	List of match-rule objects. See *MATCH OBJECT* below.
+
+# MATCH OBJECT
+
+*type* (string)
+	One of:
+	- *site* — matches the full hostname (e.g. _www.example.com_)
+	- *domain* — matches the registered domain (e.g. _example.com_)
+	- *regex* — matches the full URL against a regular expression
+
+*value* (string)
+	The value to match against (hostname, domain, or regex pattern).
+
+# PLUGIN OBJECT
+
+*path* (string)
+	Path to the plugin _.so_ file, absolute or relative to the plugin folder
+	(_/usr/lib/linkquisition/plugins/_).
+
+*isDisabled* (boolean)
+	If _true_, the plugin is not loaded.
+
+*settings* (object, optional)
+	Plugin-specific key-value settings.
+
+# UI OBJECT
+
+*hideKeyboardGuideLabel* (boolean, optional)
+	If _true_, hides the keyboard shortcut guide at the bottom of the picker.
+
+# EXAMPLE
+
+```
+{
+  "logLevel": "info",
+  "browsers": [
+    {
+      "name": "Firefox",
+      "command": "firefox %u",
+      "hidden": false,
+      "source": "auto",
+      "matches": [
+        {
+          "type": "site",
+          "value": "www.mozilla.org"
+        }
+      ]
+    }
+  ],
+  "plugins": [
+    {
+      "path": "unwrap",
+      "isDisabled": false
+    }
+  ]
+}
+```
+
+# SEE ALSO
+
+*linkquisition*(1)
+
+# AUTHORS
+
+Juha Jantunen <juha@strobotti.com>


### PR DESCRIPTION
Adds man pages for the Linux release:

- `linkquisition(1)` — command usage, options, and keyboard shortcuts
- `linkquisition(5)` — configuration file format documentation

Man pages are written in scdoc format (`doc/`) and compiled during `task package:linux`, so they're automatically included in `.deb`/`.rpm` packages at the standard `/usr/share/man/` location.

Also adds `scdoc` to the CI build dependencies and the README requirements list.