### PR TITLE
docs: add agent instructions file

### DIFF
--- a/.agent-instructions.md
+++ b/.agent-instructions.md
@@ -1,0 +1,102 @@
+# Agent Instructions
+
+This file contains instructions for AI coding agents working on this project.
+It documents conventions, gotchas, and the checklist to follow when making changes.
+
+## Project overview
+
+Linkquisition is a browser-picker for Linux and macOS written in Go. It supports
+a plugin system (`.so` shared objects) that can modify URLs before they're opened.
+
+## Documentation surfaces to keep in sync
+
+When making changes, ensure ALL relevant documentation is updated:
+
+1. **`README.md`** — project overview, features list, TODO section
+2. **`plugins/README.md`** — plugin documentation, configuration examples, "Developing plugins" section
+3. **`doc/linkquisition.1.scd`** — man page for the command (scdoc format)
+4. **`doc/linkquisition.5.scd`** — man page for the config file format (scdoc format)
+
+### When adding a new plugin
+
+- [ ] Add a section in `plugins/README.md` with description, config example, and settings table
+- [ ] Update `Taskfile.build.yml` — add the plugin name to the `PLUGINS` variable in `build-plugins`
+- [ ] Update `README.md` if it references plugin capabilities or the TODO list
+- [ ] Ensure the plugin's behavior is accurately described (don't leave "for now" placeholders in released docs)
+
+### When changing plugin behavior
+
+- [ ] Update `plugins/README.md` to match the actual implementation
+- [ ] If settings or actions changed, update the settings table and examples
+- [ ] If the plugin interface changed, update the "Developing plugins" section
+
+### When changing the config file format
+
+- [ ] Update `doc/linkquisition.5.scd` man page
+- [ ] Update `README.md` example config if affected
+- [ ] Update `plugins/README.md` example configs if affected
+
+### When adding CLI flags or changing app behavior
+
+- [ ] Update `doc/linkquisition.1.scd` man page
+
+## Plugin system conventions
+
+- Plugins export `var Plugin <type>` as a package-level variable (value type, not pointer)
+- All methods use pointer receivers
+- The plugin interface has three methods: `Setup`, `ModifyUrl`, `Shutdown`
+- `Shutdown` receives a `context.Context` — respect the deadline
+- Use `NewPluginServiceProvider` to access logger, settings, and config folder path
+- Plugin `.so` files MUST be built from the same source tree as the main binary (interface mismatch = crash)
+
+### Testing plugins
+
+- Use `NewForTesting()` if the plugin struct contains a `sync.Mutex` (avoid copying the global `Plugin` var)
+- Pass `""` for `configFolderPath` in tests unless testing file I/O
+- Use `t.TempDir()` for any file system operations in tests
+- Use `httptest.NewServer` for testing HTTP-dependent plugins
+
+## Build system
+
+- **Taskfile** (not Make) — see `Taskfile.yml`, `Taskfile.build.yml`, `Taskfile.package.yml`
+- `task build` — build binary
+- `task build:plugins` / `task build:plugins-darwin` — build all plugin `.so` files
+- `task package:deb` — Linux `.deb` package
+- `task package:app` — macOS `.app` bundle (includes plugins)
+- `task package:app:install` — build + install to `/Applications`
+- The `PLUGINS` var in `Taskfile.build.yml` is the single source of truth for which plugins are built
+
+## Linting
+
+The project uses `golangci-lint`. Key rules to watch for:
+
+- **goconst** — extract repeated strings (3+ occurrences) into constants
+- **mnd** — no magic numbers in arguments/conditions; use named constants
+- **lll** — max 140 characters per line
+- **noctx** — use `http.NewRequestWithContext` instead of `http.Get` / `client.Get`
+- **gocritic/paramTypeCombine** — combine consecutive same-type params: `func(a, b string)` not
+  `func(a string, b string)`
+- **gocritic/exitAfterDefer** — don't call `os.Exit` in a function with defers; use a helper
+- **unparam** — if a function always returns nil for error, either fix it or add `//nolint:unparam`
+
+## Platform-specific code
+
+- `cmd/application_linux.go` — Linux-specific setup (build tag `//go:build linux`)
+- `cmd/application_darwin.go` — macOS-specific setup (build tag `//go:build darwin`)
+- Both must stay in sync for shared patterns (e.g. `NewPluginServiceProvider` call)
+
+## Paths on each platform
+
+| What                  | Linux                             | macOS                                                 |
+|-----------------------|-----------------------------------|-------------------------------------------------------|
+| Config                | `~/.config/linkquisition/`        | `~/Library/Application Support/linkquisition/`        |
+| Logs                  | `~/.local/state/linkquisition/`   | `~/Library/Logs/linkquisition/`                       |
+| Plugins (system)      | `/usr/lib/linkquisition/plugins/` | `Linkquisition.app/Contents/Resources/plugins/`       |
+| Plugin cache (defang) | `~/.config/linkquisition/defang/` | `~/Library/Application Support/linkquisition/defang/` |
+
+## Localization
+
+- Translation files live in `internal/i18n/translations/` (JSON, keyed by locale code)
+- Supported: `en`, `fi`, `es`, `sv`
+- The `locale` config key overrides system detection
+- Plugins do NOT currently have access to the i18n system

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.goreleaser.yaml
 !.golangci.yml
 !.release.yml
+!.agent-instructions.md
 /bin/
 /package/linux/
 /dist/


### PR DESCRIPTION
Adds .agent-instructions.md with conventions, documentation checklists, and gotchas for AI coding agents working on this project. Covers the documentation surfaces to keep in sync, plugin system conventions, build system, linting rules, platform-specific paths, and localization notes.