### PR TITLE
test: add unit tests for untested business logic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,6 +114,9 @@ linters:
         linters:
           - noctx
           - goconst
+      - path: internal/i18n/
+        linters:
+          - goconst
       - text: "G704:"
         linters:
           - gosec

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -119,3 +119,71 @@ func TestDetectLocale_EmptyOverrideFallsBack(t *testing.T) {
 		t.Error("detectLocale(\"\") returned empty string")
 	}
 }
+
+func TestAvailableLocales(t *testing.T) {
+	locales := AvailableLocales()
+
+	// Should contain at least the four known locales
+	if len(locales) < 4 {
+		t.Errorf("AvailableLocales() returned %d locales, want at least 4", len(locales))
+	}
+
+	expected := map[string]bool{"en": false, "es": false, "fi": false, "sv": false}
+	for _, loc := range locales {
+		if _, ok := expected[loc]; ok {
+			expected[loc] = true
+		}
+	}
+
+	for code, found := range expected {
+		if !found {
+			t.Errorf("AvailableLocales() missing expected locale %q", code)
+		}
+	}
+}
+
+func TestLocaleDisplayName(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		{LocaleEnglish, "English"},
+		{LocaleFinnish, "Suomi"},
+		{LocaleSpanish, "Español"},
+		{LocaleSwedish, "Svenska"},
+		{"unknown", "unknown"}, // falls back to code itself
+		{"", ""},               // empty code returns empty
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			got := LocaleDisplayName(tt.code)
+			if got != tt.want {
+				t.Errorf("LocaleDisplayName(%q) = %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTWithCount_FallbackOnMissingPluralForms(t *testing.T) {
+	Init("en")
+
+	// TWithCount returns the fallback format when the message doesn't define plural forms
+	// This exercises the error handling path of TWithCount
+	got := TWithCount("picker.window_title", 1)
+	want := "[picker.window_title]"
+	if got != want {
+		t.Errorf("TWithCount(\"picker.window_title\", 1) = %q, want %q", got, want)
+	}
+}
+
+func TestT_NilTemplateData(t *testing.T) {
+	Init("en")
+
+	// Passing nil as template data should not panic and should work normally
+	got := T("picker.window_title", nil)
+	want := "Linkquisition"
+	if got != want {
+		t.Errorf("T with nil template data = %q, want %q", got, want)
+	}
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,34 @@
+package linkquisition_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/strobotti/linkquisition"
+)
+
+func TestNewPluginServiceProvider(t *testing.T) {
+	logger := slog.Default()
+	settings := &Settings{
+		LogLevel: "debug",
+		Browsers: []BrowserSettings{
+			{Name: "Firefox", Command: "firefox"},
+		},
+	}
+
+	provider := NewPluginServiceProvider(logger, settings)
+
+	assert.Equal(t, logger, provider.GetLogger())
+	assert.Equal(t, settings, provider.GetSettings())
+}
+
+func TestNewPluginServiceProvider_NilLogger(t *testing.T) {
+	settings := &Settings{}
+
+	provider := NewPluginServiceProvider(nil, settings)
+
+	assert.Nil(t, provider.GetLogger())
+	assert.Equal(t, settings, provider.GetSettings())
+}

--- a/settings_test.go
+++ b/settings_test.go
@@ -531,3 +531,196 @@ func TestSettings_UpdateWithBrowsers_PreservesNonBrowserFields(t *testing.T) {
 	assert.Equal(t, "/usr/lib/linkquisition/plugins/unwrap.so", result.Plugins[0].Path)
 	assert.True(t, result.Ui.HideKeyboardGuideLabel)
 }
+
+func TestSettings_GetSelectableBrowsers(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		settings Settings
+		expected []Browser
+	}{
+		{
+			name: "returns only visible browsers",
+			settings: Settings{
+				Browsers: []BrowserSettings{
+					{Name: "Firefox", Command: "firefox", Hidden: false},
+					{Name: "Chromium", Command: "chromium", Hidden: true},
+					{Name: "Brave", Command: "brave", Hidden: false},
+				},
+			},
+			expected: []Browser{
+				{Name: "Firefox", Command: "firefox"},
+				{Name: "Brave", Command: "brave"},
+			},
+		},
+		{
+			name: "returns empty slice when all are hidden",
+			settings: Settings{
+				Browsers: []BrowserSettings{
+					{Name: "Firefox", Command: "firefox", Hidden: true},
+					{Name: "Chromium", Command: "chromium", Hidden: true},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns all when none are hidden",
+			settings: Settings{
+				Browsers: []BrowserSettings{
+					{Name: "Firefox", Command: "firefox", Hidden: false},
+					{Name: "Chromium", Command: "chromium", Hidden: false},
+				},
+			},
+			expected: []Browser{
+				{Name: "Firefox", Command: "firefox"},
+				{Name: "Chromium", Command: "chromium"},
+			},
+		},
+		{
+			name:     "returns nil when there are no browsers",
+			settings: Settings{Browsers: nil},
+			expected: nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.settings.GetSelectableBrowsers()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSettings_GetMatchingBrowser(t *testing.T) {
+	settings := &Settings{
+		Browsers: []BrowserSettings{
+			{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeSite, Value: "www.facebook.com"},
+				},
+			},
+			{
+				Name:    "Edge",
+				Command: "edge",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeDomain, Value: "office.com"},
+				},
+			},
+		},
+	}
+
+	t.Run("returns matching browser for site rule", func(t *testing.T) {
+		browser, err := settings.GetMatchingBrowser("https://www.facebook.com/feed")
+		assert.NoError(t, err)
+		assert.Equal(t, "Firefox", browser.Name)
+		assert.Equal(t, "firefox", browser.Command)
+	})
+
+	t.Run("returns matching browser for domain rule", func(t *testing.T) {
+		browser, err := settings.GetMatchingBrowser("https://outlook.office.com/mail")
+		assert.NoError(t, err)
+		assert.Equal(t, "Edge", browser.Name)
+		assert.Equal(t, "edge", browser.Command)
+	})
+
+	t.Run("returns ErrNoMatchFound when no browser matches", func(t *testing.T) {
+		browser, err := settings.GetMatchingBrowser("https://github.com/something")
+		assert.ErrorIs(t, err, ErrNoMatchFound)
+		assert.Nil(t, browser)
+	})
+
+	t.Run("returns first match when multiple browsers could match", func(t *testing.T) {
+		s := &Settings{
+			Browsers: []BrowserSettings{
+				{
+					Name:    "First",
+					Command: "first",
+					Matches: []BrowserMatch{{Type: BrowserMatchTypeDomain, Value: "example.com"}},
+				},
+				{
+					Name:    "Second",
+					Command: "second",
+					Matches: []BrowserMatch{{Type: BrowserMatchTypeDomain, Value: "example.com"}},
+				},
+			},
+		}
+		browser, err := s.GetMatchingBrowser("https://www.example.com/page")
+		assert.NoError(t, err)
+		assert.Equal(t, "First", browser.Name)
+	})
+}
+
+func TestSettings_AddRuleToBrowser(t *testing.T) {
+	t.Run("adds a rule to the matching browser", func(t *testing.T) {
+		settings := &Settings{
+			Browsers: []BrowserSettings{
+				{Name: "Firefox", Command: "firefox"},
+				{Name: "Edge", Command: "edge"},
+			},
+		}
+
+		browser := &Browser{Name: "Firefox", Command: "firefox"}
+		settings.AddRuleToBrowser(browser, BrowserMatchTypeSite, "www.example.com")
+
+		assert.Len(t, settings.Browsers[0].Matches, 1)
+		assert.Equal(t, BrowserMatchTypeSite, settings.Browsers[0].Matches[0].Type)
+		assert.Equal(t, "www.example.com", settings.Browsers[0].Matches[0].Value)
+		// Other browser should be untouched
+		assert.Empty(t, settings.Browsers[1].Matches)
+	})
+
+	t.Run("does nothing when browser command does not match", func(t *testing.T) {
+		settings := &Settings{
+			Browsers: []BrowserSettings{
+				{Name: "Firefox", Command: "firefox"},
+			},
+		}
+
+		browser := &Browser{Name: "Nonexistent", Command: "nonexistent"}
+		settings.AddRuleToBrowser(browser, BrowserMatchTypeDomain, "example.com")
+
+		assert.Empty(t, settings.Browsers[0].Matches)
+	})
+
+	t.Run("appends to existing matches", func(t *testing.T) {
+		settings := &Settings{
+			Browsers: []BrowserSettings{
+				{
+					Name:    "Firefox",
+					Command: "firefox",
+					Matches: []BrowserMatch{
+						{Type: BrowserMatchTypeSite, Value: "existing.com"},
+					},
+				},
+			},
+		}
+
+		browser := &Browser{Name: "Firefox", Command: "firefox"}
+		settings.AddRuleToBrowser(browser, BrowserMatchTypeDomain, "new.com")
+
+		assert.Len(t, settings.Browsers[0].Matches, 2)
+		assert.Equal(t, "existing.com", settings.Browsers[0].Matches[0].Value)
+		assert.Equal(t, "new.com", settings.Browsers[0].Matches[1].Value)
+	})
+}
+
+func TestMapSettingsLogLevelToSlog(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{name: "debug", input: "debug", expected: -4},
+		{name: "info", input: "info", expected: 0},
+		{name: "warn", input: "warn", expected: 4},
+		{name: "error", input: "error", expected: 8},
+		{name: "unknown defaults to info", input: "something", expected: 0},
+		{name: "empty defaults to info", input: "", expected: 0},
+		{name: "case insensitive DEBUG", input: "DEBUG", expected: -4},
+		{name: "case insensitive Warn", input: "Warn", expected: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MapSettingsLogLevelToSlog(tt.input)
+			assert.Equal(t, tt.expected, int(result))
+		})
+	}
+}

