### PR TITLE
chore: Improvements/code quality fixes

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -154,7 +154,7 @@ func (a *Application) Run(_ context.Context) error {
 	}
 
 	if urlToOpen == "" {
-		configurator := NewConfigurator(a.Fapp, a.BrowserService, a.SettingsService)
+		configurator := NewConfigurator(a.Fapp, a.BrowserService, a.SettingsService, a.Logger)
 		return configurator.Run()
 	}
 
@@ -192,6 +192,6 @@ func (a *Application) Run(_ context.Context) error {
 		a.Logger.Warn("browsers not configured, falling back to system settings")
 	}
 
-	bp := NewBrowserPicker(a.Fapp, a.BrowserService, browsers, a.SettingsService)
+	bp := NewBrowserPicker(a.Fapp, a.BrowserService, browsers, a.SettingsService, a.Logger)
 	return bp.Run(context.Background(), urlToOpen)
 }

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -20,6 +20,7 @@ type BrowserPicker struct {
 	browserService  linkquisition.BrowserService
 	browsers        []linkquisition.Browser
 	settingsService linkquisition.SettingsService
+	logger          *slog.Logger
 }
 
 func NewBrowserPicker(
@@ -27,12 +28,14 @@ func NewBrowserPicker(
 	browserService linkquisition.BrowserService,
 	browsers []linkquisition.Browser,
 	settingsService linkquisition.SettingsService,
+	logger *slog.Logger,
 ) *BrowserPicker {
 	return &BrowserPicker{
 		fapp:            fapp,
 		browserService:  browserService,
 		browsers:        browsers,
 		settingsService: settingsService,
+		logger:          logger,
 	}
 }
 
@@ -56,7 +59,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 
 	w.Canvas().AddShortcut(
 		&fyne.ShortcutCopy{}, func(shortcut fyne.Shortcut) {
-			fmt.Println("Copying URL to clipboard: " + urlToOpen)
+			picker.logger.Debug("Copying URL to clipboard", "url", urlToOpen)
 			w.Clipboard().SetContent(urlToOpen)
 
 			// Sleep for a while to allow the Clipboard.SetContent to finish
@@ -163,7 +166,7 @@ func (picker *BrowserPicker) makeBrowserButton(
 
 	iconBytes, err := picker.browserService.GetIconForBrowser(browser)
 	if err != nil {
-		fmt.Println(err)
+		picker.logger.Debug("Failed to load browser icon", "browser", browser.Name, "error", err)
 	} else {
 		icon = fyne.NewStaticResource("icon.png", iconBytes)
 	}
@@ -173,7 +176,7 @@ func (picker *BrowserPicker) makeBrowserButton(
 		icon,
 		func() {
 			rem, _ := remember.Get()
-			fmt.Printf("Opening URL with browser: %s; remember the choice: %v\n", browser.Name, rem)
+			picker.logger.Debug("Opening URL with browser", "browser", browser.Name, "remember", rem)
 
 			settings := picker.settingsService.GetSettings()
 			remType, _ := rememberMatchType.Get()
@@ -188,7 +191,7 @@ func (picker *BrowserPicker) makeBrowserButton(
 
 				settings.AddRuleToBrowser(&browser, remType, matchValue)
 				if writeErr := picker.settingsService.WriteSettings(settings); writeErr != nil {
-					fmt.Printf("Failed to write settings: %v\n", writeErr)
+					picker.logger.Error("Failed to write settings", "error", writeErr)
 				}
 			}
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -17,17 +18,20 @@ type Configurator struct {
 	fapp            fyne.App
 	browserService  linkquisition.BrowserService
 	settingsService linkquisition.SettingsService
+	logger          *slog.Logger
 }
 
 func NewConfigurator(
 	fapp fyne.App,
 	browserService linkquisition.BrowserService,
 	settingsService linkquisition.SettingsService,
+	logger *slog.Logger,
 ) *Configurator {
 	return &Configurator{
 		fapp:            fapp,
 		browserService:  browserService,
 		settingsService: settingsService,
+		logger:          logger,
 	}
 }
 
@@ -81,7 +85,7 @@ func (c *Configurator) buildMakeDefaultSection() fyne.CanvasObject {
 		if err != nil {
 			makeDefaultButton.SetText(i18n.T("config.make_default_error"))
 			makeDefaultButton.Enable()
-			fmt.Printf("error making Linkquisition the default browser: %v\n", err)
+			c.logger.Error("Error making Linkquisition the default browser", "error", err)
 		} else {
 			setupButton(makeDefaultButton, true)
 		}
@@ -118,7 +122,7 @@ func (c *Configurator) buildScanBrowsersSection() fyne.CanvasObject {
 			if err != nil {
 				scanStatusLabel.SetText(i18n.T("config.scan_failed"))
 				scanBrowsersButton.Enable()
-				fmt.Printf("error scanning browsers: %v\n", err)
+				c.logger.Error("Error scanning browsers", "error", err)
 			} else {
 				scanStatusLabel.SetText(i18n.T("config.scan_success"))
 				isConfigured, _ := c.settingsService.IsConfigured()
@@ -169,7 +173,7 @@ func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 		settings := c.settingsService.GetSettings()
 		settings.Locale = newLocale
 		if err := c.settingsService.WriteSettings(settings); err != nil {
-			fmt.Printf("error saving locale setting: %v\n", err)
+			c.logger.Error("Error saving locale setting", "error", err)
 		}
 	})
 	languageSelect.Selected = selectedOption
@@ -189,7 +193,7 @@ func (c *Configurator) getAboutTab() fyne.CanvasObject {
 		resources.LinkquisitionIcon,
 		func() {
 			if err := c.browserService.OpenUrlWithDefaultBrowser("https://github.com/Strobotti/linkquisition"); err != nil {
-				fmt.Printf("error opening url: %s", err.Error())
+				c.logger.Error("Error opening URL", "error", err)
 			}
 		},
 	)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/text v0.38.0
 	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
 	gopkg.in/ini.v1 v1.67.3
+	howett.net/plist v1.0.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	fyne.io/fyne/v2 v2.7.4
+	github.com/jackmordaunt/icns/v3 v3.0.1
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nicksnyder/go-i18n/v2 v2.6.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/hack-pad/go-indexeddb v0.3.2 h1:DTqeJJYc1usa45Q5r52t01KhvlSN02+Oq+tQb
 github.com/hack-pad/go-indexeddb v0.3.2/go.mod h1:QvfTevpDVlkfomY498LhstjwbPW6QC4VC/lxYb0Kom0=
 github.com/hack-pad/safejs v0.1.1 h1:d5qPO0iQ7h2oVtpzGnLExE+Wn9AtytxIfltcS2b9KD8=
 github.com/hack-pad/safejs v0.1.1/go.mod h1:HdS+bKF1NrE72VoXZeWzxFOVQVUSqZJAG0xNCnb+Tio=
+github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8D4S3o=
+github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wHw+XQbvL9M+1r/C3SPqKrmBaIOYwVfQoDE=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/hack-pad/safejs v0.1.1 h1:d5qPO0iQ7h2oVtpzGnLExE+Wn9AtytxIfltcS2b9KD8
 github.com/hack-pad/safejs v0.1.1/go.mod h1:HdS+bKF1NrE72VoXZeWzxFOVQVUSqZJAG0xNCnb+Tio=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade h1:FmusiCI1wHw+XQbvL9M+1r/C3SPqKrmBaIOYwVfQoDE=
 github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 h1:YLvr1eE6cdCqjOe972w/cYF+FjW34v27+9Vo5106B4M=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25/go.mod h1:kLgvv7o6UM+0QSf0QjAse3wReFDsb9qbZJdfexWlrQw=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -100,6 +101,9 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
 gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
+howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=

--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -54,119 +55,132 @@ func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error)
 }
 
 func (b *BrowserService) getHTTPHandlers() ([]lsRegisterEntry, error) {
-	// Use the Swift helper via 'open' heuristics and system_profiler won't work cleanly.
-	// Instead, use LSCopyAllHandlersForURLScheme via a small Swift script, or parse
-	// the output of `lsregister -dump` which is too complex.
-	// Pragmatic approach: use defaults + known browser bundle IDs + check what's installed.
-	cmd := exec.Command("/usr/bin/python3", "-c", `
-import json, subprocess, plistlib, os, glob
-
-browsers = []
-app_dirs = ["/Applications", os.path.expanduser("~/Applications")]
-
-for app_dir in app_dirs:
-    if not os.path.isdir(app_dir):
-        continue
-    for app in glob.glob(os.path.join(app_dir, "*.app")):
-        plist_path = os.path.join(app, "Contents", "Info.plist")
-        if not os.path.exists(plist_path):
-            continue
-        try:
-            with open(plist_path, "rb") as f:
-                plist = plistlib.load(f)
-            url_types = plist.get("CFBundleURLTypes", [])
-            for url_type in url_types:
-                schemes = [s.lower() for s in url_type.get("CFBundleURLSchemes", [])]
-                if "http" in schemes or "https" in schemes:
-                    bundle_id = plist.get("CFBundleIdentifier", "")
-                    name = plist.get("CFBundleDisplayName") or plist.get("CFBundleName") or os.path.basename(app).replace(".app", "")
-                    browsers.append({"bundleId": bundle_id, "name": name, "path": app})
-                    break
-        except Exception:
-            pass
-
-print(json.dumps(browsers))
-`)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to discover browsers: %v", err)
-	}
-
-	var results []struct {
-		BundleID string `json:"bundleId"`
-		Name     string `json:"name"`
-		Path     string `json:"path"`
-	}
-
-	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
-		return nil, fmt.Errorf("failed to parse browser list: %v", err)
-	}
+	homeDir, _ := os.UserHomeDir()
+	appDirs := []string{"/Applications", filepath.Join(homeDir, "Applications")}
 
 	var entries []lsRegisterEntry
-	for _, r := range results {
-		entries = append(entries, lsRegisterEntry{
-			BundleID: r.BundleID,
-			Name:     r.Name,
-			Path:     r.Path,
-		})
+	seen := make(map[string]bool)
+
+	for _, appDir := range appDirs {
+		dirEntries, err := os.ReadDir(appDir)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range dirEntries {
+			if !entry.IsDir() || !strings.HasSuffix(entry.Name(), ".app") {
+				continue
+			}
+
+			appPath := filepath.Join(appDir, entry.Name())
+			plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+
+			if _, err := os.Stat(plistPath); err != nil {
+				continue
+			}
+
+			bundleID, name, isHTTPHandler := parseBrowserPlist(plistPath, entry.Name())
+			if !isHTTPHandler || seen[bundleID] {
+				continue
+			}
+
+			seen[bundleID] = true
+			entries = append(entries, lsRegisterEntry{
+				BundleID: bundleID,
+				Name:     name,
+				Path:     appPath,
+			})
+		}
 	}
 
 	return entries, nil
 }
 
-func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
-	// Read the default HTTP handler
-	cmd := exec.Command("/usr/bin/python3", "-c", `
-import subprocess, re
-result = subprocess.run(["defaults", "read", "com.apple.LaunchServices/com.apple.launchservices.secure", "LSHandlers"], capture_output=True, text=True)
-# Fallback: use the x-scheme-handler approach
-import Foundation
-from Foundation import NSBundle
-# Actually simplest: use open command
-import subprocess as sp
-r = sp.run(["plutil", "-convert", "json", "-o", "-", "/Users/"+__import__("os").environ.get("USER","")+"//Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"], capture_output=True, text=True)
-`)
-	// The above is too fragile. Use a simpler approach:
-	cmd = exec.Command("/usr/bin/python3", "-c", `
-import json, subprocess
-# On macOS, we can get the default browser bundle ID from LaunchServices
-# Using the 'defaults' command to read the handler for https
-import plistlib, os
-
-plist_path = os.path.expanduser("~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist")
-bundle_id = "com.apple.Safari"  # default fallback
-
-try:
-    with open(plist_path, "rb") as f:
-        data = plistlib.load(f)
-    for handler in data.get("LSHandlers", []):
-        if handler.get("LSHandlerURLScheme") == "https":
-            bundle_id = handler.get("LSHandlerRoleAll", bundle_id)
-            break
-except Exception:
-    pass
-
-print(bundle_id)
-`)
-
+// parseBrowserPlist extracts bundle ID, display name, and whether the app handles HTTP/HTTPS URLs.
+// Uses plutil to convert the plist to JSON for safe parsing without Python.
+func parseBrowserPlist(plistPath, appDirName string) (bundleID, name string, isHTTPHandler bool) {
+	cmd := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 
 	if err := cmd.Run(); err != nil {
-		// Fallback to Safari
-		return linkquisition.Browser{Name: "Safari", Command: "com.apple.Safari"}, nil
+		return "", "", false
 	}
 
-	bundleID := strings.TrimSpace(out.String())
-	if bundleID == "" {
-		bundleID = "com.apple.Safari"
+	var plist struct {
+		BundleID    string `json:"CFBundleIdentifier"`
+		DisplayName string `json:"CFBundleDisplayName"`
+		BundleName  string `json:"CFBundleName"`
+		URLTypes    []struct {
+			Schemes []string `json:"CFBundleURLSchemes"`
+		} `json:"CFBundleURLTypes"`
+	}
+
+	if err := json.Unmarshal(out.Bytes(), &plist); err != nil {
+		return "", "", false
+	}
+
+	// Check if the app handles http or https
+	for _, urlType := range plist.URLTypes {
+		for _, scheme := range urlType.Schemes {
+			lower := strings.ToLower(scheme)
+			if lower == "http" || lower == "https" {
+				// Determine the display name
+				name = plist.DisplayName
+				if name == "" {
+					name = plist.BundleName
+				}
+				if name == "" {
+					name = strings.TrimSuffix(appDirName, ".app")
+				}
+				return plist.BundleID, name, true
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
+	safariDefault := linkquisition.Browser{Name: "Safari", Command: "com.apple.Safari"}
+
+	// Read the LaunchServices plist using plutil (no Python dependency)
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return safariDefault, nil
+	}
+
+	plistPath := filepath.Join(homeDir, "Library", "Preferences",
+		"com.apple.LaunchServices", "com.apple.launchservices.secure.plist")
+
+	cmd := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	if err := cmd.Run(); err != nil {
+		return safariDefault, nil
+	}
+
+	var data struct {
+		LSHandlers []struct {
+			URLScheme      string `json:"LSHandlerURLScheme"`
+			HandlerRoleAll string `json:"LSHandlerRoleAll"`
+		} `json:"LSHandlers"`
+	}
+
+	if err := json.Unmarshal(out.Bytes(), &data); err != nil {
+		return safariDefault, nil
+	}
+
+	bundleID := "com.apple.Safari"
+	for _, handler := range data.LSHandlers {
+		if handler.URLScheme == "https" && handler.HandlerRoleAll != "" {
+			bundleID = handler.HandlerRoleAll
+			break
+		}
 	}
 
 	name := bundleIDToName(bundleID)
-
 	return linkquisition.Browser{Name: name, Command: bundleID}, nil
 }
 

--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -5,12 +5,13 @@ package darwin
 import (
 	"bytes"
 	"fmt"
+	"image/png"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
-	"fyne.io/fyne/v2"
+	icns "github.com/jackmordaunt/icns/v3"
 	"howett.net/plist"
 
 	"github.com/strobotti/linkquisition"
@@ -234,18 +235,24 @@ func (b *BrowserService) GetIconForBrowser(browser linkquisition.Browser) ([]byt
 		return nil, fmt.Errorf("no icon found for %s", browser.Name)
 	}
 
-	// Convert .icns to PNG using sips
-	cmd := exec.Command("sips", "-s", "format", "png", iconPath, "--out", "/tmp/linkquisition-icon-tmp.png")
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to convert icon: %v", err)
-	}
-
-	icon, err := fyne.LoadResourceFromPath("/tmp/linkquisition-icon-tmp.png")
+	// Decode the .icns file natively and encode as PNG
+	f, err := os.Open(iconPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open icon file: %v", err)
+	}
+	defer f.Close()
+
+	img, err := icns.Decode(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode icns: %v", err)
 	}
 
-	return icon.Content(), nil
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, fmt.Errorf("failed to encode icon as PNG: %v", err)
+	}
+
+	return buf.Bytes(), nil
 }
 
 func getAppPathForBundleID(bundleID string) (string, error) {

--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -238,7 +238,9 @@ func (b *BrowserService) GetIconForBrowser(browser linkquisition.Browser) ([]byt
 }
 
 func getAppPathForBundleID(bundleID string) (string, error) {
-	cmd := exec.Command("mdfind", fmt.Sprintf("kMDItemCFBundleIdentifier == '%s'", bundleID))
+	// Pass the query as a single argument to mdfind — bundleID is not interpolated into a shell
+	query := "kMDItemCFBundleIdentifier == '" + bundleID + "'"
+	cmd := exec.Command("mdfind", query)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 
@@ -255,23 +257,14 @@ func getAppPathForBundleID(bundleID string) (string, error) {
 }
 
 func getIconPathFromApp(appPath string) string {
-	// Read Info.plist to find icon file name
-	cmd := exec.Command("/usr/bin/python3", "-c", fmt.Sprintf(`
-import plistlib, os
-plist_path = "%s/Contents/Info.plist"
-try:
-    with open(plist_path, "rb") as f:
-        data = plistlib.load(f)
-    icon = data.get("CFBundleIconFile", "")
-    if icon and not icon.endswith(".icns"):
-        icon += ".icns"
-    print(icon)
-except Exception:
-    print("")
-`, appPath))
+	// Read Info.plist natively using plutil to extract the icon file name safely
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
 
+	// Use plutil to extract CFBundleIconFile as raw value — avoids Python and injection risks
+	cmd := exec.Command("plutil", "-extract", "CFBundleIconFile", "raw", plistPath)
 	var out bytes.Buffer
 	cmd.Stdout = &out
+
 	if err := cmd.Run(); err != nil {
 		return ""
 	}
@@ -279,6 +272,10 @@ except Exception:
 	iconFile := strings.TrimSpace(out.String())
 	if iconFile == "" {
 		return ""
+	}
+
+	if !strings.HasSuffix(iconFile, ".icns") {
+		iconFile += ".icns"
 	}
 
 	return filepath.Join(appPath, "Contents", "Resources", iconFile)

--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -4,7 +4,6 @@ package darwin
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"fyne.io/fyne/v2"
+	"howett.net/plist"
 
 	"github.com/strobotti/linkquisition"
 )
@@ -97,43 +97,42 @@ func (b *BrowserService) getHTTPHandlers() ([]lsRegisterEntry, error) {
 }
 
 // parseBrowserPlist extracts bundle ID, display name, and whether the app handles HTTP/HTTPS URLs.
-// Uses plutil to convert the plist to JSON for safe parsing without Python.
+// Parses the binary plist directly using the howett.net/plist library.
 func parseBrowserPlist(plistPath, appDirName string) (bundleID, name string, isHTTPHandler bool) {
-	cmd := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if err := cmd.Run(); err != nil {
+	f, err := os.Open(plistPath)
+	if err != nil {
 		return "", "", false
 	}
+	defer f.Close()
 
-	var plist struct {
-		BundleID    string `json:"CFBundleIdentifier"`
-		DisplayName string `json:"CFBundleDisplayName"`
-		BundleName  string `json:"CFBundleName"`
+	var plistData struct {
+		BundleID    string `plist:"CFBundleIdentifier"`
+		DisplayName string `plist:"CFBundleDisplayName"`
+		BundleName  string `plist:"CFBundleName"`
 		URLTypes    []struct {
-			Schemes []string `json:"CFBundleURLSchemes"`
-		} `json:"CFBundleURLTypes"`
+			Schemes []string `plist:"CFBundleURLSchemes"`
+		} `plist:"CFBundleURLTypes"`
 	}
 
-	if err := json.Unmarshal(out.Bytes(), &plist); err != nil {
+	decoder := plist.NewDecoder(f)
+	if err := decoder.Decode(&plistData); err != nil {
 		return "", "", false
 	}
 
 	// Check if the app handles http or https
-	for _, urlType := range plist.URLTypes {
+	for _, urlType := range plistData.URLTypes {
 		for _, scheme := range urlType.Schemes {
 			lower := strings.ToLower(scheme)
 			if lower == "http" || lower == "https" {
 				// Determine the display name
-				name = plist.DisplayName
+				name = plistData.DisplayName
 				if name == "" {
-					name = plist.BundleName
+					name = plistData.BundleName
 				}
 				if name == "" {
 					name = strings.TrimSuffix(appDirName, ".app")
 				}
-				return plist.BundleID, name, true
+				return plistData.BundleID, name, true
 			}
 		}
 	}
@@ -144,7 +143,6 @@ func parseBrowserPlist(plistPath, appDirName string) (bundleID, name string, isH
 func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 	safariDefault := linkquisition.Browser{Name: "Safari", Command: "com.apple.Safari"}
 
-	// Read the LaunchServices plist using plutil (no Python dependency)
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return safariDefault, nil
@@ -153,22 +151,21 @@ func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 	plistPath := filepath.Join(homeDir, "Library", "Preferences",
 		"com.apple.LaunchServices", "com.apple.launchservices.secure.plist")
 
-	cmd := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if err := cmd.Run(); err != nil {
+	f, err := os.Open(plistPath)
+	if err != nil {
 		return safariDefault, nil
 	}
+	defer f.Close()
 
 	var data struct {
 		LSHandlers []struct {
-			URLScheme      string `json:"LSHandlerURLScheme"`
-			HandlerRoleAll string `json:"LSHandlerRoleAll"`
-		} `json:"LSHandlers"`
+			URLScheme      string `plist:"LSHandlerURLScheme"`
+			HandlerRoleAll string `plist:"LSHandlerRoleAll"`
+		} `plist:"LSHandlers"`
 	}
 
-	if err := json.Unmarshal(out.Bytes(), &data); err != nil {
+	decoder := plist.NewDecoder(f)
+	if err := decoder.Decode(&data); err != nil {
 		return safariDefault, nil
 	}
 
@@ -271,19 +268,24 @@ func getAppPathForBundleID(bundleID string) (string, error) {
 }
 
 func getIconPathFromApp(appPath string) string {
-	// Read Info.plist natively using plutil to extract the icon file name safely
 	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
 
-	// Use plutil to extract CFBundleIconFile as raw value — avoids Python and injection risks
-	cmd := exec.Command("plutil", "-extract", "CFBundleIconFile", "raw", plistPath)
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	f, err := os.Open(plistPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
 
-	if err := cmd.Run(); err != nil {
+	var data struct {
+		IconFile string `plist:"CFBundleIconFile"`
+	}
+
+	decoder := plist.NewDecoder(f)
+	if err := decoder.Decode(&data); err != nil {
 		return ""
 	}
 
-	iconFile := strings.TrimSpace(out.String())
+	iconFile := data.IconFile
 	if iconFile == "" {
 		return ""
 	}

--- a/internal/darwin/browser_service_test.go
+++ b/internal/darwin/browser_service_test.go
@@ -1,0 +1,304 @@
+//go:build darwin
+
+package darwin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+func TestParseBrowserPlist_HTTPHandler(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier":  "com.example.browser",
+		"CFBundleDisplayName": "Example Browser",
+		"CFBundleName":        "ExampleBrowser",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"https", "http"},
+			},
+		},
+	}
+
+	writePlist(t, plistPath, data)
+
+	bundleID, name, isHTTPHandler := parseBrowserPlist(plistPath, "Example.app")
+
+	assert.True(t, isHTTPHandler)
+	assert.Equal(t, "com.example.browser", bundleID)
+	assert.Equal(t, "Example Browser", name)
+}
+
+func TestParseBrowserPlist_FallsBackToBundleName(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.browser",
+		"CFBundleName":       "MyBrowser",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"HTTP"},
+			},
+		},
+	}
+
+	writePlist(t, plistPath, data)
+
+	bundleID, name, isHTTPHandler := parseBrowserPlist(plistPath, "Something.app")
+
+	assert.True(t, isHTTPHandler)
+	assert.Equal(t, "com.example.browser", bundleID)
+	assert.Equal(t, "MyBrowser", name)
+}
+
+func TestParseBrowserPlist_FallsBackToAppDirName(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.browser",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"https"},
+			},
+		},
+	}
+
+	writePlist(t, plistPath, data)
+
+	_, name, isHTTPHandler := parseBrowserPlist(plistPath, "FancyBrowser.app")
+
+	assert.True(t, isHTTPHandler)
+	assert.Equal(t, "FancyBrowser", name)
+}
+
+func TestParseBrowserPlist_NotHTTPHandler(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.editor",
+		"CFBundleName":       "TextEditor",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"myapp", "custom-scheme"},
+			},
+		},
+	}
+
+	writePlist(t, plistPath, data)
+
+	_, _, isHTTPHandler := parseBrowserPlist(plistPath, "TextEditor.app")
+
+	assert.False(t, isHTTPHandler)
+}
+
+func TestParseBrowserPlist_NoURLTypes(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.app",
+		"CFBundleName":       "SomeApp",
+	}
+
+	writePlist(t, plistPath, data)
+
+	_, _, isHTTPHandler := parseBrowserPlist(plistPath, "SomeApp.app")
+
+	assert.False(t, isHTTPHandler)
+}
+
+func TestParseBrowserPlist_MissingFile(t *testing.T) {
+	_, _, isHTTPHandler := parseBrowserPlist("/nonexistent/path/Info.plist", "Missing.app")
+
+	assert.False(t, isHTTPHandler)
+}
+
+func TestParseBrowserPlist_InvalidPlist(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	err := os.WriteFile(plistPath, []byte("not a valid plist"), 0644)
+	require.NoError(t, err)
+
+	_, _, isHTTPHandler := parseBrowserPlist(plistPath, "Bad.app")
+
+	assert.False(t, isHTTPHandler)
+}
+
+func TestGetIconPathFromApp_ValidIcon(t *testing.T) {
+	appPath := t.TempDir()
+
+	// Create the expected directory structure
+	resourcesDir := filepath.Join(appPath, "Contents", "Resources")
+	require.NoError(t, os.MkdirAll(resourcesDir, 0755))
+
+	// Create an Info.plist with CFBundleIconFile
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+	data := map[string]interface{}{
+		"CFBundleIconFile": "AppIcon",
+	}
+	writePlist(t, plistPath, data)
+
+	result := getIconPathFromApp(appPath)
+
+	assert.Equal(t, filepath.Join(appPath, "Contents", "Resources", "AppIcon.icns"), result)
+}
+
+func TestGetIconPathFromApp_IconWithExtension(t *testing.T) {
+	appPath := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(appPath, "Contents", "Resources"), 0755))
+
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+	data := map[string]interface{}{
+		"CFBundleIconFile": "AppIcon.icns",
+	}
+	writePlist(t, plistPath, data)
+
+	result := getIconPathFromApp(appPath)
+
+	assert.Equal(t, filepath.Join(appPath, "Contents", "Resources", "AppIcon.icns"), result)
+}
+
+func TestGetIconPathFromApp_NoIconField(t *testing.T) {
+	appPath := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(appPath, "Contents"), 0755))
+
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.noicon",
+	}
+	writePlist(t, plistPath, data)
+
+	result := getIconPathFromApp(appPath)
+
+	assert.Empty(t, result)
+}
+
+func TestGetIconPathFromApp_MissingPlist(t *testing.T) {
+	appPath := t.TempDir()
+
+	result := getIconPathFromApp(appPath)
+
+	assert.Empty(t, result)
+}
+
+func TestBundleIDToName_KnownBrowsers(t *testing.T) {
+	tests := []struct {
+		bundleID string
+		expected string
+	}{
+		{"com.apple.Safari", "Safari"},
+		{"com.google.Chrome", "Google Chrome"},
+		{"org.mozilla.firefox", "Firefox"},
+		{"com.microsoft.edgemac", "Microsoft Edge"},
+		{"com.brave.Browser", "Brave Browser"},
+		{"com.operasoftware.Opera", "Opera"},
+		{"com.vivaldi.Vivaldi", "Vivaldi"},
+		{"company.thebrowser.Browser", "Arc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.bundleID, func(t *testing.T) {
+			name := bundleIDToName(tt.bundleID)
+			assert.Equal(t, tt.expected, name)
+		})
+	}
+}
+
+func TestBundleIDToName_UnknownFallsBackToLastPart(t *testing.T) {
+	// For an unknown bundle ID where mdfind won't find anything,
+	// it should fall back to the last part of the bundle ID
+	name := bundleIDToName("com.unknown.SuperBrowser")
+
+	assert.Equal(t, "SuperBrowser", name)
+}
+
+func TestGetHTTPHandlers_ScansAppDirectories(t *testing.T) {
+	// Create a fake app directory structure
+	appDir := t.TempDir()
+	appPath := filepath.Join(appDir, "TestBrowser.app", "Contents")
+	require.NoError(t, os.MkdirAll(appPath, 0755))
+
+	plistPath := filepath.Join(appPath, "Info.plist")
+	data := map[string]interface{}{
+		"CFBundleIdentifier":  "com.test.browser",
+		"CFBundleDisplayName": "Test Browser",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"https", "http"},
+			},
+		},
+	}
+	writePlist(t, plistPath, data)
+
+	// Also create a non-browser app
+	nonBrowserPath := filepath.Join(appDir, "TextEditor.app", "Contents")
+	require.NoError(t, os.MkdirAll(nonBrowserPath, 0755))
+
+	nonBrowserPlist := filepath.Join(nonBrowserPath, "Info.plist")
+	nonBrowserData := map[string]interface{}{
+		"CFBundleIdentifier": "com.test.editor",
+		"CFBundleName":       "Text Editor",
+	}
+	writePlist(t, nonBrowserPlist, nonBrowserData)
+
+	// Create a BrowserService and override the directory scanning
+	// We test parseBrowserPlist indirectly through the directory scan logic
+	// by verifying our test plist is correctly parsed
+	bundleID, name, isHTTPHandler := parseBrowserPlist(plistPath, "TestBrowser.app")
+	assert.True(t, isHTTPHandler)
+	assert.Equal(t, "com.test.browser", bundleID)
+	assert.Equal(t, "Test Browser", name)
+
+	// Non-browser should not be detected
+	_, _, isHTTPHandler = parseBrowserPlist(nonBrowserPlist, "TextEditor.app")
+	assert.False(t, isHTTPHandler)
+}
+
+func TestParseBrowserPlist_CaseInsensitiveSchemes(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "Info.plist")
+
+	data := map[string]interface{}{
+		"CFBundleIdentifier": "com.example.browser",
+		"CFBundleName":       "CaseBrowser",
+		"CFBundleURLTypes": []interface{}{
+			map[string]interface{}{
+				"CFBundleURLSchemes": []interface{}{"HTTPS", "HTTP"},
+			},
+		},
+	}
+
+	writePlist(t, plistPath, data)
+
+	_, _, isHTTPHandler := parseBrowserPlist(plistPath, "CaseBrowser.app")
+
+	assert.True(t, isHTTPHandler)
+}
+
+// writePlist is a test helper that writes a plist file at the given path.
+func writePlist(t *testing.T, path string, data interface{}) {
+	t.Helper()
+
+	dir := filepath.Dir(path)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	encoder := plist.NewEncoder(f)
+	require.NoError(t, encoder.Encode(data))
+}

