### PR TITLE
Settings UI improvements and platform-native shortcuts

### DIFF
--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"runtime"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -134,10 +135,17 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	)
 
 	if !picker.settingsService.GetSettings().Ui.HideKeyboardGuideLabel {
+		copyShortcut := "Ctrl+C"
+		if runtime.GOOS == "darwin" {
+			copyShortcut = "⌘+C"
+		}
+
 		widgets = append(
 			widgets,
 			layout.NewSpacer(),
-			widget.NewLabel(i18n.T("picker.keyboard_guide")),
+			widget.NewLabel(i18n.T("picker.keyboard_guide", map[string]interface{}{
+				"CopyShortcut": copyShortcut,
+			})),
 		)
 	}
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -205,21 +205,56 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 }
 
 func (c *Configurator) getAboutTab() fyne.CanvasObject {
+	openURL := func() {
+		if err := c.openExternalURL("https://github.com/Strobotti/linkquisition"); err != nil {
+			c.logger.Error("Error opening URL", "error", err)
+		}
+	}
+
 	icon := widget.NewButtonWithIcon(
 		"",
 		resources.LinkquisitionIcon,
-		func() {
-			if err := c.browserService.OpenUrlWithDefaultBrowser("https://github.com/Strobotti/linkquisition"); err != nil {
-				c.logger.Error("Error opening URL", "error", err)
-			}
-		},
+		openURL,
 	)
 
-	return container.NewBorder(
-		container.NewBorder(nil, nil, icon, nil, widget.NewLabel(fmt.Sprintf("Linkquisition %s", version))),
-		nil,
-		nil,
-		nil,
+	title := widget.NewLabel(fmt.Sprintf("Linkquisition %s", version))
+	title.TextStyle = fyne.TextStyle{Bold: true}
+
+	description := widget.NewLabel(i18n.T("about.description"))
+	description.Wrapping = fyne.TextWrapWord
+
+	githubLink := widget.NewButton("github.com/Strobotti/linkquisition", openURL)
+	githubLink.Importance = widget.LowImportance
+
+	details := container.NewVBox(
+		container.NewHBox(widget.NewLabel(i18n.T("about.author_label")), widget.NewLabel("Juha Jantunen")),
+		container.NewHBox(widget.NewLabel(i18n.T("about.license_label")), widget.NewLabel("MIT")),
+		container.NewHBox(widget.NewLabel(i18n.T("about.github_label")), githubLink),
+	)
+
+	return container.NewVBox(
+		container.NewHBox(icon, title),
+		layout.NewSpacer(),
+		description,
+		layout.NewSpacer(),
+		details,
 		layout.NewSpacer(),
 	)
+}
+
+// openExternalURL opens a URL in a real browser, bypassing Linkquisition if it is
+// the default browser (which would otherwise cause a circular loop).
+func (c *Configurator) openExternalURL(rawURL string) error {
+	if !c.browserService.AreWeTheDefaultBrowser() {
+		return c.browserService.OpenUrlWithDefaultBrowser(rawURL)
+	}
+
+	// We are the default browser, so we need to pick a real browser to open with
+	browsers, err := c.browserService.GetAvailableBrowsers()
+	if err != nil || len(browsers) == 0 {
+		// Last resort: try anyway
+		return c.browserService.OpenUrlWithDefaultBrowser(rawURL)
+	}
+
+	return c.browserService.OpenUrlWithBrowser(rawURL, &browsers[0])
 }

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -40,6 +40,7 @@ func (c *Configurator) Run() error {
 
 	tabs := container.NewAppTabs(
 		container.NewTabItem(i18n.T("config.tab_general"), c.getGeneralTab()),
+		container.NewTabItem(i18n.T("config.tab_rules"), c.getRulesTab()),
 		container.NewTabItem(i18n.T("config.tab_about"), c.getAboutTab()),
 	)
 	tabs.SetTabLocation(container.TabLocationTop)
@@ -202,6 +203,24 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 	hideGuideCheck.Checked = settings.Ui.HideKeyboardGuideLabel
 
 	return container.NewVBox(hideGuideCheck)
+}
+
+func (c *Configurator) getRulesTab() fyne.CanvasObject {
+	description := widget.NewLabel(i18n.T("config.rules_description"))
+	description.Wrapping = fyne.TextWrapWord
+
+	editButton := widget.NewButton(i18n.T("config.rules_edit_button"), func() {
+		configPath := c.settingsService.GetConfigFilePath()
+		if err := openFileInEditor(configPath); err != nil {
+			c.logger.Error("Error opening config file in editor", "error", err)
+		}
+	})
+
+	return container.NewVBox(
+		description,
+		layout.NewSpacer(),
+		editButton,
+	)
 }
 
 func (c *Configurator) getAboutTab() fyne.CanvasObject {

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -62,6 +62,8 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		c.buildScanBrowsersSection(),
 		layout.NewSpacer(),
 		c.buildLanguageSection(),
+		layout.NewSpacer(),
+		c.buildUiSection(),
 	)
 }
 
