### PR TITLE
feat: Add localization support with language selector UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Currently supported languages:
 - English (en) — default
 - Finnish (fi)
 - Spanish (es)
+- Swedish (sv)
 
 To contribute a new translation, add a JSON file to `internal/i18n/translations/` following the
 format of the existing files (e.g. `en.json`). The filename should be the locale code (e.g. `de.json` for German).

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Currently supported languages:
 
 - English (en) — default
 - Finnish (fi)
+- Spanish (es)
 
 To contribute a new translation, add a JSON file to `internal/i18n/translations/` following the
 format of the existing files (e.g. `en.json`). The filename should be the locale code (e.g. `de.json` for German).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ it will be treated as a different browser and might be removed if not safe-guard
 
 ```json
 {
+  "locale": "",
   "browsers": [
     {
       "name": "Microsoft Edge",
@@ -109,6 +110,22 @@ it will be treated as a different browser and might be removed if not safe-guard
   ]
 }
 ```
+
+### Localization
+
+Linkquisition supports localization. The UI language is determined in the following order:
+
+1. If `locale` is set in `config.json` (e.g. `"locale": "fi"`), that locale is used
+2. Otherwise, the system locale is auto-detected
+3. If no matching translation is available, English is used as fallback
+
+Currently supported languages:
+
+- English (en) — default
+- Finnish (fi)
+
+To contribute a new translation, add a JSON file to `internal/i18n/translations/` following the
+format of the existing files (e.g. `en.json`). The filename should be the locale code (e.g. `de.json` for German).
 
 ## Development
 
@@ -158,7 +175,7 @@ See [plugins](./plugins/README.md) for more information.
 ## TODO
 
 - [X] Add support for plugins
-- [ ] Add support for translations
+- [X] Add support for translations
 - [X] Add support for browser icons
 - [ ] Add support for more platforms
 - [ ] Add support for more architectures

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -14,6 +14,7 @@ import (
 	"fyne.io/fyne/v2"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/i18n"
 )
 
 const logDirPerms = 0755
@@ -134,6 +135,9 @@ func setupLogger(settingsService linkquisition.SettingsService) *slog.Logger {
 }
 
 func (a *Application) Run(_ context.Context) error {
+	// Initialize localization before any UI strings are used
+	i18n.Init(a.SettingsService.GetSettings().Locale)
+
 	args := os.Args
 
 	urlToOpen := ""

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -12,6 +12,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/i18n"
 )
 
 type BrowserPicker struct {
@@ -51,7 +52,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		)
 	}
 
-	w := picker.fapp.NewWindow("Linkquisition")
+	w := picker.fapp.NewWindow(i18n.T("picker.window_title"))
 
 	w.Canvas().AddShortcut(
 		&fyne.ShortcutCopy{}, func(shortcut fyne.Shortcut) {
@@ -114,13 +115,13 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 
 	widgets = append(
 		widgets,
-		container.NewBorder(nil, nil, widget.NewLabel("Open:"), nil, input),
+		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("picker.open_label")), nil, input),
 	)
 
 	uto := linkquisition.NewURL(urlToOpen)
 	site, _ := uto.GetSite()
 	check := widget.NewCheckWithData(
-		"Remember this choice with "+site,
+		i18n.T("picker.remember_choice", map[string]interface{}{"Site": site}),
 		remember,
 	)
 
@@ -133,7 +134,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		widgets = append(
 			widgets,
 			layout.NewSpacer(),
-			widget.NewLabel("Press 'ENTER' to pick first, 'ESC' to quit, 'ctrl+c' to copy URL to clipboard"),
+			widget.NewLabel(i18n.T("picker.keyboard_guide")),
 		)
 	}
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/i18n"
 	"github.com/strobotti/linkquisition/resources"
 )
 
