### PR TITLE
feat: add log level setting and log file rotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,12 @@ When making changes, ensure ALL relevant documentation is updated:
 
 ## Linting
 
-The project uses `golangci-lint`. Key rules to watch for:
+The project uses `golangci-lint`. The full rule configuration is in `.golangci.yml` — refer to
+it for the authoritative list of enabled linters and their settings. The linter runs in CI only
+(the CI version may differ from what's installed locally). Key rules to watch for:
 
 - **goconst** — extract repeated strings (3+ occurrences) into constants
+- **gosec** — security checks (e.g. `G306`: file permissions must be 0600 or less)
 - **mnd** — no magic numbers in arguments/conditions; use named constants
 - **lll** — max 140 characters per line
 - **noctx** — use `http.NewRequestWithContext` instead of `http.Get` / `client.Get`
@@ -84,6 +87,25 @@ The project uses `golangci-lint`. Key rules to watch for:
 - `cmd/application_linux.go` — Linux-specific setup (build tag `//go:build linux`)
 - `cmd/application_darwin.go` — macOS-specific setup (build tag `//go:build darwin`)
 - Both must stay in sync for shared patterns (e.g. `NewPluginServiceProvider` call)
+
+## The `cmd` package
+
+The `cmd/` directory is `package main` — it cannot be imported by other packages.
+Tests for code in `cmd/` must live in `cmd/*_test.go` files (same package). Use
+the `linkquisition.FileSettingsService` with a test `PathProvider` for integration-style
+tests (see `cmd/log_rotation_test.go` for an example).
+
+The app has two UI modes, both in `cmd/`:
+- **Configurator** (`cmd/configurator.go`) — settings screen, shown when launched with no args.
+  The General tab is composed of `build*Section()` methods. Add new sections there.
+- **BrowserPicker** (`cmd/browser_picker.go`) — the URL picker, shown when launched with a URL.
+
+## Settings and config model
+
+- `settings.go` — `Settings` struct, constants (`LogLevel*`, `BrowserMatchType*`, `Source*`),
+  `SettingsService` interface, `MapSettingsLogLevelToSlog`
+- `settings_service.go` — `FileSettingsService` (shared, platform-independent implementation)
+- Use named constants for repeated string values (log levels, match types, sources)
 
 ## Paths on each platform
 

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -22,6 +22,7 @@ import (
 const logDirPerms = 0755
 const logFilePerms = 0644
 const pluginShutdownTimeout = 10 * time.Second
+const maxLogFileSize = 1 << 20 // 1 MB
 
 type Application struct {
 	Fapp            fyne.App
@@ -156,6 +157,25 @@ func setupLogger(settingsService linkquisition.SettingsService) *slog.Logger {
 	return slog.New(slog.NewTextHandler(logWriter, logHandlerOpts))
 }
 
+// rotateLogFile checks the log file size and rotates it if it exceeds the threshold.
+// Keeps at most one backup (linkquisition.log.1).
+func rotateLogFile(settingsService linkquisition.SettingsService) {
+	logPath := settingsService.GetLogFilePath()
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		return // file doesn't exist yet, nothing to rotate
+	}
+
+	if info.Size() < maxLogFileSize {
+		return
+	}
+
+	backupPath := logPath + ".1"
+	_ = os.Remove(backupPath)
+	_ = os.Rename(logPath, backupPath)
+}
+
 func (a *Application) Run(_ context.Context) error {
 	defer a.shutdownPlugins()
 
@@ -186,6 +206,10 @@ func (a *Application) Run(_ context.Context) error {
 		a.Logger.Error("Invalid URL: " + urlToOpen)
 		return nil
 	}
+
+	// Rotate the log file if it has grown too large. Deferred so it runs as one
+	// of the last things before the process exits in the URL-opening path.
+	defer rotateLogFile(a.SettingsService)
 
 	a.Logger.Debug(fmt.Sprintf("Starting linkquisition with URL: `%s`", urlToOpen))
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -65,6 +65,8 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 		layout.NewSpacer(),
 		c.buildLanguageSection(),
 		layout.NewSpacer(),
+		c.buildLogLevelSection(),
+		layout.NewSpacer(),
 		c.buildUiSection(),
 	)
 }
@@ -189,6 +191,25 @@ func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.language_label")), nil, languageSelect),
 		restartNote,
 	)
