### PR TITLE
feat: add sanitize plugin to strip tracking parameters from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ See [plugins](./plugins/README.md) for more information.
 <img src="Icon.png" width="142" height="142" alt="Linkquisition" align="left"/>
 
 With the above list the most interesting feature for me personally is the plugins -feature, as it would allow for
-doing some more complex processing of the URL before opening it in a browser. For example, I could write a plugin that
-strips any tracking parameters from the URL before opening it in the browser.
+doing some more complex processing of the URL before opening it in a browser. ~~For example, I could write a plugin that
+strips any tracking parameters from the URL before opening it in the browser.~~ See
+[Sanitize](./plugins/sanitize/sanitize.go) -plugin for more information.
 
 ~~I also would like to have a plugin that checks if the opened url is a Microsoft Defender (Evergreen) URL and then,
 with

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -46,15 +46,24 @@ tasks:
 
   plugins:
     cmds:
-      - mkdir -p package/linux/usr/lib/linkquisition/plugins
-      - go build -buildmode=plugin -o package/linux/usr/lib/linkquisition/plugins/unwrap.so ./plugins/unwrap/unwrap.go
-      - go build -buildmode=plugin -o package/linux/usr/lib/linkquisition/plugins/terminus.so ./plugins/terminus/terminus.go
+      - task: build-plugins
+        vars:
+          OUTPUT_DIR: "package/linux/usr/lib/linkquisition/plugins"
 
   plugins-darwin:
     cmds:
