### PR TITLE
refactor: extract shared settings service

### DIFF
--- a/cmd/application_darwin.go
+++ b/cmd/application_darwin.go
@@ -12,8 +12,9 @@ import (
 func newPlatformServices() (linkquisition.BrowserService, linkquisition.SettingsService) {
 	browserService := &darwin.BrowserService{}
 
-	settingsService := &darwin.SettingsService{
+	settingsService := &linkquisition.FileSettingsService{
 		BrowserService: browserService,
+		PathProvider:   &darwin.PathProvider{},
 	}
 
 	return browserService, settingsService

--- a/cmd/application_linux.go
+++ b/cmd/application_linux.go
@@ -20,8 +20,9 @@ func newPlatformServices() (linkquisition.BrowserService, linkquisition.Settings
 		},
 	}
 
-	settingsService := &freedesktop.SettingsService{
+	settingsService := &linkquisition.FileSettingsService{
 		BrowserService: browserService,
+		PathProvider:   &freedesktop.PathProvider{},
 	}
 
 	return browserService, settingsService

--- a/darwin/settings.go
+++ b/darwin/settings.go
@@ -3,29 +3,17 @@
 package darwin
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/strobotti/linkquisition"
 )
 
-var configDirPerms = 0700
-var configFilePerms = 0600
+var _ linkquisition.PathProvider = (*PathProvider)(nil)
 
-var _ linkquisition.SettingsService = (*SettingsService)(nil)
+type PathProvider struct{}
 
-type SettingsService struct {
-	BrowserService linkquisition.BrowserService
-}
-
-func (s *SettingsService) GetConfigFilePath() string {
-	return filepath.Join(s.GetConfigFolderPath(), "config.json")
-}
-
-func (s *SettingsService) GetConfigFolderPath() string {
+func (p *PathProvider) GetConfigFolderPath() string {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		homeDir, _ := os.UserHomeDir()
@@ -34,11 +22,7 @@ func (s *SettingsService) GetConfigFolderPath() string {
 	return filepath.Join(configDir, "linkquisition")
 }
 
-func (s *SettingsService) GetLogFilePath() string {
-	return filepath.Join(s.GetLogFolderPath(), "linkquisition.log")
-}
-
-func (s *SettingsService) GetLogFolderPath() string {
+func (p *PathProvider) GetLogFolderPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), "linkquisition")
@@ -46,7 +30,7 @@ func (s *SettingsService) GetLogFolderPath() string {
 	return filepath.Join(homeDir, "Library", "Logs", "linkquisition")
 }
 
-func (s *SettingsService) GetPluginFolderPath() string {
+func (p *PathProvider) GetPluginFolderPath() string {
 	execPath, err := os.Executable()
 	if err == nil {
 		bundlePath := filepath.Join(filepath.Dir(execPath), "..", "Resources", "plugins")
@@ -56,93 +40,4 @@ func (s *SettingsService) GetPluginFolderPath() string {
 	}
 	homeDir, _ := os.UserHomeDir()
 	return filepath.Join(homeDir, "Library", "Application Support", "linkquisition", "plugins")
-}
-
-func (s *SettingsService) ReadSettings() (*linkquisition.Settings, error) {
-	data, err := os.ReadFile(s.GetConfigFilePath())
-	if err != nil {
-		return nil, fmt.Errorf("unable to open config-file `%s` for reading: %v", s.GetConfigFilePath(), err)
-	}
-
-	var settings = &linkquisition.Settings{}
-	if err := json.Unmarshal(data, settings); err != nil {
-		return nil, fmt.Errorf("unable to parse the config-file `%s`: %v", s.GetConfigFilePath(), err)
-	}
-
-	return settings, nil
-}
-
-func (s *SettingsService) WriteSettings(settings *linkquisition.Settings) error {
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return fmt.Errorf("unable to marshal settings: %v", err)
-	}
-
-	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
-		return fmt.Errorf("failed to write settings: %v", errMkdir)
-	}
-
-	if errWrite := os.WriteFile(s.GetConfigFilePath(), data, os.FileMode(configFilePerms)); errWrite != nil {
-		return fmt.Errorf("failed to write settings: %v", errWrite)
-	}
-
-	return nil
-}
-
-func (s *SettingsService) IsConfigured() (bool, error) {
-	if _, err := os.Stat(s.GetConfigFilePath()); errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-
-	_, err := s.ReadSettings()
-	return err == nil, err
-}
-
-func (s *SettingsService) GetSettings() *linkquisition.Settings {
-	isConfigured, err := s.IsConfigured()
-	if !isConfigured || err != nil {
-		return linkquisition.GetDefaultSettings()
-	}
-
-	settings, err := s.ReadSettings()
-	if err != nil {
-		return linkquisition.GetDefaultSettings()
-	}
-
-	return settings
-}
-
-func (s *SettingsService) ScanBrowsers() error {
-	var oldSettings *linkquisition.Settings
-
-	if isConfigured, configErr := s.IsConfigured(); !isConfigured || configErr != nil {
-		oldSettings = &linkquisition.Settings{}
-	} else {
-		var err error
-		if oldSettings, err = s.ReadSettings(); err != nil {
-			return fmt.Errorf("failed to scan browsers: %v", err)
-		}
-	}
-
-	browsers, err := s.BrowserService.GetAvailableBrowsers()
-	if err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	newSettings := oldSettings.UpdateWithBrowsers(browsers).NormalizeBrowsers()
-
-	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
-		return fmt.Errorf("failed to scan browsers: %v", errMkdir)
-	}
-
-	data, err := json.MarshalIndent(newSettings, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	if err := os.WriteFile(s.GetConfigFilePath(), data, os.FileMode(configFilePerms)); err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	return nil
 }

--- a/freedesktop/settings.go
+++ b/freedesktop/settings.go
@@ -3,30 +3,17 @@
 package freedesktop
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/strobotti/linkquisition"
 )
 
-var configDirPerms = 0700
-var configFilePerms = 0600
+var _ linkquisition.PathProvider = (*PathProvider)(nil)
 
-var _ linkquisition.SettingsService = (*SettingsService)(nil)
+type PathProvider struct{}
 
-type SettingsService struct {
-	BrowserService linkquisition.BrowserService
-}
-
-func (s *SettingsService) GetConfigFilePath() string {
-	return filepath.Join(s.GetConfigFolderPath(), "config.json")
-}
-
-func (s *SettingsService) GetConfigFolderPath() string {
-	// get the user's home directory
+func (p *PathProvider) GetConfigFolderPath() string {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return ".config"
@@ -35,11 +22,7 @@ func (s *SettingsService) GetConfigFolderPath() string {
 	return filepath.Join(configDir, "linkquisition")
 }
 
-func (s *SettingsService) GetLogFilePath() string {
-	return filepath.Join(s.GetLogFolderPath(), "linkquisition.log")
-}
-
-func (s *SettingsService) GetLogFolderPath() string {
+func (p *PathProvider) GetLogFolderPath() string {
 	stateDir, isset := os.LookupEnv("XDG_STATE_HOME")
 	if isset {
 		return filepath.Join(stateDir, "linkquisition")
@@ -53,100 +36,6 @@ func (s *SettingsService) GetLogFolderPath() string {
 	return filepath.Join(os.TempDir(), "linkquisition")
 }
 
-func (s *SettingsService) GetPluginFolderPath() string {
+func (p *PathProvider) GetPluginFolderPath() string {
 	return "/usr/lib/linkquisition/plugins"
-}
-
-func (s *SettingsService) ReadSettings() (*linkquisition.Settings, error) {
-	data, err := os.ReadFile(s.GetConfigFilePath())
-	if err != nil {
-		return nil, fmt.Errorf("unable to open config-file `%s` for reading: %v", s.GetConfigFilePath(), err)
-	}
-
-	var settings = &linkquisition.Settings{}
-
-	if err := json.Unmarshal(data, settings); err != nil {
-		return nil, fmt.Errorf("unable to parse the config-file `%s`: %v", s.GetConfigFilePath(), err)
-	}
-
-	return settings, nil
-}
-
-func (s *SettingsService) WriteSettings(settings *linkquisition.Settings) error {
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return fmt.Errorf("unable to marshal settings: %v", err)
-	}
-
-	// ensure the directory exists
-	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
-		return fmt.Errorf("failed to write settings: %v", errMkdir)
-	}
-
-	if errWrite := os.WriteFile(s.GetConfigFilePath(), data, os.FileMode(configFilePerms)); errWrite != nil {
-		return fmt.Errorf("failed to write settings: %v", errWrite)
-	}
-
-	return nil
-}
-
-func (s *SettingsService) IsConfigured() (bool, error) {
-	if _, err := os.Stat(s.GetConfigFilePath()); errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-
-	_, err := s.ReadSettings()
-
-	return err == nil, err
-}
-
-func (s *SettingsService) GetSettings() *linkquisition.Settings {
-	isConfigured, err := s.IsConfigured()
-	if !isConfigured || err != nil {
-		return linkquisition.GetDefaultSettings()
-	}
-
-	settings, err := s.ReadSettings()
-	if err != nil {
-		return linkquisition.GetDefaultSettings()
-	}
-
-	return settings
-}
-
-func (s *SettingsService) ScanBrowsers() error {
-	var oldSettings *linkquisition.Settings
-
-	if isConfigured, configErr := s.IsConfigured(); !isConfigured || configErr != nil {
-		oldSettings = &linkquisition.Settings{}
-	} else {
-		var err error
-		if oldSettings, err = s.ReadSettings(); err != nil {
-			return fmt.Errorf("failed to scan browsers: %v", err)
-		}
-	}
-
-	browsers, err := s.BrowserService.GetAvailableBrowsers()
-	if err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	newSettings := oldSettings.UpdateWithBrowsers(browsers).NormalizeBrowsers()
-
-	// ensure the directory exists
-	if errMkdir := os.MkdirAll(s.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
-		return fmt.Errorf("failed to scan browsers: %v", errMkdir)
-	}
-
-	data, err := json.MarshalIndent(newSettings, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	//nolint:mnd
-	if err := os.WriteFile(s.GetConfigFilePath(), data, 0600); err != nil {
-		return fmt.Errorf("failed to scan browsers: %v", err)
-	}
-
-	return nil
 }

--- a/settings_service.go
+++ b/settings_service.go
@@ -1,0 +1,124 @@
+package linkquisition
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const configDirPerms = 0700
+const configFilePerms = 0600
+
+// PathProvider supplies platform-specific paths used by the SettingsService.
+type PathProvider interface {
+	GetConfigFolderPath() string
+	GetLogFolderPath() string
+	GetPluginFolderPath() string
+}
+
+// FileSettingsService is the shared, platform-independent implementation of SettingsService.
+type FileSettingsService struct {
+	BrowserService BrowserService
+	PathProvider   PathProvider
+}
+
+var _ SettingsService = (*FileSettingsService)(nil)
+
+func (s *FileSettingsService) GetConfigFilePath() string {
+	return filepath.Join(s.PathProvider.GetConfigFolderPath(), "config.json")
+}
+
+func (s *FileSettingsService) GetLogFilePath() string {
+	return filepath.Join(s.PathProvider.GetLogFolderPath(), "linkquisition.log")
+}
+
+func (s *FileSettingsService) GetLogFolderPath() string {
+	return s.PathProvider.GetLogFolderPath()
+}
+
+func (s *FileSettingsService) GetPluginFolderPath() string {
+	return s.PathProvider.GetPluginFolderPath()
+}
+
+func (s *FileSettingsService) ReadSettings() (*Settings, error) {
+	data, err := os.ReadFile(s.GetConfigFilePath())
+	if err != nil {
+		return nil, fmt.Errorf("unable to open config-file `%s` for reading: %v", s.GetConfigFilePath(), err)
+	}
+
+	var settings = &Settings{}
+	if err := json.Unmarshal(data, settings); err != nil {
+		return nil, fmt.Errorf("unable to parse the config-file `%s`: %v", s.GetConfigFilePath(), err)
+	}
+
+	return settings, nil
+}
+
+func (s *FileSettingsService) WriteSettings(settings *Settings) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal settings: %v", err)
+	}
+
+	if errMkdir := os.MkdirAll(s.PathProvider.GetConfigFolderPath(), os.FileMode(configDirPerms)); errMkdir != nil {
+		return fmt.Errorf("failed to write settings: %v", errMkdir)
+	}
+
+	if errWrite := os.WriteFile(s.GetConfigFilePath(), data, os.FileMode(configFilePerms)); errWrite != nil {
+		return fmt.Errorf("failed to write settings: %v", errWrite)
+	}
+
+	return nil
+}
+
+func (s *FileSettingsService) IsConfigured() (bool, error) {
+	if _, err := os.Stat(s.GetConfigFilePath()); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+
+	_, err := s.ReadSettings()
+
+	return err == nil, err
+}
+
+func (s *FileSettingsService) GetSettings() *Settings {
+	isConfigured, err := s.IsConfigured()
+	if !isConfigured || err != nil {
+		return GetDefaultSettings()
+	}
+
+	settings, err := s.ReadSettings()
+	if err != nil {
+		return GetDefaultSettings()
+	}
+
+	return settings
+}
+
+func (s *FileSettingsService) ScanBrowsers() error {
+	var oldSettings *Settings
+
+	if isConfigured, configErr := s.IsConfigured(); !isConfigured || configErr != nil {
+		oldSettings = &Settings{}
+	} else {
+		var err error
+		if oldSettings, err = s.ReadSettings(); err != nil {
+			return fmt.Errorf("failed to scan browsers: %v", err)
+		}
+	}
+
+	browsers, err := s.BrowserService.GetAvailableBrowsers()
+	if err != nil {
+		return fmt.Errorf("failed to scan browsers: %v", err)
+	}
+
+	newSettings := oldSettings.UpdateWithBrowsers(browsers).NormalizeBrowsers()
+
+	if err := s.WriteSettings(newSettings); err != nil {
+		return fmt.Errorf("failed to scan browsers: %v", err)
+	}
+
+	return nil
+}

--- a/settings_service_test.go
+++ b/settings_service_test.go
@@ -1,0 +1,165 @@
+package linkquisition_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/strobotti/linkquisition"
+)
+
+type testPathProvider struct {
+	dir string
+}
+
+func (p *testPathProvider) GetConfigFolderPath() string { return p.dir }
+func (p *testPathProvider) GetLogFolderPath() string    { return p.dir }
+func (p *testPathProvider) GetPluginFolderPath() string { return p.dir }
+
+type mockBrowserService struct {
+	browsers []Browser
+	err      error
+}
+
+func (m *mockBrowserService) GetAvailableBrowsers() ([]Browser, error)  { return m.browsers, m.err }
+func (m *mockBrowserService) GetDefaultBrowser() (Browser, error)       { return Browser{}, nil }
+func (m *mockBrowserService) OpenUrlWithDefaultBrowser(string) error    { return nil }
+func (m *mockBrowserService) OpenUrlWithBrowser(string, *Browser) error { return nil }
+func (m *mockBrowserService) AreWeTheDefaultBrowser() bool              { return false }
+func (m *mockBrowserService) MakeUsTheDefaultBrowser() error            { return nil }
+func (m *mockBrowserService) GetIconForBrowser(Browser) ([]byte, error) {
+	return nil, nil
+}
+
+func newTestService(t *testing.T, browsers []Browser) *FileSettingsService {
+	t.Helper()
+	return &FileSettingsService{
+		BrowserService: &mockBrowserService{browsers: browsers},
+		PathProvider:   &testPathProvider{dir: t.TempDir()},
+	}
+}
+
+func TestFileSettingsService_IsConfigured_ReturnsFalseWhenNoFile(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	configured, err := svc.IsConfigured()
+
+	assert.NoError(t, err)
+	assert.False(t, configured)
+}
+
+func TestFileSettingsService_WriteAndReadSettings(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	settings := &Settings{
+		LogLevel: "debug",
+		Browsers: []BrowserSettings{
+			{Name: "Firefox", Command: "firefox", Source: SourceAuto},
+		},
+	}
+
+	err := svc.WriteSettings(settings)
+	require.NoError(t, err)
+
+	read, err := svc.ReadSettings()
+	require.NoError(t, err)
+	assert.Equal(t, settings, read)
+}
+
+func TestFileSettingsService_IsConfigured_ReturnsTrueAfterWrite(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	err := svc.WriteSettings(GetDefaultSettings())
+	require.NoError(t, err)
+
+	configured, err := svc.IsConfigured()
+
+	assert.NoError(t, err)
+	assert.True(t, configured)
+}
+
+func TestFileSettingsService_GetSettings_ReturnsDefaultWhenNotConfigured(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	settings := svc.GetSettings()
+
+	assert.Equal(t, GetDefaultSettings(), settings)
+}
+
+func TestFileSettingsService_GetSettings_ReturnsStoredSettings(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	written := &Settings{
+		LogLevel: "warn",
+		Browsers: []BrowserSettings{
+			{Name: "Chrome", Command: "chrome", Source: SourceManual},
+		},
+	}
+	require.NoError(t, svc.WriteSettings(written))
+
+	settings := svc.GetSettings()
+
+	assert.Equal(t, written, settings)
+}
+
+func TestFileSettingsService_ScanBrowsers_CreatesConfig(t *testing.T) {
+	browsers := []Browser{
+		{Name: "Firefox", Command: "firefox"},
+		{Name: "Chrome", Command: "chrome"},
+	}
+	svc := newTestService(t, browsers)
+
+	err := svc.ScanBrowsers()
+	require.NoError(t, err)
+
+	configured, _ := svc.IsConfigured()
+	assert.True(t, configured)
+
+	settings, err := svc.ReadSettings()
+	require.NoError(t, err)
+	assert.Len(t, settings.Browsers, 2)
+	assert.Equal(t, "Firefox", settings.Browsers[0].Name)
+	assert.Equal(t, "Chrome", settings.Browsers[1].Name)
+}
+
+func TestFileSettingsService_ScanBrowsers_PreservesExistingRules(t *testing.T) {
+	browsers := []Browser{
+		{Name: "Firefox", Command: "firefox"},
+	}
+	svc := newTestService(t, browsers)
+
+	// Write initial settings with a rule
+	initial := &Settings{
+		Browsers: []BrowserSettings{
+			{
+				Name:    "Firefox",
+				Command: "firefox",
+				Source:  SourceAuto,
+				Matches: []BrowserMatch{{Type: BrowserMatchTypeSite, Value: "example.com"}},
+			},
+		},
+	}
+	require.NoError(t, svc.WriteSettings(initial))
+
+	// Re-scan should preserve the existing rule
+	err := svc.ScanBrowsers()
+	require.NoError(t, err)
+
+	settings, _ := svc.ReadSettings()
+	require.Len(t, settings.Browsers, 1)
+	assert.Len(t, settings.Browsers[0].Matches, 1)
+	assert.Equal(t, "example.com", settings.Browsers[0].Matches[0].Value)
+}
+
+func TestFileSettingsService_ReadSettings_ReturnsErrorForCorruptFile(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	// Write garbage to the config file
+	configPath := svc.GetConfigFilePath()
+	require.NoError(t, os.WriteFile(configPath, []byte("{invalid json"), 0600))
+
+	_, err := svc.ReadSettings()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

The `darwin/settings.go` and `freedesktop/settings.go` files were ~90% identical — all the settings I/O logic (read, write, scan, config detection) was copy-pasted with only the path resolution differing between platforms. This PR extracts the shared logic into a single `FileSettingsService` in the root package, with platform-specific paths supplied via a `PathProvider` interface.

## Changes

- Introduced `PathProvider` interface (3 methods: `GetConfigFolderPath`, `GetLogFolderPath`, `GetPluginFolderPath`)
- Introduced `FileSettingsService` struct implementing `SettingsService` using a `PathProvider`
- Reduced `darwin/settings.go` from 149 lines to ~45 (path provider only)
- Reduced `freedesktop/settings.go` from 153 lines to ~42 (path provider only)
- `ScanBrowsers` now reuses `WriteSettings` instead of reimplementing JSON serialization inline
- Added unit tests for `FileSettingsService` covering read/write roundtrip, config state detection, scan workflow, and error handling

## Net result

- **-90 lines** of duplicated code
- Single source of truth for settings I/O logic
- Bug fixes in settings logic only need to happen in one place going forward
- New test coverage for previously-untested code paths

## Testing

- All existing tests pass
- 8 new unit tests covering the core `FileSettingsService` workflows
- Verified compilation on macOS (native) and Linux (`go vet` with `GOOS=linux`)