+}
+
+func (c *Configurator) buildLogLevelSection() fyne.CanvasObject {
+	levels := []string{"debug", linkquisition.LogLevelInfo, "warn", "error"}
+	currentLevel := c.settingsService.GetSettings().LogLevel
+	if currentLevel == "" {
+		currentLevel = linkquisition.LogLevelInfo
+	}
+
+	logLevelSelect := widget.NewSelect(levels, func(selected string) {
+		settings := c.settingsService.GetSettings()
+		settings.LogLevel = selected
+		if err := c.settingsService.WriteSettings(settings); err != nil {
+			c.logger.Error("Error saving log level setting", "error", err)
+		}
+	})
+	logLevelSelect.Selected = currentLevel
+
+	return container.NewBorder(nil, nil, widget.NewLabel(i18n.T("config.log_level_label")), nil, logLevelSelect)
 }
 
 func (c *Configurator) buildUiSection() fyne.CanvasObject {

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -194,10 +194,10 @@ func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 }
 
 func (c *Configurator) buildLogLevelSection() fyne.CanvasObject {
-	levels := []string{"debug", linkquisition.LogLevelInfo, "warn", "error"}
+	levels := []string{"debug", linkquisition.LogLevelInfo, linkquisition.LogLevelWarn, "error"}
 	currentLevel := c.settingsService.GetSettings().LogLevel
 	if currentLevel == "" {
-		currentLevel = linkquisition.LogLevelInfo
+		currentLevel = linkquisition.LogLevelWarn
 	}
 
 	logLevelSelect := widget.NewSelect(levels, func(selected string) {

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -194,7 +194,12 @@ func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 }
 
 func (c *Configurator) buildLogLevelSection() fyne.CanvasObject {
-	levels := []string{"debug", linkquisition.LogLevelInfo, linkquisition.LogLevelWarn, "error"}
+	levels := []string{
+		linkquisition.LogLevelDebug,
+		linkquisition.LogLevelInfo,
+		linkquisition.LogLevelWarn,
+		linkquisition.LogLevelError,
+	}
 	currentLevel := c.settingsService.GetSettings().LogLevel
 	if currentLevel == "" {
 		currentLevel = linkquisition.LogLevelWarn

--- a/cmd/log_rotation_test.go
+++ b/cmd/log_rotation_test.go
@@ -44,7 +44,7 @@ func TestRotateLogFile_SmallFile(t *testing.T) {
 	logPath := svc.GetLogFilePath()
 
 	// Create a small log file (under threshold)
-	if err := os.WriteFile(logPath, []byte("small log content\n"), 0644); err != nil {
+	if err := os.WriteFile(logPath, []byte("small log content\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +71,7 @@ func TestRotateLogFile_LargeFile(t *testing.T) {
 		largeContent[i] = 'x'
 	}
 
-	if err := os.WriteFile(logPath, largeContent, 0644); err != nil {
+	if err := os.WriteFile(logPath, largeContent, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,13 +99,13 @@ func TestRotateLogFile_OverwritesOldBackup(t *testing.T) {
 	backupPath := logPath + ".1"
 
 	// Create an existing backup
-	if err := os.WriteFile(backupPath, []byte("old backup"), 0644); err != nil {
+	if err := os.WriteFile(backupPath, []byte("old backup"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create a large current log
 	largeContent := make([]byte, maxLogFileSize+100)
-	if err := os.WriteFile(logPath, largeContent, 0644); err != nil {
+	if err := os.WriteFile(logPath, largeContent, 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/log_rotation_test.go
+++ b/cmd/log_rotation_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/strobotti/linkquisition"
+)
+
+// testPathProvider implements linkquisition.PathProvider for testing.
+type testPathProvider struct {
+	configFolder string
+	logFolder    string
+	pluginFolder string
+}
+
+func (p *testPathProvider) GetConfigFolderPath() string { return p.configFolder }
+func (p *testPathProvider) GetLogFolderPath() string    { return p.logFolder }
+func (p *testPathProvider) GetPluginFolderPath() string { return p.pluginFolder }
+
+func newTestSettingsService(t *testing.T) *linkquisition.FileSettingsService {
+	t.Helper()
+	dir := t.TempDir()
+
+	return &linkquisition.FileSettingsService{
+		PathProvider: &testPathProvider{
+			configFolder: dir,
+			logFolder:    dir,
+			pluginFolder: dir,
+		},
+	}
+}
+
+func TestRotateLogFile_NoFile(t *testing.T) {
+	svc := newTestSettingsService(t)
+
+	// Should not panic when the log file does not exist
+	rotateLogFile(svc)
+}
+
+func TestRotateLogFile_SmallFile(t *testing.T) {
+	svc := newTestSettingsService(t)
+	logPath := svc.GetLogFilePath()
+
+	// Create a small log file (under threshold)
+	if err := os.WriteFile(logPath, []byte("small log content\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rotateLogFile(svc)
+
+	// Original file should still exist (not rotated)
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("expected log file to still exist, got: %v", err)
+	}
+
+	// No backup should exist
+	if _, err := os.Stat(logPath + ".1"); !os.IsNotExist(err) {
+		t.Error("expected no backup file for small log")
+	}
+}
+
+func TestRotateLogFile_LargeFile(t *testing.T) {
+	svc := newTestSettingsService(t)
+	logPath := svc.GetLogFilePath()
+
+	// Create a file larger than maxLogFileSize (1 MB)
+	largeContent := make([]byte, maxLogFileSize+1)
+	for i := range largeContent {
+		largeContent[i] = 'x'
+	}
+
+	if err := os.WriteFile(logPath, largeContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rotateLogFile(svc)
+
+	// Original file should have been renamed to .1
+	backupPath := logPath + ".1"
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatalf("expected backup file to exist, got: %v", err)
+	}
+	if info.Size() != int64(maxLogFileSize+1) {
+		t.Errorf("expected backup size %d, got %d", maxLogFileSize+1, info.Size())
+	}
+
+	// Original path should no longer exist
+	if _, errStat := os.Stat(logPath); !os.IsNotExist(errStat) {
+		t.Error("expected original log file to be gone after rotation")
+	}
+}
+
+func TestRotateLogFile_OverwritesOldBackup(t *testing.T) {
+	svc := newTestSettingsService(t)
+	logPath := svc.GetLogFilePath()
+	backupPath := logPath + ".1"
+
+	// Create an existing backup
+	if err := os.WriteFile(backupPath, []byte("old backup"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a large current log
+	largeContent := make([]byte, maxLogFileSize+100)
+	if err := os.WriteFile(logPath, largeContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rotateLogFile(svc)
+
+	// Backup should now be the new large file, not the old content
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != int64(maxLogFileSize+100) {
+		t.Errorf("expected backup to be overwritten with new content, got size %d", info.Size())
+	}
+}
+
+func TestRotateLogFile_LogFilePath(t *testing.T) {
+	svc := newTestSettingsService(t)
+	logPath := svc.GetLogFilePath()
+
+	// Verify the path ends with linkquisition.log
+	expected := filepath.Join(svc.GetLogFolderPath(), "linkquisition.log")
+	if logPath != expected {
+		t.Errorf("expected log path %s, got %s", expected, logPath)
+	}
+}

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -24,7 +24,7 @@ The file is JSON and is managed either manually or via the configuration screen
 	translation is available.
 
 *logLevel* (string, optional)
-	Log verbosity. One of: _debug_, _info_, _warn_, _error_. Default: _info_.
+	Log verbosity. One of: _debug_, _info_, _warn_, _error_. Default: _warn_.
 
 *browsers* (array)
 	List of browser objects. See *BROWSER OBJECT* below.

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -77,6 +77,9 @@
   "config.scan_failed": {
     "other": "✗ Scan failed"
   },
+  "config.log_level_label": {
+    "other": "Log level:"
+  },
   "config.hide_keyboard_guide": {
     "other": "Hide keyboard shortcut guide in picker"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -77,6 +77,9 @@
   "config.scan_failed": {
     "other": "✗ La búsqueda falló"
   },
+  "config.log_level_label": {
+    "other": "Nivel de registro:"
+  },
   "config.hide_keyboard_guide": {
     "other": "Ocultar guía de atajos de teclado en el selector"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -77,6 +77,9 @@
   "config.scan_failed": {
     "other": "✗ Haku epäonnistui"
   },
+  "config.log_level_label": {
+    "other": "Lokitaso:"
+  },
   "config.hide_keyboard_guide": {
     "other": "Piilota pikanäppäinohje valitsimessa"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -77,6 +77,9 @@
   "config.scan_failed": {
     "other": "✗ Sökningen misslyckades"
   },
+  "config.log_level_label": {
+    "other": "Loggnivå:"
+  },
   "config.hide_keyboard_guide": {
     "other": "Dölj tangentbordsguide i väljaren"
   },

--- a/settings.go
+++ b/settings.go
@@ -17,8 +17,10 @@ const (
 	SourceAuto   = "auto"
 	SourceManual = "manual"
 
-	LogLevelInfo = "info"
-	LogLevelWarn = "warn"
+	LogLevelDebug = "debug"
+	LogLevelInfo  = "info"
+	LogLevelWarn  = "warn"
+	LogLevelError = "error"
 )
 
 type BrowserMatch struct {
@@ -279,13 +281,13 @@ func GetDefaultSettings() *Settings {
 
 func MapSettingsLogLevelToSlog(logLevel string) slog.Level {
 	switch strings.ToLower(logLevel) {
-	case "debug":
+	case LogLevelDebug:
 		return slog.LevelDebug
 	case LogLevelInfo:
 		return slog.LevelInfo
 	case LogLevelWarn:
 		return slog.LevelWarn
-	case "error":
+	case LogLevelError:
 		return slog.LevelError
 	default:
 		return slog.LevelWarn

--- a/settings.go
+++ b/settings.go
@@ -18,6 +18,7 @@ const (
 	SourceManual = "manual"
 
 	LogLevelInfo = "info"
+	LogLevelWarn = "warn"
 )
 
 type BrowserMatch struct {
@@ -270,7 +271,7 @@ type SettingsService interface {
 
 func GetDefaultSettings() *Settings {
 	return &Settings{
-		LogLevel: LogLevelInfo,
+		LogLevel: LogLevelWarn,
 		Browsers: nil,
 		Ui:       UiSettings{},
 	}
@@ -282,11 +283,11 @@ func MapSettingsLogLevelToSlog(logLevel string) slog.Level {
 		return slog.LevelDebug
 	case LogLevelInfo:
 		return slog.LevelInfo
-	case "warn":
+	case LogLevelWarn:
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
 	default:
-		return slog.LevelInfo
+		return slog.LevelWarn
 	}
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -787,8 +787,8 @@ func TestMapSettingsLogLevelToSlog(t *testing.T) {
 		{name: "info", input: "info", expected: 0},
 		{name: "warn", input: "warn", expected: 4},
 		{name: "error", input: "error", expected: 8},
-		{name: "unknown defaults to info", input: "something", expected: 0},
-		{name: "empty defaults to info", input: "", expected: 0},
+		{name: "unknown defaults to warn", input: "something", expected: 4},
+		{name: "empty defaults to warn", input: "", expected: 4},
 		{name: "case insensitive DEBUG", input: "DEBUG", expected: -4},
 		{name: "case insensitive Warn", input: "Warn", expected: 4},
 	} {


### PR DESCRIPTION
Add configurable log level to the settings screen and automatic log rotation in the URL-opening path.

## Changes

- **Log level selector** — new dropdown in the General tab (debug / info / warn / error), persisted to `config.json` immediately. Translations included for all supported locales.
- **Log file rotation** — when the log file exceeds 1 MB, it is rotated to `linkquisition.log.1` (one backup kept). Runs as a deferred call at the end of the URL-opening flow, which is the only path that produces meaningful log output.
- **Default log level changed to `warn`** — a browser-picker produces very little interesting output at info level during normal use; warn keeps the log small unless the user opts in to more verbosity.

## Testing

- Unit tests added for the rotation logic (no-file, small file, large file, backup overwrite)
- Existing `TestMapSettingsLogLevelToSlog` updated for new default
- Full test suite passes