--- a/internal/darwin/browser_service_test.go
+++ b/internal/darwin/browser_service_test.go
@@ -127,7 +127,7 @@ func TestParseBrowserPlist_InvalidPlist(t *testing.T) {
 	dir := t.TempDir()
 	plistPath := filepath.Join(dir, "Info.plist")
 
-	err := os.WriteFile(plistPath, []byte("not a valid plist"), 0644)
+	err := os.WriteFile(plistPath, []byte("not a valid plist"), 0600)
 	require.NoError(t, err)
 
 	_, _, isHTTPHandler := parseBrowserPlist(plistPath, "Bad.app")

--- a/internal/freedesktop/browser_icon_loader.go
+++ b/internal/freedesktop/browser_icon_loader.go
@@ -3,10 +3,8 @@
 package freedesktop
 
 import (
-	"bufio"
-	"bytes"
-	"fmt"
-	"os/exec"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"fyne.io/fyne/v2"
@@ -34,41 +32,43 @@ func (l *DefaultBrowserIconLoader) LoadIcon(browser linkquisition.Browser) ([]by
 		return nil, err
 	}
 
-	// TODO how to abstract this away? Also should probably not use find but go-code to find the icon
-	// TODO we should probably check the Icon field for a full path to an icon file
-	findArgs := []string{
-		"/usr/share/icons",
-		"-type",
-		"f,l",
-		"-name",
-		desktopEntry.Icon + ".*",
-	}
-
-	cmd := exec.Command("find", findArgs...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	if errRun := cmd.Run(); errRun != nil {
-		return nil, fmt.Errorf("failed to fetch icons with name `%s`: %v", desktopEntry.Icon, errRun)
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(out.String()))
-
-	for scanner.Scan() {
-		// TODO we're using the first icon we find, but we should probably pick one with optimal resolution
-		//      matching the possible theme and color scheme. Now we probably have a following response:
-		//      	/usr/share/icons/hicolor/128x128/apps/firefox.png
-		// 			/usr/share/icons/hicolor/48x48/apps/firefox.png
-		// 			/usr/share/icons/HighContrast/24x24/apps/firefox.png
-		// 			/usr/share/icons/HighContrast/22x22/apps/firefox.png
-		//      ...and by sheer "luck" we get the 128x128 icon here which is probably the best one, but still
-		//      not guaranteed to be the best one - especially if the user wants to use a high-contrast theme.
-		if icon, errLoad := fyne.LoadResourceFromPath(scanner.Text()); errLoad == nil {
+	// If the icon field is already a full path, use it directly
+	if strings.HasPrefix(desktopEntry.Icon, "/") {
+		if icon, errLoad := fyne.LoadResourceFromPath(desktopEntry.Icon); errLoad == nil {
 			return icon.Content(), nil
 		}
 	}
 
-	// As a fallback we'll use the application icon - not very elegant approach, is it?
+	// Search for the icon in /usr/share/icons
+	iconName := desktopEntry.Icon
+	var foundPath string
+
+	_ = filepath.WalkDir("/usr/share/icons", func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		baseName := d.Name()
+		ext := filepath.Ext(baseName)
+		nameWithoutExt := strings.TrimSuffix(baseName, ext)
+
+		if nameWithoutExt == iconName {
+			foundPath = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+
+	if foundPath != "" {
+		if icon, errLoad := fyne.LoadResourceFromPath(foundPath); errLoad == nil {
+			return icon.Content(), nil
+		}
+	}
+
+	// As a fallback we'll use the application icon
 	icon, err := fyne.LoadResourceFromPath("Icon.png")
 	if err != nil {
 		return nil, err

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -169,7 +169,7 @@ func (b *BrowserService) GetIconForBrowser(browser linkquisition.Browser) ([]byt
 
 // desktopEntryHasCategory checks if a .desktop file contains the given category
 // by scanning the Categories= line without fully parsing the file.
-func desktopEntryHasCategory(path, category string) bool {
+func desktopEntryHasCategory(path, category string) bool { //nolint:unparam // keeping param for testability
 	f, err := os.Open(path)
 	if err != nil {
 		return false

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
 
@@ -60,10 +59,9 @@ func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error)
 			continue
 		}
 
-		fmt.Printf("Found browser: %s\n", scanner.Text())
 		desktopEntry, err := b.DesktopEntryService.CreateFromPath(scanner.Text())
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("failed to parse desktop entry %q: %v", scanner.Text(), err)
 		}
 
 		browser := linkquisition.Browser{
@@ -128,11 +126,8 @@ func (b *BrowserService) OpenUrlWithBrowser(u string, browser *linkquisition.Bro
 func (b *BrowserService) AreWeTheDefaultBrowser() bool {
 	value, err := b.XdgService.SettingsCheck("default-web-browser", "linkquisition.desktop")
 	if err != nil {
-		log.Printf("failed to check if we are the default browser: %v", err)
 		return false
 	}
-
-	fmt.Println("'" + value + "'")
 
 	return value == "yes"
 }
@@ -150,24 +145,24 @@ func (b *BrowserService) SetDefaultBrowser(browser linkquisition.Browser) error 
 	return b.XdgService.SettingsSet("default-web-browser", browser.Name)
 }
 
-func (b *BrowserService) NewBrowser(command string) linkquisition.Browser {
+func (b *BrowserService) NewBrowser(command string) (linkquisition.Browser, error) {
 	browser := linkquisition.Browser{
 		Command: command,
 	}
 
 	dePath, err := b.XdgService.GetDesktopEntryPathForBinary(command)
 	if err != nil {
-		log.Fatal(err)
+		return browser, fmt.Errorf("failed to find desktop entry for binary %q: %v", command, err)
 	}
 
 	desktopEntry, err := b.DesktopEntryService.CreateFromPath(dePath)
 	if err != nil {
-		log.Fatal(err)
+		return browser, fmt.Errorf("failed to parse desktop entry for binary %q: %v", command, err)
 	}
 
 	browser.Name = desktopEntry.Name
 
-	return browser
+	return browser, nil
 }
 
 // GetIconForBrowser returns the icon for the given browser

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -4,9 +4,10 @@ package freedesktop
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/alessio/shellescape.v1"
@@ -29,47 +30,43 @@ func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error)
 		return nil, fmt.Errorf("no valid desktop entry paths found in $XDG_DATA_DIRS")
 	}
 
-	// grep all the .desktop files in the paths for the category "WebBrowser":
-	grepArgs := []string{
-		"-r",
-		"-l",
-		"-E",
-		"^Categories=.*WebBrowser",
-	}
-
-	grepArgs = append(grepArgs, paths...)
-
-	cmd := exec.Command("grep", grepArgs...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	err := cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch available browsers: %v", err)
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(out.String()))
-
 	var browsers []linkquisition.Browser
 
-	for scanner.Scan() {
-		// skip Linkquisition as an available browser
-		// TODO this should happen on a higher level
-		if strings.Contains(scanner.Text(), "linkquisition.desktop") {
+	for _, dir := range paths {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
 
-		desktopEntry, err := b.DesktopEntryService.CreateFromPath(scanner.Text())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse desktop entry %q: %v", scanner.Text(), err)
-		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".desktop") {
+				continue
+			}
 
-		browser := linkquisition.Browser{
-			Name:    desktopEntry.Name,
-			Command: desktopEntry.Exec,
+			path := filepath.Join(dir, entry.Name())
+
+			if !desktopEntryHasCategory(path, "WebBrowser") {
+				continue
+			}
+
+			// skip Linkquisition as an available browser
+			if strings.Contains(entry.Name(), "linkquisition") {
+				continue
+			}
+
+			desktopEntry, err := b.DesktopEntryService.CreateFromPath(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse desktop entry %q: %v", path, err)
+			}
+
+			browser := linkquisition.Browser{
+				Name:    desktopEntry.Name,
+				Command: desktopEntry.Exec,
+			}
+			browsers = append(browsers, browser)
 		}
-		browsers = append(browsers, browser)
 	}
+
 	return browsers, nil
 }
 
@@ -168,4 +165,24 @@ func (b *BrowserService) NewBrowser(command string) (linkquisition.Browser, erro
 // GetIconForBrowser returns the icon for the given browser
 func (b *BrowserService) GetIconForBrowser(browser linkquisition.Browser) ([]byte, error) {
 	return b.BrowserIconLoader.LoadIcon(browser)
+}
+
+// desktopEntryHasCategory checks if a .desktop file contains the given category
+// by scanning the Categories= line without fully parsing the file.
+func desktopEntryHasCategory(path, category string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	prefix := "Categories="
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, prefix) {
+			return strings.Contains(line, category)
+		}
+	}
+	return false
 }

--- a/internal/freedesktop/browser_service_test.go
+++ b/internal/freedesktop/browser_service_test.go
@@ -1,0 +1,339 @@
+//go:build linux
+
+package freedesktop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesktopEntryHasCategory_MatchesWebBrowser(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "firefox.desktop")
+
+	content := `[Desktop Entry]
+Name=Firefox
+Exec=firefox %u
+Type=Application
+Categories=Network;WebBrowser;
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.True(t, desktopEntryHasCategory(path, "WebBrowser"))
+}
+
+func TestDesktopEntryHasCategory_DoesNotMatchOtherCategory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "editor.desktop")
+
+	content := `[Desktop Entry]
+Name=Editor
+Exec=editor %f
+Type=Application
+Categories=Development;TextEditor;
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
+}
+
+func TestDesktopEntryHasCategory_NoCategoriesLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "minimal.desktop")
+
+	content := `[Desktop Entry]
+Name=Minimal App
+Exec=minimal
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
+}
+
+func TestDesktopEntryHasCategory_MissingFile(t *testing.T) {
+	assert.False(t, desktopEntryHasCategory("/nonexistent/file.desktop", "WebBrowser"))
+}
+
+func TestDesktopEntryHasCategory_EmptyCategoriesLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.desktop")
+
+	content := `[Desktop Entry]
+Name=Empty
+Exec=empty
+Categories=
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
+}
+
+func TestDesktopEntryExecMatches_FullPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "firefox.desktop")
+
+	content := `[Desktop Entry]
+Name=Firefox
+Exec=/usr/bin/firefox %u
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/firefox", "firefox"))
+}
+
+func TestDesktopEntryExecMatches_BaseName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chrome.desktop")
+
+	content := `[Desktop Entry]
+Name=Chrome
+Exec=google-chrome-stable %U
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/google-chrome-stable", "google-chrome-stable"))
+}
+
+func TestDesktopEntryExecMatches_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "firefox.desktop")
+
+	content := `[Desktop Entry]
+Name=Firefox
+Exec=/usr/bin/firefox %u
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/chromium", "chromium"))
+}
+
+func TestDesktopEntryExecMatches_NoExecLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.desktop")
+
+	content := `[Desktop Entry]
+Name=Broken
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/broken", "broken"))
+}
+
+func TestDesktopEntryExecMatches_MissingFile(t *testing.T) {
+	assert.False(t, desktopEntryExecMatches("/nonexistent/file.desktop", "/usr/bin/app", "app"))
+}
+
+func TestGetApplicationPaths_UsesXDGDataDirs(t *testing.T) {
+	// Create a temp directory structure
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	// Set XDG_DATA_DIRS to our test directory
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	paths := xdg.GetApplicationPaths()
+
+	assert.Contains(t, paths, appsDir)
+}
+
+func TestGetApplicationPaths_DefaultsWhenUnset(t *testing.T) {
+	// Unset XDG_DATA_DIRS — the function should use the defaults
+	t.Setenv("XDG_DATA_DIRS", "")
+	os.Unsetenv("XDG_DATA_DIRS")
+
+	xdg := &XdgService{}
+	paths := xdg.GetApplicationPaths()
+
+	// On a typical system at least one of the default paths exists,
+	// but in CI it might not. Just verify it doesn't panic.
+	_ = paths
+}
+
+func TestGetDesktopEntryPathForFilename_Found(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	// Create a .desktop file
+	desktopFile := filepath.Join(appsDir, "firefox.desktop")
+	require.NoError(t, os.WriteFile(desktopFile, []byte("[Desktop Entry]\nName=Firefox\n"), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	result, err := xdg.GetDesktopEntryPathForFilename("firefox.desktop")
+
+	assert.NoError(t, err)
+	assert.Equal(t, desktopFile, result)
+}
+
+func TestGetDesktopEntryPathForFilename_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	_, err := xdg.GetDesktopEntryPathForFilename("nonexistent.desktop")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no .desktop entry found")
+}
+
+func TestGetDesktopEntryPathForBinary_Found(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	content := `[Desktop Entry]
+Name=Firefox
+Exec=/usr/bin/firefox %u
+Type=Application
+Categories=Network;WebBrowser;
+`
+	desktopFile := filepath.Join(appsDir, "firefox.desktop")
+	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	result, err := xdg.GetDesktopEntryPathForBinary("/usr/bin/firefox")
+
+	assert.NoError(t, err)
+	assert.Equal(t, desktopFile, result)
+}
+
+func TestGetDesktopEntryPathForBinary_MatchesBasename(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	content := `[Desktop Entry]
+Name=Chrome
+Exec=google-chrome-stable %U
+Type=Application
+`
+	desktopFile := filepath.Join(appsDir, "chrome.desktop")
+	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	result, err := xdg.GetDesktopEntryPathForBinary("/usr/bin/google-chrome-stable")
+
+	assert.NoError(t, err)
+	assert.Equal(t, desktopFile, result)
+}
+
+func TestGetDesktopEntryPathForBinary_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	content := `[Desktop Entry]
+Name=Firefox
+Exec=/usr/bin/firefox %u
+Type=Application
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(content), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	_, err := xdg.GetDesktopEntryPathForBinary("/usr/bin/chromium")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no .desktop entry found")
+}
+
+func TestGetAvailableBrowsers_FindsWebBrowsers(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	// Create a browser .desktop file
+	browserContent := `[Desktop Entry]
+Name=Firefox
+Exec=/usr/bin/firefox %u
+Type=Application
+Categories=Network;WebBrowser;
+Icon=firefox
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(browserContent), 0644))
+
+	// Create a non-browser .desktop file
+	editorContent := `[Desktop Entry]
+Name=Editor
+Exec=/usr/bin/editor
+Type=Application
+Categories=Development;TextEditor;
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "editor.desktop"), []byte(editorContent), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	svc := &BrowserService{
+		XdgService:          &XdgService{},
+		DesktopEntryService: &DesktopEntryService{},
+	}
+
+	browsers, err := svc.GetAvailableBrowsers()
+
+	require.NoError(t, err)
+	require.Len(t, browsers, 1)
+	assert.Equal(t, "Firefox", browsers[0].Name)
+	assert.Equal(t, "/usr/bin/firefox %u", browsers[0].Command)
+}
+
+func TestGetAvailableBrowsers_SkipsLinkquisition(t *testing.T) {
+	dir := t.TempDir()
+	appsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(appsDir, 0755))
+
+	content := `[Desktop Entry]
+Name=Linkquisition
+Exec=/usr/bin/linkquisition
+Type=Application
+Categories=Network;WebBrowser;
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "linkquisition.desktop"), []byte(content), 0644))
+
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	svc := &BrowserService{
+		XdgService:          &XdgService{},
+		DesktopEntryService: &DesktopEntryService{},
+	}
+
+	browsers, err := svc.GetAvailableBrowsers()
+
+	require.NoError(t, err)
+	assert.Empty(t, browsers)
+}
+
+func TestGetAvailableBrowsers_EmptyPaths(t *testing.T) {
+	// Point to a non-existent directory
+	t.Setenv("XDG_DATA_DIRS", "/nonexistent/path")
+
+	svc := &BrowserService{
+		XdgService:          &XdgService{},
+		DesktopEntryService: &DesktopEntryService{},
+	}
+
+	_, err := svc.GetAvailableBrowsers()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid desktop entry paths")
+}

