### PR TITLE
Improve unit test coverage for core logic and error paths

### DIFF
--- a/internal/darwin/browser_service_test.go
+++ b/internal/darwin/browser_service_test.go
@@ -5,6 +5,7 @@ package darwin
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -265,6 +266,40 @@ func TestGetHTTPHandlers_ScansAppDirectories(t *testing.T) {
 	// Non-browser should not be detected
 	_, _, isHTTPHandler = parseBrowserPlist(nonBrowserPlist, "TextEditor.app")
 	assert.False(t, isHTTPHandler)
+}
+
+func TestGetAvailableBrowsers_NoDuplicates(t *testing.T) {
+	svc := &BrowserService{}
+	browsers, err := svc.GetAvailableBrowsers()
+	require.NoError(t, err)
+
+	seen := make(map[string]bool)
+	for _, b := range browsers {
+		if seen[b.Command] {
+			t.Errorf("duplicate browser bundle ID found: %s (%s)", b.Command, b.Name)
+		}
+		seen[b.Command] = true
+	}
+}
+
+func TestGetAvailableBrowsers_ExcludesLinkquisition(t *testing.T) {
+	svc := &BrowserService{}
+	browsers, err := svc.GetAvailableBrowsers()
+	require.NoError(t, err)
+
+	for _, b := range browsers {
+		if strings.Contains(strings.ToLower(b.Command), "linkquisition") {
+			t.Errorf("linkquisition should be excluded from browser list but found: %s", b.Command)
+		}
+	}
+}
+
+func TestGetAvailableBrowsers_ReturnsNonEmptyList(t *testing.T) {
+	// On any macOS system, at least Safari should be available
+	svc := &BrowserService{}
+	browsers, err := svc.GetAvailableBrowsers()
+	require.NoError(t, err)
+	assert.NotEmpty(t, browsers, "expected at least one browser on macOS")
 }
 
 func TestParseBrowserPlist_CaseInsensitiveSchemes(t *testing.T) {

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -177,6 +177,30 @@ func TestTWithCount_FallbackOnMissingPluralForms(t *testing.T) {
 	}
 }
 