@@ -31,11 +32,11 @@ func NewConfigurator(
 }
 
 func (c *Configurator) Run() error {
-	w := c.fapp.NewWindow("Linkquisition settings")
+	w := c.fapp.NewWindow(i18n.T("config.window_title"))
 
 	tabs := container.NewAppTabs(
-		container.NewTabItem("General", c.getGeneralTab()),
-		container.NewTabItem("About", c.getAboutTab()),
+		container.NewTabItem(i18n.T("config.tab_general"), c.getGeneralTab()),
+		container.NewTabItem(i18n.T("config.tab_about"), c.getAboutTab()),
 	)
 	tabs.SetTabLocation(container.TabLocationTop)
 
@@ -52,17 +53,14 @@ func (c *Configurator) Run() error {
 
 func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	// MAKE DEFAULT -LABEL
-	makeDefaultLabel := widget.NewLabel(
-		"In order to Linkquisition to function as a browser-picker\n" +
-			"it has to be set as the default browser:",
-	)
+	makeDefaultLabel := widget.NewLabel(i18n.T("config.make_default_label"))
 
 	setupMakeDefaultButton := func(button *widget.Button, isDefault bool) {
 		if isDefault {
-			button.SetText("All good!")
+			button.SetText(i18n.T("config.make_default_done"))
 			button.Disable()
 		} else {
-			button.SetText("Make default")
+			button.SetText(i18n.T("config.make_default_button"))
 			button.Enable()
 		}
 	}
@@ -72,7 +70,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		button.Disable()
 		err := c.browserService.MakeUsTheDefaultBrowser()
 		if err != nil {
-			button.SetText("Error making default!")
+			button.SetText(i18n.T("config.make_default_error"))
 			button.Enable()
 			fmt.Printf("error making Linkquisition the default browser: %v", err)
 		} else {
@@ -80,7 +78,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		}
 	}
 
-	makeDefaultButton := widget.NewButton("checking", func() {})
+	makeDefaultButton := widget.NewButton(i18n.T("config.make_default_checking"), func() {})
 	makeDefaultButton.OnTapped = func() {
 		onClickMakeDefaultButton(makeDefaultButton)
 	}
@@ -91,9 +89,9 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	// SCAN BROWSERS -BUTTON
 	setupScanBrowsersButton := func(button *widget.Button, alreadyScanned bool) {
 		if alreadyScanned {
-			button.SetText("Re-scan browsers")
+			button.SetText(i18n.T("config.rescan_browsers"))
 		} else {
-			button.SetText("Scan browsers")
+			button.SetText(i18n.T("config.scan_browsers"))
 		}
 		button.Enable()
 	}
@@ -101,7 +99,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		button.Disable()
 		err := c.settingsService.ScanBrowsers()
 		if err != nil {
-			button.SetText("Error scanning browsers!")
+			button.SetText(i18n.T("config.scan_error"))
 			button.Enable()
 			fmt.Printf("error scanning browsers: %v", err)
 		} else {
@@ -110,7 +108,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		}
 	}
 
-	scanBrowsersButton := widget.NewButton("Scan now", func() {})
+	scanBrowsersButton := widget.NewButton(i18n.T("config.scan_now"), func() {})
 	scanBrowsersButton.OnTapped = func() {
 		onClickScanBrowsersButton(scanBrowsersButton)
 	}
@@ -125,14 +123,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		makeDefaultLabel,
 		makeDefaultButton,
 		layout.NewSpacer(),
-		widget.NewLabel(
-			"The browsers should be scanned and stored in a configuration file for\n"+
-				"faster startup and for enabling custom configuration.\n"+
-				"\n"+
-				"The scan should be safe to execute at any time: only newly detected\n"+
-				"browsers are added and the ones no longer present in the system are\n"+
-				"removed.\n\nAny existing rules, ordering or customization shouldn't be affected.",
-		),
+		widget.NewLabel(i18n.T("config.scan_description")),
 		scanBrowsersButton,
 	)
 }

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -87,6 +87,10 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	setupMakeDefaultButton(makeDefaultButton, c.browserService.AreWeTheDefaultBrowser())
 
 	// SCAN BROWSERS -BUTTON
+	scanStatusLabel := widget.NewLabel("")
+	scanStatusLabel.TextStyle = fyne.TextStyle{Italic: true}
+	scanStatusLabel.Hide()
+
 	setupScanBrowsersButton := func(button *widget.Button, alreadyScanned bool) {
 		if alreadyScanned {
 			button.SetText(i18n.T("config.rescan_browsers"))
@@ -97,15 +101,21 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	}
 	onClickScanBrowsersButton := func(button *widget.Button) {
 		button.Disable()
-		err := c.settingsService.ScanBrowsers()
-		if err != nil {
-			button.SetText(i18n.T("config.scan_error"))
-			button.Enable()
-			fmt.Printf("error scanning browsers: %v", err)
-		} else {
-			isConfigured, _ := c.settingsService.IsConfigured()
-			setupScanBrowsersButton(button, isConfigured)
-		}
+		scanStatusLabel.SetText(i18n.T("config.scan_in_progress"))
+		scanStatusLabel.Show()
+
+		go func() {
+			err := c.settingsService.ScanBrowsers()
+			if err != nil {
+				scanStatusLabel.SetText(i18n.T("config.scan_failed"))
+				button.Enable()
+				fmt.Printf("error scanning browsers: %v\n", err)
+			} else {
+				scanStatusLabel.SetText(i18n.T("config.scan_success"))
+				isConfigured, _ := c.settingsService.IsConfigured()
+				setupScanBrowsersButton(button, isConfigured)
+			}
+		}()
 	}
 
 	scanBrowsersButton := widget.NewButton(i18n.T("config.scan_now"), func() {})
@@ -113,9 +123,6 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		onClickScanBrowsersButton(scanBrowsersButton)
 	}
 
-	// TODO show a spinner while scanning
-	// TODO show a message when scanning is done
-	// TODO show a message (instead of the button) if configuration is invalid (corrupted file etc)
 	isConfigured, _ := c.settingsService.IsConfigured()
 	setupScanBrowsersButton(scanBrowsersButton, isConfigured)
 
@@ -168,6 +175,7 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		layout.NewSpacer(),
 		widget.NewLabel(i18n.T("config.scan_description")),
 		scanBrowsersButton,