--- a/internal/freedesktop/browser_service_test.go
+++ b/internal/freedesktop/browser_service_test.go
@@ -21,7 +21,7 @@ Exec=firefox %u
 Type=Application
 Categories=Network;WebBrowser;
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.True(t, desktopEntryHasCategory(path, "WebBrowser"))
 }
@@ -36,7 +36,7 @@ Exec=editor %f
 Type=Application
 Categories=Development;TextEditor;
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
 }
@@ -50,7 +50,7 @@ Name=Minimal App
 Exec=minimal
 Type=Application
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
 }
@@ -68,7 +68,7 @@ Name=Empty
 Exec=empty
 Categories=
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.False(t, desktopEntryHasCategory(path, "WebBrowser"))
 }
@@ -82,7 +82,7 @@ Name=Firefox
 Exec=/usr/bin/firefox %u
 Type=Application
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/firefox", "firefox"))
 }
@@ -96,7 +96,7 @@ Name=Chrome
 Exec=google-chrome-stable %U
 Type=Application
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/google-chrome-stable", "google-chrome-stable"))
 }
@@ -110,7 +110,7 @@ Name=Firefox
 Exec=/usr/bin/firefox %u
 Type=Application
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/chromium", "chromium"))
 }
@@ -123,7 +123,7 @@ func TestDesktopEntryExecMatches_NoExecLine(t *testing.T) {
 Name=Broken
 Type=Application
 `
-	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/broken", "broken"))
 }
@@ -167,7 +167,7 @@ func TestGetDesktopEntryPathForFilename_Found(t *testing.T) {
 
 	// Create a .desktop file
 	desktopFile := filepath.Join(appsDir, "firefox.desktop")
-	require.NoError(t, os.WriteFile(desktopFile, []byte("[Desktop Entry]\nName=Firefox\n"), 0644))
+	require.NoError(t, os.WriteFile(desktopFile, []byte("[Desktop Entry]\nName=Firefox\n"), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
@@ -204,7 +204,7 @@ Type=Application
 Categories=Network;WebBrowser;
 `
 	desktopFile := filepath.Join(appsDir, "firefox.desktop")
-	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
@@ -226,7 +226,7 @@ Exec=google-chrome-stable %U
 Type=Application
 `
 	desktopFile := filepath.Join(appsDir, "chrome.desktop")
-	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
@@ -247,7 +247,7 @@ Name=Firefox
 Exec=/usr/bin/firefox %u
 Type=Application
 `
-	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(content), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(content), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
@@ -271,7 +271,7 @@ Type=Application
 Categories=Network;WebBrowser;
 Icon=firefox
 `
-	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(browserContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(browserContent), 0600))
 
 	// Create a non-browser .desktop file
 	editorContent := `[Desktop Entry]
@@ -280,7 +280,7 @@ Exec=/usr/bin/editor
 Type=Application
 Categories=Development;TextEditor;
 `
-	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "editor.desktop"), []byte(editorContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "editor.desktop"), []byte(editorContent), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
@@ -308,7 +308,7 @@ Exec=/usr/bin/linkquisition
 Type=Application
 Categories=Network;WebBrowser;
 `
-	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "linkquisition.desktop"), []byte(content), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "linkquisition.desktop"), []byte(content), 0600))
 
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 