--- a/url_test.go
+++ b/url_test.go
@@ -67,6 +67,28 @@ func TestURL_GetDomain(t *testing.T) {
 	}
 }
 
+func TestURL_GetDomain_ErrorCases(t *testing.T) {
+	for _, tt := range [...]struct {
+		name string
+		url  string
+	}{
+		{
+			name: "invalid URL returns error",
+			url:  "://not-a-url",
+		},
+		{
+			name: "empty string returns error",
+			url:  "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			u := NewURL(tt.url)
+			_, err := u.GetDomain()
+			assert.Error(t, err)
+		})
+	}
+}
+
 func TestURL_GetSite(t *testing.T) {
 	for _, tt := range [...]struct {
 		name      string
@@ -108,6 +130,21 @@ func TestURL_GetSite(t *testing.T) {
 			name:     "ip address will be returned as is",
 			url:      "https://1.2.3.4/path/is/here",
 			expected: "1.2.3.4",
+		},
+		{
+			name:     "non-http URL returns empty string",
+			url:      "ftp://files.example.com/data",
+			expected: "",
+		},
+		{
+			name:     "empty string returns empty",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "just a path returns empty",
+			url:      "/some/path",
+			expected: "",
 		},
 	} {
 		t.Run(


### PR DESCRIPTION
- settings.go: GetSelectableBrowsers, GetMatchingBrowser, AddRuleToBrowser, MapSettingsLogLevelToSlog
- plugin.go: NewPluginServiceProvider
- url.go: GetDomain error cases, GetSite edge cases (non-http, empty, path-only)
- i18n: AvailableLocales, LocaleDisplayName, TWithCount fallback, T with nil data