@@ -185,6 +187,21 @@ func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.language_label")), nil, languageSelect),
 		restartNote,
 	)
+}
+
+func (c *Configurator) buildUiSection() fyne.CanvasObject {
+	settings := c.settingsService.GetSettings()
+
+	hideGuideCheck := widget.NewCheck(i18n.T("config.hide_keyboard_guide"), func(checked bool) {
+		s := c.settingsService.GetSettings()
+		s.Ui.HideKeyboardGuideLabel = checked
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving UI setting", "error", err)
+		}
+	})
+	hideGuideCheck.Checked = settings.Ui.HideKeyboardGuideLabel
+
+	return container.NewVBox(hideGuideCheck)
 }
 
 func (c *Configurator) getAboutTab() fyne.CanvasObject {

--- a/cmd/editor_darwin.go
+++ b/cmd/editor_darwin.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 func openFileInEditor(path string) error {
-	return exec.Command("open", "-t", path).Start()
+	return exec.CommandContext(context.Background(), "open", "-t", path).Start()
 }

--- a/cmd/editor_darwin.go
+++ b/cmd/editor_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "os/exec"
+
+func openFileInEditor(path string) error {
+	return exec.Command("open", "-t", path).Start()
+}

--- a/cmd/editor_linux.go
+++ b/cmd/editor_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package main
+
+import "os/exec"
+
+func openFileInEditor(path string) error {
+	return exec.Command("xdg-open", path).Start()
+}

--- a/cmd/editor_linux.go
+++ b/cmd/editor_linux.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "os/exec"
+import (
+	"context"
+	"os/exec"
+)
 
 func openFileInEditor(path string) error {
-	return exec.Command("xdg-open", path).Start()
+	return exec.CommandContext(context.Background(), "xdg-open", path).Start()
 }

--- a/doc/linkquisition.1.scd
+++ b/doc/linkquisition.1.scd
@@ -31,6 +31,9 @@ When launched without arguments, Linkquisition opens the configuration screen.
 *Ctrl+C*
 	Copy the URL to clipboard and close.
 
+*Escape*
+	Close the picker without opening a browser.
+
 *1-9*
 	Select a browser by its position in the list.
 

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -18,6 +18,11 @@ The file is JSON and is managed either manually or via the configuration screen
 
 # TOP-LEVEL KEYS
 
+*locale* (string, optional)
+	Override the UI language (e.g. _"fi"_, _"es"_, _"sv"_). If empty or omitted,
+	the system locale is auto-detected. Falls back to English when no matching
+	translation is available.
+
 *logLevel* (string, optional)
 	Log verbosity. One of: _debug_, _info_, _warn_, _error_. Default: _info_.
 

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -8,6 +8,15 @@
   "config.tab_about": {
     "other": "About"
   },
+  "config.tab_rules": {
+    "other": "Rules"
+  },
+  "config.rules_description": {
+    "other": "Match rules determine which browser opens a given URL automatically.\n\nRules can match by site (e.g. www.example.com), domain (e.g. example.com), or regular expression.\n\nFor now, rules are managed by editing the configuration file directly. A visual editor will be added in a future version."
+  },
+  "config.rules_edit_button": {
+    "other": "Open config file in editor"
+  },
   "config.make_default_label": {
     "other": "In order to Linkquisition to function as a browser-picker\nit has to be set as the default browser:"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -48,7 +48,7 @@
     "other": "Remember this choice with {{.Site}}"
   },
   "picker.keyboard_guide": {
-    "other": "Press 'ENTER' to pick first, 'ESC' to quit, 'ctrl+c' to copy URL to clipboard"
+    "other": "Press 'ENTER' to pick first, 'ESC' to quit, '{{.CopyShortcut}}' to copy URL to clipboard"
   },
   "config.language_label": {
     "other": "Language:"

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -70,5 +70,17 @@
   },
   "config.hide_keyboard_guide": {
     "other": "Hide keyboard shortcut guide in picker"
+  },
+  "about.description": {
+    "other": "A fast, configurable browser-picker for Linux and macOS."
+  },
+  "about.author_label": {
+    "other": "Author:"
+  },
+  "about.license_label": {
+    "other": "License:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -67,5 +67,8 @@
   },
   "config.scan_failed": {
     "other": "✗ Scan failed"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Hide keyboard shortcut guide in picker"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -67,5 +67,8 @@
   },
   "config.scan_failed": {
     "other": "✗ La búsqueda falló"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Ocultar guía de atajos de teclado en el selector"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -70,5 +70,17 @@
   },
   "config.hide_keyboard_guide": {
     "other": "Ocultar guía de atajos de teclado en el selector"
+  },
+  "about.description": {
+    "other": "Un selector de navegador rápido y configurable para Linux y macOS."
+  },
+  "about.author_label": {
+    "other": "Autor:"
+  },
+  "about.license_label": {
+    "other": "Licencia:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -48,7 +48,7 @@
     "other": "Recordar esta elección para {{.Site}}"
   },
   "picker.keyboard_guide": {
-    "other": "Pulsa 'ENTER' para elegir el primero, 'ESC' para salir, 'ctrl+c' para copiar la URL al portapapeles"
+    "other": "Pulsa 'ENTER' para elegir el primero, 'ESC' para salir, '{{.CopyShortcut}}' para copiar la URL al portapapeles"
   },
   "config.language_label": {
     "other": "Idioma:"

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -8,6 +8,15 @@
   "config.tab_about": {
     "other": "Acerca de"
   },
+  "config.tab_rules": {
+    "other": "Reglas"
+  },
+  "config.rules_description": {
+    "other": "Las reglas determinan qué navegador abre una URL automáticamente.\n\nLas reglas pueden coincidir por sitio (ej. www.example.com), dominio (ej. example.com) o expresión regular.\n\nPor ahora, las reglas se gestionan editando el archivo de configuración directamente. Un editor visual se añadirá en una versión futura."
+  },
+  "config.rules_edit_button": {
+    "other": "Abrir archivo de configuración en editor"
+  },
   "config.make_default_label": {
     "other": "Para que Linkquisition funcione como selector de navegador,\ndebe establecerse como el navegador predeterminado:"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -8,6 +8,15 @@
   "config.tab_about": {
     "other": "Tietoja"
   },
+  "config.tab_rules": {
+    "other": "Säännöt"
+  },
+  "config.rules_description": {
+    "other": "Säännöt määrittävät mikä selain avaa tietyn URL-osoitteen automaattisesti.\n\nSäännöt voivat perustua sivustoon (esim. www.example.com), verkkotunnukseen (esim. example.com) tai säännölliseen lausekkeeseen.\n\nToistaiseksi sääntöjä hallitaan muokkaamalla asetustiedostoa suoraan. Visuaalinen muokkain lisätään tulevassa versiossa."
+  },
+  "config.rules_edit_button": {
+    "other": "Avaa asetustiedosto editorissa"
+  },
   "config.make_default_label": {
     "other": "Jotta Linkquisition toimisi selainvalitsimena,\nse täytyy asettaa oletusselaimeksi:"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -48,7 +48,7 @@
     "other": "Muista tämä valinta sivustolle {{.Site}}"
   },
   "picker.keyboard_guide": {
-    "other": "Paina 'ENTER' valitaksesi ensimmäisen, 'ESC' sulkeaksesi, 'ctrl+c' kopioidaksesi URL:n leikepöydälle"
+    "other": "Paina 'ENTER' valitaksesi ensimmäisen, 'ESC' sulkeaksesi, '{{.CopyShortcut}}' kopioidaksesi URL:n leikepöydälle"
   },
   "config.language_label": {
     "other": "Kieli:"

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -67,5 +67,8 @@
   },
   "config.scan_failed": {
     "other": "✗ Haku epäonnistui"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Piilota pikanäppäinohje valitsimessa"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -70,5 +70,17 @@
   },
   "config.hide_keyboard_guide": {
     "other": "Piilota pikanäppäinohje valitsimessa"
+  },
+  "about.description": {
+    "other": "Nopea ja muokattava selainvalitsin Linuxille ja macOS:lle."
+  },
+  "about.author_label": {
+    "other": "Tekijä:"
+  },
+  "about.license_label": {
+    "other": "Lisenssi:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -48,7 +48,7 @@
     "other": "Kom ihåg detta val för {{.Site}}"
   },
   "picker.keyboard_guide": {
-    "other": "Tryck 'ENTER' för att välja första, 'ESC' för att avsluta, 'ctrl+c' för att kopiera URL till urklipp"
+    "other": "Tryck 'ENTER' för att välja första, 'ESC' för att avsluta, '{{.CopyShortcut}}' för att kopiera URL till urklipp"
   },
   "config.language_label": {
     "other": "Språk:"

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -8,6 +8,15 @@
   "config.tab_about": {
     "other": "Om"
   },
+  "config.tab_rules": {
+    "other": "Regler"
+  },
+  "config.rules_description": {
+    "other": "Regler bestämmer vilken webbläsare som öppnar en URL automatiskt.\n\nRegler kan matcha efter webbplats (t.ex. www.example.com), domän (t.ex. example.com) eller reguljärt uttryck.\n\nFör tillfället hanteras regler genom att redigera konfigurationsfilen direkt. En visuell redigerare kommer i en framtida version."
+  },
+  "config.rules_edit_button": {
+    "other": "Öppna konfigurationsfil i redigerare"
+  },
   "config.make_default_label": {
     "other": "För att Linkquisition ska fungera som webbläsarväljare\nmåste den ställas in som standardwebbläsare:"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -70,5 +70,17 @@
   },
   "config.hide_keyboard_guide": {
     "other": "Dölj tangentbordsguide i väljaren"
+  },
+  "about.description": {
+    "other": "En snabb och konfigurerbar webbläsarväljare för Linux och macOS."
+  },
+  "about.author_label": {
+    "other": "Författare:"
+  },
+  "about.license_label": {
+    "other": "Licens:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -67,5 +67,8 @@
   },
   "config.scan_failed": {
     "other": "✗ Sökningen misslyckades"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Dölj tangentbordsguide i väljaren"
   }
 }

--- a/settings.go
+++ b/settings.go
@@ -260,6 +260,9 @@ type SettingsService interface {
 
 	// GetPluginFolderPath returns the absolute path to the plugin-folder
 	GetPluginFolderPath() string
+
+	// GetConfigFilePath returns the absolute path to the config-file
+	GetConfigFilePath() string
 }
 
 func GetDefaultSettings() *Settings {


### PR DESCRIPTION
Improves the settings UI and adds platform-aware behavior for macOS support.

**Changes:**

- Show platform-native copy shortcut in the picker's keyboard guide label (⌘+C on macOS, Ctrl+C on Linux)
- Add a "Rules" tab explaining match rules with a button to open config.json in the system text editor
- Add a toggle checkbox for hiding the keyboard guide label (previously only editable in JSON)
- Enrich the About tab with app description, author, license, and a clickable GitHub link
- Fix URL opening from the About tab when Linkquisition is the default browser (circular routing)
- Document the missing `locale` config key and `Escape` shortcut in manpages

**Notes:**

- The Rules tab is a placeholder for a future visual rule editor — for now it opens the config file externally
- All new UI strings are translated (en, fi, es, sv)
- `GetConfigFilePath()` added to the `SettingsService` interface