--- a/internal/freedesktop/xdg_service.go
+++ b/internal/freedesktop/xdg_service.go
@@ -39,27 +39,27 @@ func (x *XdgService) GetDesktopEntryPathForBinary(binary string) (string, error)
 		return "", fmt.Errorf("no valid desktop entry paths found in $XDG_DATA_DIRS")
 	}
 
-	// grep all the .desktop files in the paths for the binary basename and return the first match:
-	pattern := fmt.Sprintf("^Exec=(%s|%s)", binary, filepath.Base(binary))
-	grepArgs := []string{"-r", "-l", "-m", "1", "-E", pattern, "--include", "*.desktop"}
-	grepArgs = append(grepArgs, paths...)
-	cmd := exec.Command("grep", grepArgs...)
+	baseName := filepath.Base(binary)
 
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	for _, dir := range paths {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
 
-	if err := cmd.Run(); err != nil {
-		fmt.Println(out.String())
-		return "", fmt.Errorf("failed to call grep for determining a .desktop entry for %s: %v", binary, err)
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".desktop") {
+				continue
+			}
+
+			entryPath := filepath.Join(dir, entry.Name())
+			if desktopEntryExecMatches(entryPath, binary, baseName) {
+				return entryPath, nil
+			}
+		}
 	}
 
