### PR TITLE
ci: optimize GitHub Actions workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Run Tests
         run: task test
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: test/coverage.latest/coverage.xml
+
   build:
     name: Build (${{ matrix.target }})
     needs: [ version, test ]
@@ -184,23 +190,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v6
         with:
-          go-version: '1.25'
-
-      - name: Install build dependencies (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: gcc libgl1-mesa-dev xorg-dev
-          version: 1.0
-
-      - uses: arduino/setup-task@v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Tests
-        run: task test
+          name: coverage-report
+          path: test/coverage.latest/
 
       - name: Make Coverage Badge
         uses: action-badges/cobertura-coverage-xml-badges@0.4.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,11 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
 
       - uses: arduino/setup-task@v2
         with:
@@ -71,11 +72,12 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install Linux build dependencies
+      - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev scdoc
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev scdoc
+          version: 1.0
 
       - uses: arduino/setup-task@v2
         with:
@@ -134,11 +136,14 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev scdoc
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev scdoc
+          version: 1.0
+
+      - name: Install syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - uses: arduino/setup-task@v2
         with:
@@ -183,10 +188,11 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
 
       - uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Install some build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
@@ -33,10 +34,11 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install some build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -65,11 +67,12 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install Linux build dependencies
+      - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
 
       - uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,39 +6,24 @@ permissions:
   contents: read
 
 jobs:
-  golangci:
-    name: lint
+  lint-and-test:
+    name: lint & test
     runs-on: ubuntu-latest
     steps:
-      - name: Install build dependencies (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: gcc libgl1-mesa-dev xorg-dev
-          version: 1.0
       - uses: actions/checkout@v7
+
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-
-  test:
-    name: test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.25'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: gcc libgl1-mesa-dev xorg-dev
           version: 1.0
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
## Summary

Reduces CI runtime and costs by eliminating redundant work across workflow jobs.

## Changes

1. **Remove unused syft from test workflow** — syft (SBOM tool) was only needed in the release job but was installed in the PR test job
2. **Cache apt packages** — uses `awalsh128/cache-apt-pkgs-action@v1` across all jobs, avoiding repeated `apt-get update` + download (~15-30s saved per job on cache hit)
3. **Eliminate duplicate test run in coverage job** — uploads `coverage.xml` as an artifact from the test job and downloads it in the coverage job (removes Go, apt, and Task setup entirely)
4. **Merge lint + test into single job in PR workflow** — one fewer runner spin-up, shared checkout/Go/apt setup

## What was intentionally left unchanged

- The release job still rebuilds from source because goreleaser needs to compile with its own ldflags (version, commit SHA, date) and needs the `package/linux/` tree (man pages, desktop file)
- `secrets.DEPENDABOT_TOKEN` is kept as-is since `GITHUB_TOKEN` events don't cascade to trigger downstream workflows on tag/release creation