-      - mkdir -p dist/Linkquisition.app/Contents/Resources/plugins
-      - go build -buildmode=plugin -o dist/Linkquisition.app/Contents/Resources/plugins/unwrap.so ./plugins/unwrap/unwrap.go
-      - go build -buildmode=plugin -o dist/Linkquisition.app/Contents/Resources/plugins/terminus.so ./plugins/terminus/terminus.go
+      - task: build-plugins
+        vars:
+          OUTPUT_DIR: "dist/Linkquisition.app/Contents/Resources/plugins"
+
+  build-plugins:
+    internal: true
+    vars:
+      PLUGINS: "unwrap terminus sanitize"
+    cmds:
+      - mkdir -p {{.OUTPUT_DIR}}
+      - for: { var: PLUGINS }
+        cmd: go build -buildmode=plugin -o {{.OUTPUT_DIR}}/{{.ITEM}}.so ./plugins/{{.ITEM}}/{{.ITEM}}.go
 
   clean:
     cmds:

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -78,6 +78,55 @@ allowed to take before giving up. Here's an example:
 
 ```
 
+## [Sanitize](./sanitize/sanitize.go) -plugin
+
+This plugin strips tracking and marketing query parameters (UTM tags, click IDs, etc.) from URLs before they are
+matched against browser rules or opened in a browser. This keeps your browser history and bookmarks clean from
+clutter like `?utm_source=newsletter&utm_medium=email&fbclid=abc123`.
+
+By default, the plugin removes a comprehensive list of well-known tracking parameters from all major platforms
+(Google Analytics, Meta/Facebook, Microsoft, HubSpot, Mailchimp, Yandex, and more). You can also add your own
+parameters or regex patterns, and optionally limit sanitization to specific URLs.
+
+### Configuration
+
+```json
+{
+  "browsers": [
+    ...
+  ],
+  "plugins": [
+    {
+      "path": "sanitize.so",
+      "settings": {
+        "stripDefaults": true,
+        "extraParams": ["ref", "igshid"],
+        "extraPatterns": ["^_ga"],
+        "onlyMatchingUrls": ""
+      }
+    }
+  ]
+}
+```
+
+### Settings
+
+| Setting            | Type     | Default | Description                                                                               |
+|--------------------|----------|---------|-------------------------------------------------------------------------------------------|
+| `stripDefaults`    | bool     | `true`  | Whether to strip the built-in list of known tracking parameters                           |
+| `extraParams`      | []string | `[]`    | Additional exact parameter names to strip                                                 |
+| `extraPatterns`    | []string | `[]`    | Regex patterns to match parameter names against (e.g. `^_ga` matches `_ga`, `_gac`, etc.) |
+| `onlyMatchingUrls` | string   | `""`    | Regex pattern; if set, only URLs matching this pattern are sanitized                      |
+
+### Default parameters stripped
+
+The built-in list includes parameters from: Google Analytics/Ads (`utm_*`, `gclid`, `gclsrc`, `dclid`, `gad_source`),
+Meta/Facebook (`fbclid`, `fb_action_ids`, `fb_action_types`, `fb_source`, `fb_ref`),
+Microsoft (`msclkid`), Twitter/X (`twclickid`, `twsrc`, `tweetid`),
+HubSpot (`_hsenc`, `_hsmi`, `__hssc`, `__hstc`, `__hsfp`, `hsCtaTracking`),
+Mailchimp (`mc_cid`, `mc_eid`), Yandex (`yclid`, `ymclid`), Vero (`vero_id`, `vero_conv`),
+Marketo (`mkt_tok`), Adobe (`s_cid`), and common social/affiliate trackers (`igshid`, `si`, `ref_src`, `ref_url`).
+
 ## Developing plugins
 
 As stated before, the plugins-feature is experimental, the API is not stable and therefore subject to change. However,
@@ -85,5 +134,5 @@ the plugin-interface is quite simple and should be easy to implement.
 
 The plugin is a shared object file (`.so`) that is loaded by the main application. The plugin must implement the
 [linkquisition.Plugin](../plugin.go) -interface and the only currently supported feature is the `ModifyUrl` -function.
-The function is called just before the URL is matched against the browser-rules and should return the modified URL, or 
+The function is called just before the URL is matched against the browser-rules and should return the modified URL, or
 the original if no modification is needed.

--- a/plugins/sanitize/sanitize.go
+++ b/plugins/sanitize/sanitize.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/strobotti/linkquisition"
+)
+
+// defaultParams is a list of well-known tracking/marketing query parameters that are stripped by default
+var defaultParams = []string{
+	// Google Analytics / Ads
+	"utm_source",
+	"utm_medium",
+	"utm_campaign",
+	"utm_term",
+	"utm_content",
+	"utm_id",
+	"utm_source_platform",
+	"utm_creative_format",
+	"utm_marketing_tactic",
+	"gclid",
+	"gclsrc",
+	"dclid",
+	"gad_source",
+	// Facebook / Meta
+	"fbclid",
+	"fb_action_ids",
+	"fb_action_types",
+	"fb_source",
+	"fb_ref",
+	// Microsoft
+	"msclkid",
+	// Twitter / X
+	"twclickid",
+	"twsrc",
+	"tweetid",
+	// HubSpot
+	"_hsenc",
+	"_hsmi",
+	"__hssc",
+	"__hstc",
+	"__hsfp",
+	"hsCtaTracking",
+	// Mailchimp
+	"mc_cid",
+	"mc_eid",
+	// Yandex
+	"yclid",
+	"ymclid",
+	// Vero
+	"vero_id",
+	"vero_conv",
+	// Marketo
+	"mkt_tok",
+	// Adobe
+	"s_cid",
+	// General tracking / affiliate
+	"igshid",
+	"si",
+	"ref_src",
+	"ref_url",
+}
+
+// SanitizePluginSettings holds the configuration for the sanitize plugin
+type SanitizePluginSettings struct {
+	// StripDefaults controls whether the built-in list of known tracking parameters is used (default: true)
+	StripDefaults *bool `json:"stripDefaults,omitempty"`
+
+	// ExtraParams is a list of additional exact parameter names to strip
+	ExtraParams []string `json:"extraParams,omitempty"`
+
+	// ExtraPatterns is a list of regex patterns to match parameter names against
+	ExtraPatterns []string `json:"extraPatterns,omitempty"`
+
+	// OnlyMatchingUrls is a regex pattern; if set, only URLs matching this pattern are sanitized
+	OnlyMatchingUrls string `json:"onlyMatchingUrls,omitempty"`
+}
+
+var _ linkquisition.Plugin = (*sanitize)(nil)
+
+// sanitize is a plugin that strips tracking/marketing query parameters from URLs
+type sanitize struct {
+	settings        SanitizePluginSettings
+	stripDefaults   bool
+	compiledExtra   []*regexp.Regexp
+	urlFilter       *regexp.Regexp
+	serviceProvider linkquisition.PluginServiceProvider
+}
+
+func (p *sanitize) Setup(serviceProvider linkquisition.PluginServiceProvider, config map[string]interface{}) {
+	p.serviceProvider = serviceProvider
+	p.stripDefaults = true
+
+	var settings SanitizePluginSettings
+	if err := mapstructure.Decode(config, &settings); err != nil {
+		serviceProvider.GetLogger().Warn("error decoding settings", "error", err.Error(), "plugin", "sanitize")
+		return
+	}
+
+	p.settings = settings
+
+	if settings.StripDefaults != nil {
+		p.stripDefaults = *settings.StripDefaults
+	}
+
+	// Compile extra patterns
+	for _, pattern := range settings.ExtraPatterns {
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			serviceProvider.GetLogger().Warn(
+				fmt.Sprintf("invalid regex pattern: %s", pattern),
+				"error", err.Error(),
+				"plugin", "sanitize",
+			)
+			continue
+		}
+		p.compiledExtra = append(p.compiledExtra, compiled)
+	}
+
+	// Compile URL filter
+	if settings.OnlyMatchingUrls != "" {
+		compiled, err := regexp.Compile(settings.OnlyMatchingUrls)
+		if err != nil {
+			serviceProvider.GetLogger().Warn(
+				fmt.Sprintf("invalid onlyMatchingUrls regex: %s", settings.OnlyMatchingUrls),
+				"error", err.Error(),
+				"plugin", "sanitize",
+			)
+		} else {
+			p.urlFilter = compiled
+		}
+	}
+}
+
+func (p *sanitize) ModifyUrl(address string) string {
+	// If a URL filter is configured, only sanitize matching URLs
+	if p.urlFilter != nil && !p.urlFilter.MatchString(address) {
+		return address
+	}
+
+	parsed, err := url.Parse(address)
+	if err != nil {
+		p.serviceProvider.GetLogger().Warn("error parsing URL", "error", err.Error(), "plugin", "sanitize")
+		return address
+	}
+
+	query := parsed.Query()
+	if len(query) == 0 {
+		return address
+	}
+
+	modified := false
+	for param := range query {
+		if p.shouldStrip(param) {
+			query.Del(param)
+			modified = true
+		}
+	}
+
+	if !modified {
+		return address
+	}
+
+	parsed.RawQuery = query.Encode()
+
+	newUrl := parsed.String()
+	p.serviceProvider.GetLogger().Debug(fmt.Sprintf("url sanitized `%s` => `%s`", address, newUrl), "plugin", "sanitize")
+
+	return newUrl
+}
+
+// shouldStrip returns true if the given parameter name should be removed
+func (p *sanitize) shouldStrip(param string) bool {
+	// Check the built-in default list
+	if p.stripDefaults {
+		for _, defaultParam := range defaultParams {
+			if param == defaultParam {
+				return true
+			}
+		}
+	}
+
+	// Check extra params (exact match)
+	for _, extra := range p.settings.ExtraParams {
+		if param == extra {
+			return true
+		}
+	}
+
+	// Check extra patterns (regex)
+	for _, pattern := range p.compiledExtra {
+		if pattern.MatchString(param) {
+			return true
+		}
+	}
+
+	return false
+}
+
+var Plugin sanitize

--- a/plugins/sanitize/sanitize_test.go
+++ b/plugins/sanitize/sanitize_test.go
@@ -1,0 +1,208 @@
+package main_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/mock"
+	. "github.com/strobotti/linkquisition/plugins/sanitize"
+)
+
+func TestSanitize_Setup_Defaults(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	testedPlugin.Setup(provider, map[string]interface{}{})
+
+	// With defaults, tracking params should be stripped
+	result := testedPlugin.ModifyUrl("https://example.com/page?utm_source=twitter&utm_medium=social&title=hello")
+	assert.Equal(t, "https://example.com/page?title=hello", result)
+}
+
+func TestSanitize_Setup_InvalidConfig(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+	provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+
+	testedPlugin := Plugin
+	// Pass config with wrong type — triggers mapstructure decode error
+	testedPlugin.Setup(provider, map[string]interface{}{
+		"stripDefaults": "not-a-bool",
+	})
+
+	// Plugin should still work with defaults (stripDefaults=true)
+	result := testedPlugin.ModifyUrl("https://example.com/?utm_source=test")
+	// After invalid config, defaults should apply — but since decode failed, stripDefaults stays true
+	assert.Equal(t, "https://example.com/", result)
+}
+
+func TestSanitize_ModifyUrl(t *testing.T) {
+	mockIoWriter := mock.Writer{
+		WriteFunc: func(p []byte) (n int, err error) {
+			return len(p), nil
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(mockIoWriter, nil))
+
+	for _, tt := range []struct {
+		name        string
+		config      map[string]interface{}
+		inputUrl    string
+		expectedUrl string
+	}{
+		{
+			name:        "URL without query params is unchanged",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page",
+			expectedUrl: "https://example.com/page",
+		},
+		{
+			name:        "URL with no tracking params is unchanged",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?id=123&name=test",
+			expectedUrl: "https://example.com/page?id=123&name=test",
+		},
+		{
+			name:        "UTM params are stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?utm_source=twitter&utm_medium=social&id=123",
+			expectedUrl: "https://example.com/page?id=123",
+		},
+		{
+			name:        "fbclid is stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?fbclid=abc123&id=456",
+			expectedUrl: "https://example.com/page?id=456",
+		},
+		{
+			name:        "gclid is stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?gclid=xyz789&product=widget",
+			expectedUrl: "https://example.com/page?product=widget",
+		},
+		{
+			name:        "msclkid is stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?msclkid=abc&q=search",
+			expectedUrl: "https://example.com/page?q=search",
+		},
+		{
+			name:        "all tracking params stripped leaves clean URL",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?utm_source=x&utm_medium=y&utm_campaign=z",
+			expectedUrl: "https://example.com/page",
+		},
+		{
+			name: "stripDefaults=false disables default list",
+			config: map[string]interface{}{
+				"stripDefaults": false,
+			},
+			inputUrl:    "https://example.com/page?utm_source=twitter&id=123",
+			expectedUrl: "https://example.com/page?utm_source=twitter&id=123",
+		},
+		{
+			name: "extraParams are stripped",
+			config: map[string]interface{}{
+				"stripDefaults": false,
+				"extraParams":   []interface{}{"tracking_id", "ref"},
+			},
+			inputUrl:    "https://example.com/page?tracking_id=abc&ref=homepage&id=123",
+			expectedUrl: "https://example.com/page?id=123",
+		},
+		{
+			name: "extraPatterns work with regex",
+			config: map[string]interface{}{
+				"stripDefaults": false,
+				"extraPatterns": []interface{}{"^_ga", "^itm_"},
+			},
+			inputUrl:    "https://example.com/page?_ga=123&_gac=456&itm_source=nav&id=789",
+			expectedUrl: "https://example.com/page?id=789",
+		},
+		{
+			name: "onlyMatchingUrls limits sanitization to matching URLs",
+			config: map[string]interface{}{
+				"onlyMatchingUrls": "^https://example\\.com",
+			},
+			inputUrl:    "https://other.com/page?utm_source=twitter&id=123",
+			expectedUrl: "https://other.com/page?utm_source=twitter&id=123",
+		},
+		{
+			name: "onlyMatchingUrls allows sanitization for matching URLs",
+			config: map[string]interface{}{
+				"onlyMatchingUrls": "^https://example\\.com",
+			},
+			inputUrl:    "https://example.com/page?utm_source=twitter&id=123",
+			expectedUrl: "https://example.com/page?id=123",
+		},
+		{
+			name: "invalid onlyMatchingUrls regex is handled gracefully",
+			config: map[string]interface{}{
+				"onlyMatchingUrls": "[invalid",
+			},
+			inputUrl:    "https://example.com/page?utm_source=twitter&id=123",
+			expectedUrl: "https://example.com/page?id=123",
+		},
+		{
+			name: "invalid extraPatterns regex entries are skipped",
+			config: map[string]interface{}{
+				"stripDefaults": false,
+				"extraPatterns": []interface{}{"[invalid", "^valid_"},
+			},
+			inputUrl:    "https://example.com/page?valid_tracking=1&other=2",
+			expectedUrl: "https://example.com/page?other=2",
+		},
+		{
+			name:        "URL with fragment is preserved",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?utm_source=x&id=1#section",
+			expectedUrl: "https://example.com/page?id=1#section",
+		},
+		{
+			name:        "malformed URL is returned unchanged",
+			config:      map[string]interface{}{},
+			inputUrl:    "://not-a-valid-url",
+			expectedUrl: "://not-a-valid-url",
+		},
+		{
+			name: "extraParams and defaults work together",
+			config: map[string]interface{}{
+				"extraParams": []interface{}{"custom_track"},
+			},
+			inputUrl:    "https://example.com/page?utm_source=x&custom_track=y&id=1",
+			expectedUrl: "https://example.com/page?id=1",
+		},
+		{
+			name:        "HubSpot params are stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?_hsenc=abc&_hsmi=123&title=hello",
+			expectedUrl: "https://example.com/page?title=hello",
+		},
+		{
+			name:        "Mailchimp params are stripped by default",
+			config:      map[string]interface{}{},
+			inputUrl:    "https://example.com/page?mc_cid=abc&mc_eid=123&article=news",
+			expectedUrl: "https://example.com/page?article=news",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testedPlugin := Plugin
+			provider := linkquisition.NewPluginServiceProvider(logger, &linkquisition.Settings{})
+			testedPlugin.Setup(provider, tt.config)
+
+			assert.Equal(t, tt.expectedUrl, testedPlugin.ModifyUrl(tt.inputUrl))
+		})
+	}
+}


### PR DESCRIPTION
Adds a new `sanitize` plugin that removes well-known tracking/marketing query parameters from URLs before they reach browser-matching rules or the browser itself. This was previously listed as a TODO item in the README.

## What it does

Strips parameters like `utm_source`, `utm_medium`, `fbclid`, `gclid`, `msclkid`, HubSpot/Mailchimp tags, and 50+ others from URLs — keeping browser history and bookmarks clean.

## Configuration

```json
{
  "plugins": [
    {
      "path": "sanitize.so",
      "settings": {
        "stripDefaults": true,
        "extraParams": ["ref", "igshid"],
        "extraPatterns": ["^_ga"],
        "onlyMatchingUrls": ""
      }
    }
  ]
}
```

- `stripDefaults` — toggle the built-in parameter list (default: `true`)
- `extraParams` — additional exact parameter names to strip
- `extraPatterns` — regex patterns to match parameter names
- `onlyMatchingUrls` — limit sanitization to URLs matching a regex

## Other changes

- Refactored `Taskfile.build.yml` plugin build into a shared internal task with a `for` loop — adding future plugins now only requires appending to the `PLUGINS` variable
- Updated `plugins/README.md` with full documentation
- Updated `README.md` to mark the tracking-parameter-stripping TODO as done

## Testing

20 test cases covering defaults, custom config, regex patterns, URL filtering, edge cases (malformed URLs, invalid config, invalid regex), and graceful fallback behavior. Full test suite passes.