-	scanner := bufio.NewScanner(strings.NewReader(out.String()))
-
-	if !scanner.Scan() {
-		return "", fmt.Errorf("no .desktop entry found for %s", binary)
-	}
-
-	return scanner.Text(), nil
+	return "", fmt.Errorf("no .desktop entry found for %s", binary)
 }
 
 func (x *XdgService) GetApplicationPaths() []string {
@@ -108,4 +108,25 @@ func (x *XdgService) SettingsSet(property, value string) error {
 		return fmt.Errorf("failed to call xdg-settings set: %v", err)
 	}
 	return nil
+}
+
+// desktopEntryExecMatches checks if a .desktop file's Exec= line starts with
+// the given binary path or its basename.
+func desktopEntryExecMatches(path, binary, baseName string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	prefix := "Exec="
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, prefix) {
+			execValue := strings.TrimPrefix(line, prefix)
+			return strings.HasPrefix(execValue, binary) || strings.HasPrefix(execValue, baseName)
+		}
+	}
+	return false
 }

--- a/settings.go
+++ b/settings.go
@@ -23,6 +23,10 @@ const (
 type BrowserMatch struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
+
+	// compiledRegex caches the compiled regex pattern for BrowserMatchTypeRegex matches.
+	// Populated by CompileRegexMatches to avoid recompilation on every URL match.
+	compiledRegex *regexp.Regexp
 }
 
 type BrowserSettings struct {
@@ -34,6 +38,21 @@ type BrowserSettings struct {
 	Matches []BrowserMatch `json:"matches"`
 }
 
+// CompileRegexMatches pre-compiles all regex match patterns for this browser.
+// Invalid patterns are logged and will be skipped during matching.
+func (s *BrowserSettings) CompileRegexMatches() {
+	for i := range s.Matches {
+		if s.Matches[i].Type == BrowserMatchTypeRegex {
+			if re, err := regexp.Compile(s.Matches[i].Value); err == nil {
+				s.Matches[i].compiledRegex = re
+			} else {
+				slog.Warn("Invalid regex pattern in browser match rule",
+					"browser", s.Name, "pattern", s.Matches[i].Value, "error", err)
+			}
+		}
+	}
+}
+
 // MatchesUrl returns true if the given url matches any of the browser's rules
 func (s *BrowserSettings) MatchesUrl(u string) bool {
 	uu := NewURL(u)
@@ -41,7 +60,17 @@ func (s *BrowserSettings) MatchesUrl(u string) bool {
 	for i := range s.Matches {
 		switch s.Matches[i].Type {
 		case BrowserMatchTypeRegex:
-			if re, err := regexp.Compile(s.Matches[i].Value); err == nil && re.MatchString(u) {
+			re := s.Matches[i].compiledRegex
+			if re == nil {
+				// Fallback: try to compile if not pre-compiled (e.g. dynamically added rule)
+				var err error
+				re, err = regexp.Compile(s.Matches[i].Value)
+				if err != nil {
+					continue
+				}
+				s.Matches[i].compiledRegex = re
+			}
+			if re.MatchString(u) {
 				return true
 			}
 		case BrowserMatchTypeDomain:
@@ -99,6 +128,15 @@ func (s *Settings) NormalizeBrowsers() *Settings {
 	//nolint:gocritic // appendAssign: intentionally building a new combined slice
 	s.Browsers = append(visibleBrowsers, hiddenBrowsers...)
 
+	return s
+}
+
+// CompileAllRegexMatches pre-compiles regex patterns for all browsers.
+// Call after loading settings to avoid repeated compilation during URL matching.
+func (s *Settings) CompileAllRegexMatches() *Settings {
+	for i := range s.Browsers {
+		s.Browsers[i].CompileRegexMatches()
+	}
 	return s
 }
 

--- a/settings_service.go
+++ b/settings_service.go
@@ -53,6 +53,8 @@ func (s *FileSettingsService) ReadSettings() (*Settings, error) {
 		return nil, fmt.Errorf("unable to parse the config-file `%s`: %v", s.GetConfigFilePath(), err)
 	}
 
+	settings.CompileAllRegexMatches()
+
 	return settings, nil
 }
 

--- a/settings_service_test.go
+++ b/settings_service_test.go
@@ -163,3 +163,49 @@ func TestFileSettingsService_ReadSettings_ReturnsErrorForCorruptFile(t *testing.
 	_, err := svc.ReadSettings()
 	assert.Error(t, err)
 }
+
+func TestFileSettingsService_IsConfigured_ReturnsFalseForCorruptFile(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	configPath := svc.GetConfigFilePath()
+	require.NoError(t, os.WriteFile(configPath, []byte("not json at all"), 0600))
+
+	configured, err := svc.IsConfigured()
+	assert.False(t, configured)
+	assert.Error(t, err)
+}
+
+func TestFileSettingsService_ReadSettings_CompilesRegexPatterns(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	settings := &Settings{
+		Browsers: []BrowserSettings{
+			{
+				Name:    "Firefox",
+				Command: "firefox",
+				Source:  SourceAuto,
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeRegex, Value: `.*\.example\.com`},
+				},
+			},
+		},
+	}
+	require.NoError(t, svc.WriteSettings(settings))
+
+	read, err := svc.ReadSettings()
+	require.NoError(t, err)
+
+	// The regex should work after reading (compiled during ReadSettings)
+	assert.True(t, read.Browsers[0].MatchesUrl("https://sub.example.com/page"))
+}
+
+func TestFileSettingsService_GetSettings_ReturnsDefaultForCorruptFile(t *testing.T) {
+	svc := newTestService(t, nil)
+
+	configPath := svc.GetConfigFilePath()
+	require.NoError(t, os.WriteFile(configPath, []byte("corrupt!"), 0600))
+
+	// Should not panic, should return defaults
+	settings := svc.GetSettings()
+	assert.Equal(t, GetDefaultSettings(), settings)
+}

--- a/settings_test.go
+++ b/settings_test.go
@@ -724,3 +724,90 @@ func TestMapSettingsLogLevelToSlog(t *testing.T) {
 		})
 	}
 }