+		scanStatusLabel,
 		layout.NewSpacer(),
 		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.language_label")), nil, languageSelect),
 		restartNote,

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -119,12 +119,58 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	isConfigured, _ := c.settingsService.IsConfigured()
 	setupScanBrowsersButton(scanBrowsersButton, isConfigured)
 
+	// LANGUAGE SELECTOR
+	locales := i18n.AvailableLocales()
+	autoLabel := i18n.T("config.language_auto")
+
+	// Build dropdown options: "Auto (system default)" + each locale's display name
+	options := []string{autoLabel}
+	for _, code := range locales {
+		options = append(options, fmt.Sprintf("%s (%s)", i18n.LocaleDisplayName(code), code))
+	}
+
+	// Determine current selection from settings
+	currentLocale := c.settingsService.GetSettings().Locale
+	selectedOption := autoLabel
+	for _, code := range locales {
+		if code == currentLocale {
+			selectedOption = fmt.Sprintf("%s (%s)", i18n.LocaleDisplayName(code), code)
+			break
+		}
+	}
+
+	languageSelect := widget.NewSelect(options, func(selected string) {
+		newLocale := ""
+		if selected != autoLabel {
+			// Extract locale code from "DisplayName (code)" format
+			for _, code := range locales {
+				if selected == fmt.Sprintf("%s (%s)", i18n.LocaleDisplayName(code), code) {
+					newLocale = code
+					break
+				}
+			}
+		}
+
+		settings := c.settingsService.GetSettings()
+		settings.Locale = newLocale
+		if err := c.settingsService.WriteSettings(settings); err != nil {
+			fmt.Printf("error saving locale setting: %v\n", err)
+		}
+	})
+	languageSelect.Selected = selectedOption
+
+	restartNote := widget.NewLabel(i18n.T("config.language_restart_note"))
+	restartNote.TextStyle = fyne.TextStyle{Italic: true}
+
 	return container.NewVBox(
 		makeDefaultLabel,
 		makeDefaultButton,
 		layout.NewSpacer(),
 		widget.NewLabel(i18n.T("config.scan_description")),
 		scanBrowsersButton,
+		layout.NewSpacer(),
+		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.language_label")), nil, languageSelect),
+		restartNote,
 	)
 }
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -52,10 +52,19 @@ func (c *Configurator) Run() error {
 }
 
 func (c *Configurator) getGeneralTab() fyne.CanvasObject {
-	// MAKE DEFAULT -LABEL
+	return container.NewVBox(
+		c.buildMakeDefaultSection(),
+		layout.NewSpacer(),
+		c.buildScanBrowsersSection(),
+		layout.NewSpacer(),
+		c.buildLanguageSection(),
+	)
+}
+
+func (c *Configurator) buildMakeDefaultSection() fyne.CanvasObject {
 	makeDefaultLabel := widget.NewLabel(i18n.T("config.make_default_label"))
 
-	setupMakeDefaultButton := func(button *widget.Button, isDefault bool) {
+	setupButton := func(button *widget.Button, isDefault bool) {
 		if isDefault {
 			button.SetText(i18n.T("config.make_default_done"))
 			button.Disable()
@@ -65,33 +74,31 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		}
 	}
 
-	// MAKE DEFAULT -BUTTON
-	onClickMakeDefaultButton := func(button *widget.Button) {
-		button.Disable()
-		err := c.browserService.MakeUsTheDefaultBrowser()
-		if err != nil {
-			button.SetText(i18n.T("config.make_default_error"))
-			button.Enable()
-			fmt.Printf("error making Linkquisition the default browser: %v", err)
-		} else {
-			setupMakeDefaultButton(button, true)
-		}
-	}
-
 	makeDefaultButton := widget.NewButton(i18n.T("config.make_default_checking"), func() {})
 	makeDefaultButton.OnTapped = func() {
-		onClickMakeDefaultButton(makeDefaultButton)
+		makeDefaultButton.Disable()
+		err := c.browserService.MakeUsTheDefaultBrowser()
+		if err != nil {
+			makeDefaultButton.SetText(i18n.T("config.make_default_error"))
+			makeDefaultButton.Enable()
+			fmt.Printf("error making Linkquisition the default browser: %v\n", err)
+		} else {
+			setupButton(makeDefaultButton, true)
+		}
 	}
 	makeDefaultButton.Disable()
 
-	setupMakeDefaultButton(makeDefaultButton, c.browserService.AreWeTheDefaultBrowser())
+	setupButton(makeDefaultButton, c.browserService.AreWeTheDefaultBrowser())
 
-	// SCAN BROWSERS -BUTTON
+	return container.NewVBox(makeDefaultLabel, makeDefaultButton)
+}
+
+func (c *Configurator) buildScanBrowsersSection() fyne.CanvasObject {
 	scanStatusLabel := widget.NewLabel("")
 	scanStatusLabel.TextStyle = fyne.TextStyle{Italic: true}
 	scanStatusLabel.Hide()
 
-	setupScanBrowsersButton := func(button *widget.Button, alreadyScanned bool) {
+	setupButton := func(button *widget.Button, alreadyScanned bool) {
 		if alreadyScanned {
 			button.SetText(i18n.T("config.rescan_browsers"))
 		} else {
@@ -99,8 +106,10 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		}
 		button.Enable()
 	}
-	onClickScanBrowsersButton := func(button *widget.Button) {
-		button.Disable()
+
+	scanBrowsersButton := widget.NewButton(i18n.T("config.scan_now"), func() {})
+	scanBrowsersButton.OnTapped = func() {
+		scanBrowsersButton.Disable()
 		scanStatusLabel.SetText(i18n.T("config.scan_in_progress"))
 		scanStatusLabel.Show()
 
@@ -108,35 +117,35 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 			err := c.settingsService.ScanBrowsers()
 			if err != nil {
 				scanStatusLabel.SetText(i18n.T("config.scan_failed"))
-				button.Enable()
+				scanBrowsersButton.Enable()
 				fmt.Printf("error scanning browsers: %v\n", err)
 			} else {
 				scanStatusLabel.SetText(i18n.T("config.scan_success"))
 				isConfigured, _ := c.settingsService.IsConfigured()
-				setupScanBrowsersButton(button, isConfigured)
+				setupButton(scanBrowsersButton, isConfigured)
 			}
 		}()
 	}
 
-	scanBrowsersButton := widget.NewButton(i18n.T("config.scan_now"), func() {})
-	scanBrowsersButton.OnTapped = func() {
-		onClickScanBrowsersButton(scanBrowsersButton)
-	}
-
 	isConfigured, _ := c.settingsService.IsConfigured()
-	setupScanBrowsersButton(scanBrowsersButton, isConfigured)
+	setupButton(scanBrowsersButton, isConfigured)
 
-	// LANGUAGE SELECTOR
+	return container.NewVBox(
+		widget.NewLabel(i18n.T("config.scan_description")),
+		scanBrowsersButton,
+		scanStatusLabel,
+	)
+}
+
+func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 	locales := i18n.AvailableLocales()
 	autoLabel := i18n.T("config.language_auto")
 
-	// Build dropdown options: "Auto (system default)" + each locale's display name
 	options := []string{autoLabel}
 	for _, code := range locales {
 		options = append(options, fmt.Sprintf("%s (%s)", i18n.LocaleDisplayName(code), code))
 	}
 
-	// Determine current selection from settings
 	currentLocale := c.settingsService.GetSettings().Locale
 	selectedOption := autoLabel
 	for _, code := range locales {
@@ -149,7 +158,6 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	languageSelect := widget.NewSelect(options, func(selected string) {
 		newLocale := ""
 		if selected != autoLabel {
-			// Extract locale code from "DisplayName (code)" format
 			for _, code := range locales {
 				if selected == fmt.Sprintf("%s (%s)", i18n.LocaleDisplayName(code), code) {
 					newLocale = code
@@ -170,13 +178,6 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 	restartNote.TextStyle = fyne.TextStyle{Italic: true}
 
 	return container.NewVBox(
-		makeDefaultLabel,
-		makeDefaultButton,
-		layout.NewSpacer(),
-		widget.NewLabel(i18n.T("config.scan_description")),
-		scanBrowsersButton,
-		scanStatusLabel,
-		layout.NewSpacer(),
 		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.language_label")), nil, languageSelect),
 		restartNote,
 	)

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.25.0
 
 require (
 	fyne.io/fyne/v2 v2.7.4
+	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.56.0
+	golang.org/x/text v0.38.0
 	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
 	gopkg.in/ini.v1 v1.67.3
 )
@@ -31,12 +34,10 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/hack-pad/go-indexeddb v0.3.2 // indirect
 	github.com/hack-pad/safejs v0.1.1 // indirect
-	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade // indirect
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/nicksnyder/go-i18n/v2 v2.6.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rymdport/portal v0.4.2 // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
@@ -44,6 +45,5 @@ require (
 	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -20,6 +20,43 @@ var translationFS embed.FS
 
 var localizer *i18n.Localizer
 
+// localeNames maps locale codes to their display names (in their own language).
+var localeNames = map[string]string{
+	"en": "English",
+	"es": "Español",
+	"fi": "Suomi",
+	"sv": "Svenska",
+}
+
+// AvailableLocales returns the locale codes of all embedded translation files,
+// sorted alphabetically.
+func AvailableLocales() []string {
+	entries, err := translationFS.ReadDir("translations")
+	if err != nil {
+		return []string{"en"}
+	}
+
+	var locales []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			code := strings.TrimSuffix(entry.Name(), ".json")
+			locales = append(locales, code)
+		}
+	}
+
+	return locales
+}
+
+// LocaleDisplayName returns a human-readable name for a locale code
+// (e.g. "en" → "English", "fi" → "Suomi"). Falls back to the code itself.
+func LocaleDisplayName(code string) string {
+	if name, ok := localeNames[code]; ok {
+		return name
+	}
+
+	return code
+}
+
 // Init initializes the i18n system. If localeOverride is non-empty, it is used
 // as the locale. Otherwise the system locale is detected. English is always
 // loaded as the fallback.

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -20,12 +20,20 @@ var translationFS embed.FS
 
 var localizer *i18n.Localizer
 
+// Locale code constants.
+const (
+	LocaleEnglish = "en"
+	LocaleSpanish = "es"
+	LocaleFinnish = "fi"
+	LocaleSwedish = "sv"
+)
+
 // localeNames maps locale codes to their display names (in their own language).
 var localeNames = map[string]string{
-	"en": "English",
-	"es": "Español",
-	"fi": "Suomi",
-	"sv": "Svenska",
+	LocaleEnglish: "English",
+	LocaleSpanish: "Español",
+	LocaleFinnish: "Suomi",
+	LocaleSwedish: "Svenska",
 }
 
 // AvailableLocales returns the locale codes of all embedded translation files,
@@ -33,7 +41,7 @@ var localeNames = map[string]string{
 func AvailableLocales() []string {
 	entries, err := translationFS.ReadDir("translations")
 	if err != nil {
-		return []string{"en"}
+		return []string{LocaleEnglish}
 	}
 
 	var locales []string
@@ -75,7 +83,7 @@ func Init(localeOverride string) {
 	}
 
 	lang := detectLocale(localeOverride)
-	localizer = i18n.NewLocalizer(bundle, lang, "en")
+	localizer = i18n.NewLocalizer(bundle, lang, LocaleEnglish)
 }
 
 // T returns the translated string for the given message ID.
@@ -129,5 +137,5 @@ func detectLocale(override string) string {
 		return lang
 	}
 
-	return "en"
+	return LocaleEnglish
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1,0 +1,96 @@
+// Package i18n provides localization support for the application.
+// It uses go-i18n for message management and go-locale for system locale detection.
+// English is the default/fallback language. The system locale is auto-detected
+// unless overridden via the configuration file.
+package i18n
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jeandeaual/go-locale"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/text/language"
+)
+
+//go:embed translations/*.json
+var translationFS embed.FS
+
+var localizer *i18n.Localizer
+
+// Init initializes the i18n system. If localeOverride is non-empty, it is used
+// as the locale. Otherwise the system locale is detected. English is always
+// loaded as the fallback.
+func Init(localeOverride string) {
+	bundle := i18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+
+	// Load all available translation files
+	entries, err := translationFS.ReadDir("translations")
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+				_, _ = bundle.LoadMessageFileFS(translationFS, "translations/"+entry.Name())
+			}
+		}
+	}
+
+	lang := detectLocale(localeOverride)
+	localizer = i18n.NewLocalizer(bundle, lang, "en")
+}
+
+// T returns the translated string for the given message ID.
+// Optional templateData is used for template substitution in the message.
+func T(messageID string, templateData ...map[string]interface{}) string {
+	cfg := &i18n.LocalizeConfig{
+		MessageID: messageID,
+	}
+
+	if len(templateData) > 0 && templateData[0] != nil {
+		cfg.TemplateData = templateData[0]
+	}
+
+	msg, err := localizer.Localize(cfg)
+	if err != nil {
+		// Fallback: return the message ID so it's obvious what's missing
+		return fmt.Sprintf("[%s]", messageID)
+	}
+
+	return msg
+}
+
+// TWithCount returns the translated string for the given message ID with
+// pluralization support.
+func TWithCount(messageID string, count int, templateData ...map[string]interface{}) string {
+	cfg := &i18n.LocalizeConfig{
+		MessageID:   messageID,
+		PluralCount: count,
+	}
+
+	if len(templateData) > 0 && templateData[0] != nil {
+		cfg.TemplateData = templateData[0]
+	} else {
+		cfg.TemplateData = map[string]interface{}{"Count": count}
+	}
+
+	msg, err := localizer.Localize(cfg)
+	if err != nil {
+		return fmt.Sprintf("[%s]", messageID)
+	}
+
+	return msg
+}
+
+func detectLocale(override string) string {
+	if override != "" {
+		return override
+	}
+
+	if lang, err := locale.GetLocale(); err == nil && lang != "" {
+		return lang
+	}
+
+	return "en"
+}

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -59,6 +59,28 @@ func TestInit_UnsupportedLocale_FallsBackToEnglish(t *testing.T) {
 	}
 }
 
+func TestInit_FinnishLocale(t *testing.T) {
+	Init("fi")
+
+	got := T("config.tab_general")
+	want := "Yleiset"
+
+	if got != want {
+		t.Errorf("T(\"config.tab_general\") with fi locale = %q, want %q", got, want)
+	}
+}
+
+func TestInit_FinnishLocale_WithTemplateData(t *testing.T) {
+	Init("fi")
+
+	got := T("picker.remember_choice", map[string]interface{}{"Site": "example.com"})
+	want := "Muista tämä valinta sivustolle example.com"
+
+	if got != want {
+		t.Errorf("T(\"picker.remember_choice\") with fi locale = %q, want %q", got, want)
+	}
+}
+
 func TestDetectLocale_OverrideTakesPrecedence(t *testing.T) {
 	got := detectLocale("fi")
 	want := "fi"

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -81,6 +81,17 @@ func TestInit_FinnishLocale_WithTemplateData(t *testing.T) {
 	}
 }
 
+func TestInit_SpanishLocale(t *testing.T) {
+	Init("es")
+
+	got := T("config.tab_about")
+	want := "Acerca de"
+
+	if got != want {
+		t.Errorf("T(\"config.tab_about\") with es locale = %q, want %q", got, want)
+	}
+}
+
 func TestDetectLocale_OverrideTakesPrecedence(t *testing.T) {
 	got := detectLocale("fi")
 	want := "fi"

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -92,6 +92,17 @@ func TestInit_SpanishLocale(t *testing.T) {
 	}
 }
 
+func TestInit_SwedishLocale(t *testing.T) {
+	Init("sv")
+
+	got := T("config.tab_general")
+	want := "Allmänt"
+
+	if got != want {
+		t.Errorf("T(\"config.tab_general\") with sv locale = %q, want %q", got, want)
+	}
+}
+
 func TestDetectLocale_OverrideTakesPrecedence(t *testing.T) {
 	got := detectLocale("fi")
 	want := "fi"

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -1,0 +1,77 @@
+package i18n
+
+import (
+	"testing"
+)
+
+func TestInit_DefaultEnglish(t *testing.T) {
+	Init("")
+
+	got := T("picker.window_title")
+	want := "Linkquisition"
+
+	if got != want {
+		t.Errorf("T(\"picker.window_title\") = %q, want %q", got, want)
+	}
+}
+
+func TestInit_ExplicitOverride(t *testing.T) {
+	Init("en")
+
+	got := T("config.tab_general")
+	want := "General"
+
+	if got != want {
+		t.Errorf("T(\"config.tab_general\") = %q, want %q", got, want)
+	}
+}
+
+func TestT_WithTemplateData(t *testing.T) {
+	Init("en")
+
+	got := T("picker.remember_choice", map[string]interface{}{"Site": "example.com"})
+	want := "Remember this choice with example.com"
+
+	if got != want {
+		t.Errorf("T(\"picker.remember_choice\") = %q, want %q", got, want)
+	}
+}
+
+func TestT_UnknownMessageID(t *testing.T) {
+	Init("en")
+
+	got := T("nonexistent.message")
+	want := "[nonexistent.message]"
+
+	if got != want {
+		t.Errorf("T(\"nonexistent.message\") = %q, want %q", got, want)
+	}
+}
+
+func TestInit_UnsupportedLocale_FallsBackToEnglish(t *testing.T) {
+	Init("xx")
+
+	got := T("picker.window_title")
+	want := "Linkquisition"
+
+	if got != want {
+		t.Errorf("T(\"picker.window_title\") with unsupported locale = %q, want %q", got, want)
+	}
+}
+
+func TestDetectLocale_OverrideTakesPrecedence(t *testing.T) {
+	got := detectLocale("fi")
+	want := "fi"
+
+	if got != want {
+		t.Errorf("detectLocale(\"fi\") = %q, want %q", got, want)
+	}
+}
+
+func TestDetectLocale_EmptyOverrideFallsBack(t *testing.T) {
+	got := detectLocale("")
+	// Should return either the system locale or "en" — never empty
+	if got == "" {
+		t.Error("detectLocale(\"\") returned empty string")
+	}
+}

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -49,5 +49,14 @@
   },
   "picker.keyboard_guide": {
     "other": "Press 'ENTER' to pick first, 'ESC' to quit, 'ctrl+c' to copy URL to clipboard"
+  },
+  "config.language_label": {
+    "other": "Language:"
+  },
+  "config.language_auto": {
+    "other": "Auto (system default)"
+  },
+  "config.language_restart_note": {
+    "other": "Language change takes effect on next launch."
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -58,5 +58,14 @@
   },
   "config.language_restart_note": {
     "other": "Language change takes effect on next launch."
+  },
+  "config.scan_in_progress": {
+    "other": "Scanning..."
+  },
+  "config.scan_success": {
+    "other": "✓ Browsers scanned successfully"
+  },
+  "config.scan_failed": {
+    "other": "✗ Scan failed"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -1,0 +1,53 @@
+{
+  "config.window_title": {
+    "other": "Linkquisition settings"
+  },
+  "config.tab_general": {
+    "other": "General"
+  },
+  "config.tab_about": {
+    "other": "About"
+  },
+  "config.make_default_label": {
+    "other": "In order to Linkquisition to function as a browser-picker\nit has to be set as the default browser:"
+  },
+  "config.make_default_done": {
+    "other": "All good!"
+  },
+  "config.make_default_button": {
+    "other": "Make default"
+  },
+  "config.make_default_error": {
+    "other": "Error making default!"
+  },
+  "config.make_default_checking": {
+    "other": "checking"
+  },
+  "config.scan_browsers": {
+    "other": "Scan browsers"
+  },
+  "config.rescan_browsers": {
+    "other": "Re-scan browsers"
+  },
+  "config.scan_now": {
+    "other": "Scan now"
+  },
+  "config.scan_error": {
+    "other": "Error scanning browsers!"
+  },
+  "config.scan_description": {
+    "other": "The browsers should be scanned and stored in a configuration file for\nfaster startup and for enabling custom configuration.\n\nThe scan should be safe to execute at any time: only newly detected\nbrowsers are added and the ones no longer present in the system are\nremoved.\n\nAny existing rules, ordering or customization shouldn't be affected."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Open:"
+  },
+  "picker.remember_choice": {
+    "other": "Remember this choice with {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Press 'ENTER' to pick first, 'ESC' to quit, 'ctrl+c' to copy URL to clipboard"
+  }
+}

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -49,5 +49,14 @@
   },
   "picker.keyboard_guide": {
     "other": "Pulsa 'ENTER' para elegir el primero, 'ESC' para salir, 'ctrl+c' para copiar la URL al portapapeles"
+  },
+  "config.language_label": {
+    "other": "Idioma:"
+  },
+  "config.language_auto": {
+    "other": "Automático (predeterminado del sistema)"
+  },
+  "config.language_restart_note": {
+    "other": "El cambio de idioma se aplicará en el próximo inicio."
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -58,5 +58,14 @@
   },
   "config.language_restart_note": {
     "other": "El cambio de idioma se aplicará en el próximo inicio."
+  },
+  "config.scan_in_progress": {
+    "other": "Buscando..."
+  },
+  "config.scan_success": {
+    "other": "✓ Navegadores encontrados correctamente"
+  },
+  "config.scan_failed": {
+    "other": "✗ La búsqueda falló"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -1,0 +1,53 @@
+{
+  "config.window_title": {
+    "other": "Ajustes de Linkquisition"
+  },
+  "config.tab_general": {
+    "other": "General"
+  },
+  "config.tab_about": {
+    "other": "Acerca de"
+  },
+  "config.make_default_label": {
+    "other": "Para que Linkquisition funcione como selector de navegador,\ndebe establecerse como el navegador predeterminado:"
+  },
+  "config.make_default_done": {
+    "other": "¡Todo listo!"
+  },
+  "config.make_default_button": {
+    "other": "Establecer como predeterminado"
+  },
+  "config.make_default_error": {
+    "other": "¡Error al establecer como predeterminado!"
+  },
+  "config.make_default_checking": {
+    "other": "verificando"
+  },
+  "config.scan_browsers": {
+    "other": "Buscar navegadores"
+  },
+  "config.rescan_browsers": {
+    "other": "Volver a buscar navegadores"
+  },
+  "config.scan_now": {
+    "other": "Buscar ahora"
+  },
+  "config.scan_error": {
+    "other": "¡Error al buscar navegadores!"
+  },
+  "config.scan_description": {
+    "other": "Los navegadores deben ser buscados y almacenados en un archivo de configuración\npara un inicio más rápido y para permitir configuración personalizada.\n\nLa búsqueda se puede ejecutar en cualquier momento de forma segura: solo se\nagregan los navegadores detectados recientemente y se eliminan los que ya no\nestán presentes en el sistema.\n\nLas reglas, el orden o las personalizaciones existentes no se verán afectados."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Abrir:"
+  },
+  "picker.remember_choice": {
+    "other": "Recordar esta elección para {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Pulsa 'ENTER' para elegir el primero, 'ESC' para salir, 'ctrl+c' para copiar la URL al portapapeles"
+  }
+}

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -49,5 +49,14 @@
   },
   "picker.keyboard_guide": {
     "other": "Paina 'ENTER' valitaksesi ensimmäisen, 'ESC' sulkeaksesi, 'ctrl+c' kopioidaksesi URL:n leikepöydälle"
+  },
+  "config.language_label": {
+    "other": "Kieli:"
+  },
+  "config.language_auto": {
+    "other": "Automaattinen (järjestelmän oletus)"
+  },
+  "config.language_restart_note": {
+    "other": "Kielen vaihto tulee voimaan seuraavalla käynnistyksellä."
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -1,0 +1,53 @@
+{
+  "config.window_title": {
+    "other": "Linkquisition-asetukset"
+  },
+  "config.tab_general": {
+    "other": "Yleiset"
+  },
+  "config.tab_about": {
+    "other": "Tietoja"
+  },
+  "config.make_default_label": {
+    "other": "Jotta Linkquisition toimisi selainvalitsimena,\nse täytyy asettaa oletusselaimeksi:"
+  },
+  "config.make_default_done": {
+    "other": "Kaikki kunnossa!"
+  },
+  "config.make_default_button": {
+    "other": "Aseta oletukseksi"
+  },
+  "config.make_default_error": {
+    "other": "Virhe asetettaessa oletukseksi!"
+  },
+  "config.make_default_checking": {
+    "other": "tarkistetaan"
+  },
+  "config.scan_browsers": {
+    "other": "Hae selaimet"
+  },
+  "config.rescan_browsers": {
+    "other": "Hae selaimet uudelleen"
+  },
+  "config.scan_now": {
+    "other": "Hae nyt"
+  },
+  "config.scan_error": {
+    "other": "Virhe selaimien haussa!"
+  },
+  "config.scan_description": {
+    "other": "Selaimet tulisi hakea ja tallentaa asetustiedostoon nopeampaa\nkäynnistystä ja mukautettuja asetuksia varten.\n\nHaku on turvallista suorittaa milloin tahansa: vain uudet selaimet\nlisätään ja järjestelmästä poistetut selaimet poistetaan.\n\nOlemassa olevat säännöt, järjestys tai mukautukset eivät muutu."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Avaa:"
+  },
+  "picker.remember_choice": {
+    "other": "Muista tämä valinta sivustolle {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Paina 'ENTER' valitaksesi ensimmäisen, 'ESC' sulkeaksesi, 'ctrl+c' kopioidaksesi URL:n leikepöydälle"
+  }
+}

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -58,5 +58,14 @@
   },
   "config.language_restart_note": {
     "other": "Kielen vaihto tulee voimaan seuraavalla käynnistyksellä."
+  },
+  "config.scan_in_progress": {
+    "other": "Haetaan..."
+  },
+  "config.scan_success": {
+    "other": "✓ Selaimet haettu onnistuneesti"
+  },
+  "config.scan_failed": {
+    "other": "✗ Haku epäonnistui"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -1,0 +1,53 @@
+{
+  "config.window_title": {
+    "other": "Linkquisition-inställningar"
+  },
+  "config.tab_general": {
+    "other": "Allmänt"
+  },
+  "config.tab_about": {
+    "other": "Om"
+  },
+  "config.make_default_label": {
+    "other": "För att Linkquisition ska fungera som webbläsarväljare\nmåste den ställas in som standardwebbläsare:"
+  },
+  "config.make_default_done": {
+    "other": "Allt klart!"
+  },
+  "config.make_default_button": {
+    "other": "Ange som standard"
+  },
+  "config.make_default_error": {
+    "other": "Fel vid inställning som standard!"
+  },
+  "config.make_default_checking": {
+    "other": "kontrollerar"
+  },
+  "config.scan_browsers": {
+    "other": "Sök webbläsare"
+  },
+  "config.rescan_browsers": {
+    "other": "Sök webbläsare igen"
+  },
+  "config.scan_now": {
+    "other": "Sök nu"
+  },
+  "config.scan_error": {
+    "other": "Fel vid sökning av webbläsare!"
+  },
+  "config.scan_description": {
+    "other": "Webbläsarna bör sökas igenom och lagras i en konfigurationsfil för\nsnabbare uppstart och för att möjliggöra anpassad konfiguration.\n\nSökningen kan köras när som helst utan risk: bara nyligen upptäckta\nwebbläsare läggs till och de som inte längre finns i systemet tas bort.\n\nBefintliga regler, ordning eller anpassningar påverkas inte."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Öppna:"
+  },
+  "picker.remember_choice": {
+    "other": "Kom ihåg detta val för {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Tryck 'ENTER' för att välja första, 'ESC' för att avsluta, 'ctrl+c' för att kopiera URL till urklipp"
+  }
+}

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -58,5 +58,14 @@
   },
   "config.language_restart_note": {
     "other": "Språkändringen träder i kraft vid nästa start."
+  },
+  "config.scan_in_progress": {
+    "other": "Söker..."
+  },
+  "config.scan_success": {
+    "other": "✓ Webbläsare hittades"
+  },
+  "config.scan_failed": {
+    "other": "✗ Sökningen misslyckades"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -49,5 +49,14 @@
   },
   "picker.keyboard_guide": {
     "other": "Tryck 'ENTER' för att välja första, 'ESC' för att avsluta, 'ctrl+c' för att kopiera URL till urklipp"
+  },
+  "config.language_label": {
+    "other": "Språk:"
+  },
+  "config.language_auto": {
+    "other": "Automatisk (systemstandard)"
+  },
+  "config.language_restart_note": {
+    "other": "Språkändringen träder i kraft vid nästa start."
   }
 }

--- a/settings.go
+++ b/settings.go
@@ -76,6 +76,7 @@ type UiSettings struct {
 }
 
 type Settings struct {
+	Locale   string            `json:"locale,omitempty"`
 	LogLevel string            `json:"logLevel,omitempty"`
 	Browsers []BrowserSettings `json:"browsers"`
 	Plugins  []PluginSettings  `json:"plugins,omitempty"`


### PR DESCRIPTION
Adds a complete i18n system using `go-i18n` for message management and `go-locale` for system locale detection. English is the default fallback; the system locale is auto-detected unless overridden via config.

**Changes:**
- New `internal/i18n` package with embedded JSON translation files, `T()` helper, and locale detection
- `locale` field in `config.json` for overriding the detected locale
- All hardcoded UI strings replaced with translation lookups
- Language selector dropdown in the settings window (applies instantly, takes effect on next launch)
- Browser scan now runs asynchronously with a status indicator (✓/✗)
- Translations: English, Finnish, Spanish, Swedish

**Adding a new language:**
Add a JSON file to `internal/i18n/translations/` (e.g. `de.json`) following the format of `en.json`. It will be picked up automatically.