+func TestTWithCount_WithCustomTemplateData(t *testing.T) {
+	Init("en")
+
+	// TWithCount with explicit template data should use that data
+	// even though no plural forms are defined, the error path returns fallback
+	got := TWithCount("nonexistent.key", 5, map[string]interface{}{"Count": 5, "Extra": "data"})
+	want := "[nonexistent.key]"
+	if got != want {
+		t.Errorf("TWithCount with custom data = %q, want %q", got, want)
+	}
+}
+
+func TestTWithCount_ZeroCount(t *testing.T) {
+	Init("en")
+
+	// Zero count with a message that has an "other" form should still resolve
+	// go-i18n uses PluralCount to select the plural form; 0 maps to "other" in English
+	got := TWithCount("nonexistent.key", 0)
+	want := "[nonexistent.key]"
+	if got != want {
+		t.Errorf("TWithCount with 0 count for missing key = %q, want %q", got, want)
+	}
+}
+
 func TestT_NilTemplateData(t *testing.T) {
 	Init("en")
 

--- a/plugins/terminus/terminus_test.go
+++ b/plugins/terminus/terminus_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -12,6 +13,79 @@ import (
 	"github.com/strobotti/linkquisition/mock"
 	. "github.com/strobotti/linkquisition/plugins/terminus"
 )
+
+func TestTerminus_Setup_Defaults(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	testedPlugin.Setup(provider, map[string]interface{}{})
+
+	assert.Equal(t, 5, testedPlugin.MaxRedirects)
+	assert.Equal(t, 2000*time.Millisecond, testedPlugin.RequestTimeout)
+}
+
+func TestTerminus_Setup_CustomSettings(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	testedPlugin.Setup(provider, map[string]interface{}{
+		"maxRedirects":   10,
+		"requestTimeout": "5s",
+	})
+
+	assert.Equal(t, 10, testedPlugin.MaxRedirects)
+	assert.Equal(t, 5*time.Second, testedPlugin.RequestTimeout)
+}
+
+func TestTerminus_Setup_MalformedTimeout(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	testedPlugin.Setup(provider, map[string]interface{}{
+		"requestTimeout": "not-a-duration",
+	})
+
+	// Should fall back to default timeout when parsing fails
+	assert.Equal(t, 2000*time.Millisecond, testedPlugin.RequestTimeout)
+}
+
+func TestTerminus_Setup_InvalidConfigType(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	// Pass a config with wrong types — mapstructure.Decode will produce an error
+	testedPlugin.Setup(provider, map[string]interface{}{
+		"maxRedirects": "not-an-int",
+	})
+
+	// Should fall back to defaults when decoding fails
+	assert.Equal(t, 5, testedPlugin.MaxRedirects)
+	assert.Equal(t, 2000*time.Millisecond, testedPlugin.RequestTimeout)
+}
 
 func TestTerminus_ModifyUrl(t *testing.T) {
 	mockIoWriter := mock.Writer{

--- a/plugins/unwrap/unwrap_test.go
+++ b/plugins/unwrap/unwrap_test.go
@@ -12,6 +12,106 @@ import (
 	. "github.com/strobotti/linkquisition/plugins/unwrap"
 )
 
+func TestUnwrap_ModifyUrl_EdgeCases(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+
+	for _, tt := range []struct {
+		name        string
+		config      map[string]interface{}
+		inputUrl    string
+		expectedUrl string
+	}{
+		{
+			name: "empty match rule is skipped gracefully",
+			config: map[string]interface{}{
+				"requireBrowserMatchToUnwrap": false,
+				"rules": []map[string]interface{}{
+					{
+						"match":     "",
+						"parameter": "url",
+					},
+				},
+			},
+			inputUrl:    "https://www.example.com/?url=https%3A%2F%2Fgithub.com",
+			expectedUrl: "https://www.example.com/?url=https%3A%2F%2Fgithub.com",
+		},
+		{
+			name: "matching URL but missing query parameter returns original URL",
+			config: map[string]interface{}{
+				"requireBrowserMatchToUnwrap": false,
+				"rules": []map[string]interface{}{
+					{
+						"match":     "^https://safelinks\\.example\\.com",
+						"parameter": "url",
+					},
+				},
+			},
+			inputUrl:    "https://safelinks.example.com/page?other=value&something=else",
+			expectedUrl: "https://safelinks.example.com/page?other=value&something=else",
+		},
+		{
+			name: "no rules configured returns original URL",
+			config: map[string]interface{}{
+				"requireBrowserMatchToUnwrap": false,
+				"rules":                       []map[string]interface{}{},
+			},
+			inputUrl:    "https://www.example.com/something",
+			expectedUrl: "https://www.example.com/something",
+		},
+		{
+			name: "multiple rules, second one matches",
+			config: map[string]interface{}{
+				"requireBrowserMatchToUnwrap": false,
+				"rules": []map[string]interface{}{
+					{
+						"match":     "^https://first\\.example\\.com",
+						"parameter": "target",
+					},
+					{
+						"match":     "^https://second\\.example\\.com",
+						"parameter": "redirect",
+					},
+				},
+			},
+			inputUrl:    "https://second.example.com/link?redirect=https%3A%2F%2Ffinal.example.com",
+			expectedUrl: "https://final.example.com",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testedPlugin := Plugin
+			provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+			testedPlugin.Setup(provider, tt.config)
+
+			assert.Equal(t, tt.expectedUrl, testedPlugin.ModifyUrl(tt.inputUrl))
+		})
+	}
+}
+
+func TestUnwrap_Setup_InvalidConfig(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	// Pass config with wrong type for "rules" field — triggers mapstructure decode error
+	testedPlugin.Setup(provider, map[string]interface{}{
+		"rules": "not-a-list",
+	})
+
+	// Plugin should still work — just with no rules, returning URLs unchanged
+	result := testedPlugin.ModifyUrl("https://example.com/something")
+	assert.Equal(t, "https://example.com/something", result)
+}
+
 func TestUnwrap_ModifyUrl(t *testing.T) {
 	mockIoWriter := mock.Writer{
 		WriteFunc: func(p []byte) (n int, err error) {

--- a/settings_service_test.go
+++ b/settings_service_test.go
@@ -1,7 +1,9 @@
 package linkquisition_test
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -208,4 +210,74 @@ func TestFileSettingsService_GetSettings_ReturnsDefaultForCorruptFile(t *testing
 	// Should not panic, should return defaults
 	settings := svc.GetSettings()
 	assert.Equal(t, GetDefaultSettings(), settings)
+}
+
+func TestFileSettingsService_ScanBrowsers_ReturnsErrorWhenGetAvailableBrowsersFails(t *testing.T) {
+	svc := &FileSettingsService{
+		BrowserService: &mockBrowserService{browsers: nil, err: fmt.Errorf("no browsers found")},
+		PathProvider:   &testPathProvider{dir: t.TempDir()},
+	}
+
+	err := svc.ScanBrowsers()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to scan browsers")
+}
+
+func TestFileSettingsService_ScanBrowsers_ReturnsErrorWhenWriteFails(t *testing.T) {
+	// Use a path that cannot be written to (non-existent nested directory with read-only parent)
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(readOnlyDir, 0555))
+
+	svc := &FileSettingsService{
+		BrowserService: &mockBrowserService{
+			browsers: []Browser{{Name: "Firefox", Command: "firefox"}},
+		},
+		PathProvider: &testPathProvider{dir: filepath.Join(readOnlyDir, "subdir")},
+	}
+
+	err := svc.ScanBrowsers()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to scan browsers")
+}
+
+func TestFileSettingsService_ScanBrowsers_MergesWithExistingConfigOnRescan(t *testing.T) {
+	browsers := []Browser{
+		{Name: "Firefox", Command: "firefox"},
+		{Name: "Chrome", Command: "chrome"},
+	}
+	svc := newTestService(t, browsers)
+
+	// First scan creates config
+	require.NoError(t, svc.ScanBrowsers())
+
+	// Simulate a browser being uninstalled by changing the mock
+	svc.BrowserService = &mockBrowserService{
+		browsers: []Browser{{Name: "Firefox", Command: "firefox"}},
+	}
+
+	// Re-scan should drop Chrome (auto-added, no longer present)
+	require.NoError(t, svc.ScanBrowsers())
+
+	settings, err := svc.ReadSettings()
+	require.NoError(t, err)
+	assert.Len(t, settings.Browsers, 1)
+	assert.Equal(t, "Firefox", settings.Browsers[0].Name)
+}
+
+func TestFileSettingsService_WriteSettings_ReturnsErrorForUnwritablePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(readOnlyDir, 0555))
+
+	svc := &FileSettingsService{
+		BrowserService: &mockBrowserService{},
+		PathProvider:   &testPathProvider{dir: filepath.Join(readOnlyDir, "nested", "deep")},
+	}
+
+	err := svc.WriteSettings(GetDefaultSettings())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write settings")
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -177,6 +177,80 @@ func TestBrowserSettings_MatchesUrl(t *testing.T) {
 	}
 }
 
+func TestBrowserSettings_MatchesUrl_CaseInsensitive(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		settings BrowserSettings
+		url      string
+		expected bool
+	}{
+		{
+			name: "site match is case-insensitive (rule uppercase, URL lowercase)",
+			settings: BrowserSettings{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeSite, Value: "WWW.EXAMPLE.COM"},
+				},
+			},
+			url:      "https://www.example.com/page",
+			expected: true,
+		},
+		{
+			name: "site match is case-insensitive (rule mixed case, URL lowercase)",
+			settings: BrowserSettings{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeSite, Value: "Www.Example.Com"},
+				},
+			},
+			url:      "https://www.example.com/page",
+			expected: true,
+		},
+		{
+			name: "domain match is case-insensitive (rule uppercase)",
+			settings: BrowserSettings{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeDomain, Value: "EXAMPLE.COM"},
+				},
+			},
+			url:      "https://www.example.com/page",
+			expected: true,
+		},
+		{
+			name: "domain match is case-insensitive (URL uppercase)",
+			settings: BrowserSettings{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeDomain, Value: "example.com"},
+				},
+			},
+			url:      "https://WWW.EXAMPLE.COM/page",
+			expected: true,
+		},
+		{
+			name: "site match is case-insensitive (URL uppercase)",
+			settings: BrowserSettings{
+				Name:    "Firefox",
+				Command: "firefox",
+				Matches: []BrowserMatch{
+					{Type: BrowserMatchTypeSite, Value: "www.example.com"},
+				},
+			},
+			url:      "https://WWW.EXAMPLE.COM/page",
+			expected: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.settings.MatchesUrl(tt.url))
+		})
+	}
+}
+
 func TestSettings_NormalizeBrowsers(t *testing.T) {
 	for _, tt := range [...]struct {
 		name             string

--- a/url_test.go
+++ b/url_test.go
@@ -89,6 +89,73 @@ func TestURL_GetDomain_ErrorCases(t *testing.T) {
 	}
 }
 
+func TestURL_GetDomain_WithPorts(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "port is stripped from standard domain",
+			url:      "https://www.example.com:443/path",
+			expected: "example.com",
+		},
+		{
+			name:     "port is stripped from localhost-like domain",
+			url:      "http://myapp.local:8080/api",
+			expected: "myapp.local",
+		},
+		{
+			name:     "port is stripped from IP address",
+			url:      "http://192.168.1.1:3000/admin",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "non-standard port on subdomain",
+			url:      "https://api.example.com:8443/v1/resource",
+			expected: "example.com",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			u := NewURL(tt.url)
+			domain, err := u.GetDomain()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, domain)
+		})
+	}
+}
+
+func TestURL_GetSite_WithPorts(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "site includes port number",
+			url:      "http://localhost:8080/path",
+			expected: "localhost:8080",
+		},
+		{
+			name:     "site includes explicit standard port",
+			url:      "https://www.example.com:443/page",
+			expected: "www.example.com:443",
+		},
+		{
+			name:     "site includes non-standard port on IP",
+			url:      "http://192.168.1.1:3000/api",
+			expected: "192.168.1.1:3000",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			u := NewURL(tt.url)
+			site, err := u.GetSite()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, site)
+		})
+	}
+}
+
 func TestURL_GetSite(t *testing.T) {
 	for _, tt := range [...]struct {
 		name      string


### PR DESCRIPTION
Adds targeted test coverage for areas identified as gaps in the existing test suite. Each commit is self-contained and covers a specific area.

## Changes

- **FileSettingsService error paths**: Test `ScanBrowsers` when browser discovery fails, config directory is unwritable, and verify correct merge behavior on rescan
- **Terminus plugin Setup()**: Verify graceful handling of malformed `requestTimeout` strings, invalid config types, and confirm default values
- **Unwrap plugin edge cases**: Cover empty match rules, missing query parameters, multi-rule matching, and invalid config decoding
- **URL extraction with ports**: Confirm `GetDomain` strips port numbers and `GetSite` preserves them in host:port format (localhost, IPs, standard domains)
- **Darwin GetAvailableBrowsers invariants**: Verify no duplicate bundle IDs, self-exclusion of Linkquisition, and non-empty results on macOS
- **i18n TWithCount**: Exercise the custom template data branch and zero-count fallback path
- **Case-insensitive matching**: Confirm site and domain rules work regardless of casing in config values or URLs

## Motivation

These tests protect against regressions in user-facing behavior: config corruption on failure, plugins silently breaking with bad JSON, URL matching failing for real-world URLs with ports, and case sensitivity issues in manually-edited config files.