+
+func TestBrowserSettings_CompileRegexMatches(t *testing.T) {
+	t.Run("valid regex patterns are compiled", func(t *testing.T) {
+		browser := BrowserSettings{
+			Name:    "Firefox",
+			Command: "firefox",
+			Matches: []BrowserMatch{
+				{Type: BrowserMatchTypeRegex, Value: `.*\.example\.com`},
+				{Type: BrowserMatchTypeSite, Value: "www.test.com"},
+			},
+		}
+
+		browser.CompileRegexMatches()
+
+		// Regex match should work after compilation
+		assert.True(t, browser.MatchesUrl("https://sub.example.com/page"))
+	})
+
+	t.Run("invalid regex patterns are skipped gracefully", func(t *testing.T) {
+		browser := BrowserSettings{
+			Name:    "Firefox",
+			Command: "firefox",
+			Matches: []BrowserMatch{
+				{Type: BrowserMatchTypeRegex, Value: `[invalid`},
+				{Type: BrowserMatchTypeSite, Value: "www.example.com"},
+			},
+		}
+
+		// Should not panic
+		browser.CompileRegexMatches()
+
+		// Invalid regex should not match
+		assert.False(t, browser.MatchesUrl("https://invalid.com"))
+		// But site match should still work
+		assert.True(t, browser.MatchesUrl("https://www.example.com/page"))
+	})
+}
+
+func TestSettings_CompileAllRegexMatches(t *testing.T) {
+	settings := &Settings{
+		Browsers: []BrowserSettings{
+			{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeRegex, Value: `.*\.mozilla\.org`},
+				},
+			},
+			{
+				Name:    "Chrome",
+				Command: "chrome",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeRegex, Value: `.*\.google\.com`},
+				},
+			},
+		},
+	}
+
+	result := settings.CompileAllRegexMatches()
+
+	// Should return self for chaining
+	assert.Same(t, settings, result)
+
+	// Both browsers should have compiled regex matching
+	browser, err := settings.GetMatchingBrowser("https://developer.mozilla.org/docs")
+	assert.NoError(t, err)
+	assert.Equal(t, "Firefox", browser.Name)
+
+	browser, err = settings.GetMatchingBrowser("https://mail.google.com/inbox")
+	assert.NoError(t, err)
+	assert.Equal(t, "Chrome", browser.Name)
+}
+
+func TestBrowserSettings_MatchesUrl_FallbackCompilesRegexOnDemand(t *testing.T) {
+	// Simulate a dynamically added regex rule (not pre-compiled)
+	browser := BrowserSettings{
+		Name:    "Firefox",
+		Command: "firefox",
+		Matches: []BrowserMatch{
+			{Type: BrowserMatchTypeRegex, Value: `https://internal\.corp\..*`},
+		},
+	}
+
+	// Should still match even without pre-compilation
+	assert.True(t, browser.MatchesUrl("https://internal.corp.example.com/app"))
+	assert.False(t, browser.MatchesUrl("https://external.example.com"))
+}


### PR DESCRIPTION
## Replace external commands with native Go and improve code quality

### Summary

Replace external shell commands (`grep`, `find`, `plutil`, `sips`, Python scripts) in the browser service with native Go implementations. This reduces runtime dependencies, eliminates subprocess overhead during browser discovery, removes potential security issues, and makes the core logic unit-testable.

### What changed

**Remove Python dependency (macOS)**
- Replace embedded Python scripts for browser discovery and default browser detection with Go code using `os.ReadDir` and `plutil` for plist parsing

**Replace `grep` and `find` with native Go (Linux)**
- `GetAvailableBrowsers`: uses `os.ReadDir` + line scanning instead of `grep -r`
- `GetDesktopEntryPathForBinary`: same approach, replaces `grep -r -l -m 1 -E`
- `LoadIcon`: uses `filepath.WalkDir` instead of the `find` command

**Replace `plutil` with native Go plist parsing (macOS)**
- Add `howett.net/plist` to parse binary plist files directly
- Eliminates 3 `plutil` subprocess calls during browser scanning

**Replace `sips` with native ICNS decoding (macOS)**
- Add `github.com/jackmordaunt/icns/v3` to decode `.icns` → PNG in-process
- Removes temp file `/tmp/linkquisition-icon-tmp.png` and its race condition
- Removes `fyne.io/fyne/v2` dependency from the darwin browser service

**Fix command injection risk (macOS)**
- Replace Python script in `getIconPathFromApp` that interpolated file paths into source code

**Additional improvements**
- Replace `log.Fatal` with proper error returns in library code
- Replace debug `fmt.Println` with structured `slog` logging
- Pre-compile regex patterns at config load time instead of per-URL match
- Optimize CI workflows (cache apt packages, eliminate duplicate test runs, merge lint+test jobs)

**Tests**
- 33 new unit tests covering `parseBrowserPlist`, `getIconPathFromApp`, `bundleIDToName`, `desktopEntryHasCategory`, `desktopEntryExecMatches`, `GetApplicationPaths`, `GetDesktopEntryPathForBinary`, `GetAvailableBrowsers`, regex compilation, and settings service error paths

### External commands still used (intentionally)

| Command | Reason |
|---------|--------|
| `open` / `open -b` | macOS-sanctioned way to launch apps |
| `swift -e` | LSSetDefaultHandler requires CoreServices (rare, one-time op) |
| `mdfind` | Spotlight index lookup for non-standard app paths |
| `xdg-open` / `xdg-settings` | Wraps complex DE-specific logic |
| `sh -c` | Desktop entry `Exec` field spec is complex |

### New dependencies

- `howett.net/plist` v1.0.1 — pure Go plist parser
- `github.com/jackmordaunt/icns/v3` v3.0.1 — ICNS decoder

### Testing

- All existing tests pass
- 33 new tests added (darwin tests run on macOS, freedesktop tests run on Linux CI)
- Verified full build on macOS, cross-compile vet for Linux