### PR TITLE
feat: GUI plugin configuration via Plugins tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,21 @@ It documents conventions, gotchas, and the checklist to follow when making chang
 Linkquisition is a browser-picker for Linux and macOS written in Go. It supports
 a plugin system (`.so` shared objects) that can modify URLs before they're opened.
 
+## Commit conventions
+
+This project uses **Angular conventional commits**. Every commit message must have
+a type prefix:
+
+- `feat:` — new feature (minor version bump)
+- `fix:` — bug fix (patch version bump)
+- `feat!:` or `fix!:` with `BREAKING CHANGE:` in body — major version bump
+- `refactor:`, `docs:`, `style:`, `test:`, `chore:`, `ci:`, `perf:` — no release
+
+Prefer **small, self-contained commits** over large monolithic changes. Each commit
+should ideally do one thing and be independently reviewable. If a feature requires
+multiple steps (e.g. interface change + migration + tests + docs), split them into
+separate commits on the same branch rather than squashing everything together.
+
 ## Documentation surfaces to keep in sync
 
 When making changes, ensure ALL relevant documentation is updated:

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -27,6 +27,7 @@ const logFilePerms = 0644
 const pluginShutdownTimeout = 10 * time.Second
 const maxLogFileSize = 1 << 20 // 1 MB
 const pluginProcessTimeout = 30 * time.Second
+const pluginExtension = ".so"
 
 type Application struct {
 	Fapp            fyne.App
@@ -52,8 +53,8 @@ func setupPlugins(
 		}
 
 		pluginPath := pluginSettings.Path
-		if !strings.HasSuffix(pluginPath, ".so") {
-			pluginPath += ".so"
+		if !strings.HasSuffix(pluginPath, pluginExtension) {
+			pluginPath += pluginExtension
 		}
 
 		if _, err := os.Stat(pluginPath); err != nil {

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -134,6 +134,33 @@ func setupPlugin(
 	return p, nil
 }
 
+// probePluginMetadata opens a plugin .so file and retrieves its Metadata without calling Setup.
+// Used by the configurator to display plugin info without fully initializing plugins.
+func probePluginMetadata(path string, logger *slog.Logger) (meta linkquisition.PluginMetadata, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while probing plugin %s: %v", path, r)
+		}
+	}()
+
+	plug, openErr := openPlugin(path, logger)
+	if plug == nil || openErr != nil {
+		return meta, fmt.Errorf("failed to open plugin: %w", openErr)
+	}
+
+	symbol, lookupErr := plug.Lookup("Plugin")
+	if lookupErr != nil {
+		return meta, fmt.Errorf("plugin symbol lookup failed: %w", lookupErr)
+	}
+
+	p, ok := symbol.(linkquisition.Plugin)
+	if !ok {
+		return meta, fmt.Errorf("plugin does not implement Plugin interface (got %T)", symbol)
+	}
+
+	return p.Metadata(), nil
+}
+
 func setupLogger(settingsService linkquisition.SettingsService) *slog.Logger {
 	fallbackLog := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	settings := settingsService.GetSettings()

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -41,6 +41,7 @@ func (c *Configurator) Run() error {
 
 	tabs := container.NewAppTabs(
 		container.NewTabItem(i18n.T("config.tab_general"), c.getGeneralTab()),
+		container.NewTabItem(i18n.T("config.tab_plugins"), c.getPluginsTab()),
 		container.NewTabItem(i18n.T("config.tab_rules"), c.getRulesTab()),
 		container.NewTabItem(i18n.T("config.tab_about"), c.getAboutTab()),
 	)
@@ -48,8 +49,7 @@ func (c *Configurator) Run() error {
 
 	w.SetContent(tabs)
 
-	w.SetFixedSize(true)
-	w.Resize(fyne.NewSize(500, 400)) //nolint:mnd
+	w.Resize(fyne.NewSize(650, 550)) //nolint:mnd
 	w.CenterOnScreen()
 
 	w.ShowAndRun()

--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -27,7 +27,8 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 	editors := make(map[string]func() interface{})
 	formItems := make([]*widget.FormItem, 0, len(meta.Settings))
 
-	for _, desc := range meta.Settings {
+	for i := range meta.Settings {
+		desc := &meta.Settings[i]
 		item, getValue := c.buildSettingWidget(desc, ps.Settings)
 		formItems = append(formItems, item)
 		editors[desc.Key] = getValue
@@ -89,10 +90,9 @@ func (c *Configurator) savePluginSettings(
 	c.rebuildPluginsList(listContainer)
 }
 
-//nolint:funlen
 func (c *Configurator) buildSettingWidget(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	switch desc.Type {
 	case linkquisition.SettingTypeBool:
 		return c.buildBoolSetting(desc, currentSettings)
@@ -110,26 +110,26 @@ func (c *Configurator) buildSettingWidget(
 }
 
 func (c *Configurator) buildBoolSetting(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	current := getSettingBool(currentSettings, desc.Key, desc.Default)
 	check := widget.NewCheck("", nil)
 	check.Checked = current
 
-	item := widget.NewFormItem(desc.Label, check)
+	item = widget.NewFormItem(desc.Label, check)
 	item.HintText = desc.Description
 
 	return item, func() interface{} { return check.Checked }
 }
 
 func (c *Configurator) buildChoiceSetting(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	current := getSettingString(currentSettings, desc.Key, desc.Default)
 	sel := widget.NewSelect(desc.Options, nil)
 	sel.Selected = current
 
-	item := widget.NewFormItem(desc.Label, sel)
+	item = widget.NewFormItem(desc.Label, sel)
 	item.HintText = desc.Description
 
 	return item, func() interface{} {
@@ -141,8 +141,8 @@ func (c *Configurator) buildChoiceSetting(
 }
 
 func (c *Configurator) buildIntSetting(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	current := getSettingString(currentSettings, desc.Key, desc.Default)
 	entry := widget.NewEntry()
 	entry.SetText(current)
@@ -156,7 +156,7 @@ func (c *Configurator) buildIntSetting(
 		return nil
 	}
 
-	item := widget.NewFormItem(desc.Label, entry)
+	item = widget.NewFormItem(desc.Label, entry)
 	item.HintText = desc.Description
 
 	return item, func() interface{} {
@@ -172,8 +172,8 @@ func (c *Configurator) buildIntSetting(
 }
 
 func (c *Configurator) buildStringSetting(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	current := getSettingString(currentSettings, desc.Key, desc.Default)
 	entry := widget.NewEntry()
 	entry.SetText(current)
@@ -182,7 +182,7 @@ func (c *Configurator) buildStringSetting(
 		entry.SetPlaceHolder("e.g. 5s, 168h")
 	}
 
-	item := widget.NewFormItem(desc.Label, entry)
+	item = widget.NewFormItem(desc.Label, entry)
 	item.HintText = desc.Description
 
 	return item, func() interface{} {
@@ -194,15 +194,15 @@ func (c *Configurator) buildStringSetting(
 }
 
 func (c *Configurator) buildStringListSetting(
-	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
-) (*widget.FormItem, func() interface{}) {
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
 	current := getSettingStringList(currentSettings, desc.Key)
 	entry := widget.NewMultiLineEntry()
 	entry.SetText(strings.Join(current, "\n"))
 	entry.SetMinRowsVisible(3) //nolint:mnd
 	entry.SetPlaceHolder("One entry per line")
 
-	item := widget.NewFormItem(desc.Label, entry)
+	item = widget.NewFormItem(desc.Label, entry)
 	item.HintText = desc.Description
 
 	return item, func() interface{} {

--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/i18n"
+)
+
+func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Container) {
+	settings := c.settingsService.GetSettings()
+	ps := settings.Plugins[pluginIdx]
+	meta := c.getPluginMetadata(ps.Path)
+
+	if ps.Settings == nil {
+		ps.Settings = make(map[string]interface{})
+	}
+
+	// Build form items from metadata setting descriptors
+	editors := make(map[string]func() interface{})
+	formItems := make([]*widget.FormItem, 0, len(meta.Settings))
+
+	for _, desc := range meta.Settings {
+		item, getValue := c.buildSettingWidget(desc, ps.Settings)
+		formItems = append(formItems, item)
+		editors[desc.Key] = getValue
+	}
+
+	// Build the form
+	form := widget.NewForm(formItems...)
+
+	title := i18n.T("config.plugins_settings_title", map[string]interface{}{"Name": meta.Name})
+
+	// Get the parent window — use the fyne app's driver to find it
+	windows := c.fapp.Driver().AllWindows()
+	if len(windows) == 0 {
+		return
+	}
+	parentWindow := windows[0]
+
+	scrollContent := container.NewVScroll(form)
+	scrollContent.SetMinSize(fyne.NewSize(550, 300)) //nolint:mnd
+
+	d := dialog.NewCustomConfirm(
+		title,
+		i18n.T("config.plugins_save"),
+		i18n.T("config.plugins_cancel"),
+		scrollContent,
+		func(save bool) {
+			if !save {
+				return
+			}
+			c.savePluginSettings(pluginIdx, editors, listContainer)
+		},
+		parentWindow,
+	)
+	d.Resize(fyne.NewSize(600, 450)) //nolint:mnd
+	d.Show()
+}
+
+func (c *Configurator) savePluginSettings(
+	pluginIdx int, editors map[string]func() interface{}, listContainer *fyne.Container,
+) {
+	settings := c.settingsService.GetSettings()
+	if settings.Plugins[pluginIdx].Settings == nil {
+		settings.Plugins[pluginIdx].Settings = make(map[string]interface{})
+	}
+
+	for key, getValue := range editors {
+		val := getValue()
+		if val == nil {
+			delete(settings.Plugins[pluginIdx].Settings, key)
+		} else {
+			settings.Plugins[pluginIdx].Settings[key] = val
+		}
+	}
+
+	if err := c.settingsService.WriteSettings(settings); err != nil {
+		c.logger.Error("Error saving plugin settings", "error", err)
+	}
+
+	c.rebuildPluginsList(listContainer)
+}
+
+//nolint:funlen
+func (c *Configurator) buildSettingWidget(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	switch desc.Type {
+	case linkquisition.SettingTypeBool:
+		return c.buildBoolSetting(desc, currentSettings)
+	case linkquisition.SettingTypeChoice:
+		return c.buildChoiceSetting(desc, currentSettings)
+	case linkquisition.SettingTypeInt:
+		return c.buildIntSetting(desc, currentSettings)
+	case linkquisition.SettingTypeString, linkquisition.SettingTypeDuration:
+		return c.buildStringSetting(desc, currentSettings)
+	case linkquisition.SettingTypeStringList:
+		return c.buildStringListSetting(desc, currentSettings)
+	default:
+		return c.buildStringSetting(desc, currentSettings)
+	}
+}
+
+func (c *Configurator) buildBoolSetting(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	current := getSettingBool(currentSettings, desc.Key, desc.Default)
+	check := widget.NewCheck("", nil)
+	check.Checked = current
+
+	item := widget.NewFormItem(desc.Label, check)
+	item.HintText = desc.Description
+
+	return item, func() interface{} { return check.Checked }
+}
+
+func (c *Configurator) buildChoiceSetting(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	current := getSettingString(currentSettings, desc.Key, desc.Default)
+	sel := widget.NewSelect(desc.Options, nil)
+	sel.Selected = current
+
+	item := widget.NewFormItem(desc.Label, sel)
+	item.HintText = desc.Description
+
+	return item, func() interface{} {
+		if sel.Selected == "" {
+			return nil
+		}
+		return sel.Selected
+	}
+}
+
+func (c *Configurator) buildIntSetting(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	current := getSettingString(currentSettings, desc.Key, desc.Default)
+	entry := widget.NewEntry()
+	entry.SetText(current)
+	entry.Validator = func(s string) error {
+		if s == "" {
+			return nil
+		}
+		if _, err := strconv.Atoi(s); err != nil {
+			return fmt.Errorf("must be a number")
+		}
+		return nil
+	}
+
+	item := widget.NewFormItem(desc.Label, entry)
+	item.HintText = desc.Description
+
+	return item, func() interface{} {
+		text := entry.Text
+		if text == "" {
+			return nil
+		}
+		if v, err := strconv.Atoi(text); err == nil {
+			return v
+		}
+		return nil
+	}
+}
+
+func (c *Configurator) buildStringSetting(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	current := getSettingString(currentSettings, desc.Key, desc.Default)
+	entry := widget.NewEntry()
+	entry.SetText(current)
+
+	if desc.Type == linkquisition.SettingTypeDuration {
+		entry.SetPlaceHolder("e.g. 5s, 168h")
+	}
+
+	item := widget.NewFormItem(desc.Label, entry)
+	item.HintText = desc.Description
+
+	return item, func() interface{} {
+		if entry.Text == "" {
+			return nil
+		}
+		return entry.Text
+	}
+}
+
+func (c *Configurator) buildStringListSetting(
+	desc linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (*widget.FormItem, func() interface{}) {
+	current := getSettingStringList(currentSettings, desc.Key)
+	entry := widget.NewMultiLineEntry()
+	entry.SetText(strings.Join(current, "\n"))
+	entry.SetMinRowsVisible(3) //nolint:mnd
+	entry.SetPlaceHolder("One entry per line")
+
+	item := widget.NewFormItem(desc.Label, entry)
+	item.HintText = desc.Description
+
+	return item, func() interface{} {
+		text := strings.TrimSpace(entry.Text)
+		if text == "" {
+			return nil
+		}
+		lines := strings.Split(text, "\n")
+		result := make([]interface{}, 0, len(lines))
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" {
+				result = append(result, trimmed)
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	}
+}
+
+// Helper functions to extract current setting values from the untyped map
+
+func getSettingString(settings map[string]interface{}, key string, defaultVal interface{}) string {
+	if v, ok := settings[key]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	if defaultVal != nil {
+		return fmt.Sprintf("%v", defaultVal)
+	}
+	return ""
+}
+
+func getSettingBool(settings map[string]interface{}, key string, defaultVal interface{}) bool {
+	if v, ok := settings[key]; ok {
+		switch b := v.(type) {
+		case bool:
+			return b
+		case string:
+			return b == "true"
+		}
+	}
+	if defaultVal != nil {
+		if b, ok := defaultVal.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func getSettingStringList(settings map[string]interface{}, key string) []string {
+	v, ok := settings[key]
+	if !ok {
+		return nil
+	}
+
+	switch list := v.(type) {
+	case []interface{}:
+		result := make([]string, 0, len(list))
+		for _, item := range list {
+			result = append(result, fmt.Sprintf("%v", item))
+		}
+		return result
+	case []string:
+		return list
+	}
+
+	return nil
+}

--- a/cmd/configurator_plugins.go
+++ b/cmd/configurator_plugins.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,18 +41,12 @@ func (c *Configurator) rebuildPluginsList(content *fyne.Container) {
 	available := c.discoverUnconfiguredPlugins(settings)
 	if len(available) > 0 {
 		content.Add(layout.NewSpacer())
-		content.Add(widget.NewLabel(i18n.T("config.plugins_available")))
+		availLabel := widget.NewLabel(i18n.T("config.plugins_available"))
+		availLabel.TextStyle = fyne.TextStyle{Bold: true}
+		content.Add(availLabel)
 
 		for _, name := range available {
-			pluginName := name
-			addBtn := widget.NewButton(
-				fmt.Sprintf("%s  [%s]", pluginName, i18n.T("config.plugins_add")),
-				func() {
-					c.addPlugin(pluginName, content)
-				},
-			)
-			addBtn.Importance = widget.LowImportance
-			content.Add(addBtn)
+			content.Add(c.buildAvailablePluginRow(name, content))
 		}
 	} else if len(settings.Plugins) == 0 {
 		content.Add(widget.NewLabel(i18n.T("config.plugins_none_available")))
@@ -88,11 +81,10 @@ func (c *Configurator) buildPluginCard(
 	})
 	enableCheck.Checked = !ps.IsDisabled
 
-	// Configure button
+	// Configure button — uses default importance (visible border)
 	configBtn := widget.NewButton(i18n.T("config.plugins_configure"), func() {
 		c.showPluginSettings(idx, listContainer)
 	})
-	configBtn.Importance = widget.LowImportance
 
 	// Only show configure button if plugin has settings
 	if len(meta.Settings) == 0 {
@@ -103,7 +95,6 @@ func (c *Configurator) buildPluginCard(
 	upBtn := widget.NewButton(i18n.T("config.plugins_move_up"), func() {
 		c.movePlugin(idx, -1, listContainer)
 	})
-	upBtn.Importance = widget.LowImportance
 	if idx == 0 {
 		upBtn.Disable()
 	}
@@ -111,7 +102,6 @@ func (c *Configurator) buildPluginCard(
 	downBtn := widget.NewButton(i18n.T("config.plugins_move_down"), func() {
 		c.movePlugin(idx, 1, listContainer)
 	})
-	downBtn.Importance = widget.LowImportance
 	if idx == len(settings.Plugins)-1 {
 		downBtn.Disable()
 	}
@@ -126,6 +116,26 @@ func (c *Configurator) buildPluginCard(
 	actionRow := container.NewHBox(configBtn)
 
 	card := container.NewVBox(headerRow, desc, actionRow)
+
+	return widget.NewCard("", "", card)
+}
+
+func (c *Configurator) buildAvailablePluginRow(name string, listContainer *fyne.Container) fyne.CanvasObject {
+	pluginName := name
+	meta := c.getPluginMetadata(pluginName + ".so")
+
+	title := widget.NewLabel(meta.Name)
+	title.TextStyle = fyne.TextStyle{Bold: true}
+
+	desc := widget.NewLabel(meta.Description)
+	desc.Wrapping = fyne.TextWrapWord
+
+	addBtn := widget.NewButton(i18n.T("config.plugins_add"), func() {
+		c.addPlugin(pluginName, listContainer)
+	})
+
+	headerRow := container.NewBorder(nil, nil, title, addBtn)
+	card := container.NewVBox(headerRow, desc)
 
 	return widget.NewCard("", "", card)
 }

--- a/cmd/configurator_plugins.go
+++ b/cmd/configurator_plugins.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/i18n"
+)
+
+func (c *Configurator) getPluginsTab() fyne.CanvasObject {
+	content := container.NewVBox()
+	c.rebuildPluginsList(content)
+	return container.NewVScroll(content)
+}
+
+func (c *Configurator) rebuildPluginsList(content *fyne.Container) {
+	content.RemoveAll()
+
+	settings := c.settingsService.GetSettings()
+
+	// Configured plugins
+	for idx := range settings.Plugins {
+		content.Add(c.buildPluginCard(settings, idx, content))
+	}
+
+	// Reorder note
+	if len(settings.Plugins) > 0 {
+		note := widget.NewLabel(i18n.T("config.plugins_restart_note"))
+		note.TextStyle = fyne.TextStyle{Italic: true}
+		content.Add(note)
+	}
+
+	// Available but unconfigured plugins
+	available := c.discoverUnconfiguredPlugins(settings)
+	if len(available) > 0 {
+		content.Add(layout.NewSpacer())
+		content.Add(widget.NewLabel(i18n.T("config.plugins_available")))
+
+		for _, name := range available {
+			pluginName := name
+			addBtn := widget.NewButton(
+				fmt.Sprintf("%s  [%s]", pluginName, i18n.T("config.plugins_add")),
+				func() {
+					c.addPlugin(pluginName, content)
+				},
+			)
+			addBtn.Importance = widget.LowImportance
+			content.Add(addBtn)
+		}
+	} else if len(settings.Plugins) == 0 {
+		content.Add(widget.NewLabel(i18n.T("config.plugins_none_available")))
+	}
+
+	content.Refresh()
+}
+
+func (c *Configurator) buildPluginCard(
+	settings *linkquisition.Settings, idx int, listContainer *fyne.Container,
+) fyne.CanvasObject {
+	ps := settings.Plugins[idx]
+	pluginName := pluginDisplayName(ps.Path)
+
+	// Try to get metadata from the .so file
+	meta := c.getPluginMetadata(ps.Path)
+
+	// Title and description
+	title := widget.NewLabel(meta.Name)
+	title.TextStyle = fyne.TextStyle{Bold: true}
+
+	desc := widget.NewLabel(meta.Description)
+	desc.Wrapping = fyne.TextWrapWord
+
+	// Enable/disable toggle
+	enableCheck := widget.NewCheck(i18n.T("config.plugins_enabled"), func(checked bool) {
+		s := c.settingsService.GetSettings()
+		s.Plugins[idx].IsDisabled = !checked
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving plugin state", "error", err, "plugin", pluginName)
+		}
+	})
+	enableCheck.Checked = !ps.IsDisabled
+
+	// Configure button
+	configBtn := widget.NewButton(i18n.T("config.plugins_configure"), func() {
+		c.showPluginSettings(idx, listContainer)
+	})
+	configBtn.Importance = widget.LowImportance
+
+	// Only show configure button if plugin has settings
+	if len(meta.Settings) == 0 {
+		configBtn.Hide()
+	}
+
+	// Reorder buttons
+	upBtn := widget.NewButton(i18n.T("config.plugins_move_up"), func() {
+		c.movePlugin(idx, -1, listContainer)
+	})
+	upBtn.Importance = widget.LowImportance
+	if idx == 0 {
+		upBtn.Disable()
+	}
+
+	downBtn := widget.NewButton(i18n.T("config.plugins_move_down"), func() {
+		c.movePlugin(idx, 1, listContainer)
+	})
+	downBtn.Importance = widget.LowImportance
+	if idx == len(settings.Plugins)-1 {
+		downBtn.Disable()
+	}
+
+	// Layout
+	headerRow := container.NewBorder(
+		nil, nil,
+		container.NewHBox(title),
+		container.NewHBox(upBtn, downBtn, enableCheck),
+	)
+
+	actionRow := container.NewHBox(configBtn)
+
+	card := container.NewVBox(headerRow, desc, actionRow)
+
+	return widget.NewCard("", "", card)
+}
+
+func (c *Configurator) getPluginMetadata(pluginPath string) linkquisition.PluginMetadata {
+	path := c.resolvePluginPath(pluginPath)
+	if path == "" {
+		return linkquisition.PluginMetadata{
+			Name:        pluginDisplayName(pluginPath),
+			Description: "(plugin file not found)",
+		}
+	}
+
+	meta, err := probePluginMetadata(path, c.logger)
+	if err != nil {
+		c.logger.Warn("Failed to probe plugin metadata", "plugin", pluginPath, "error", err)
+		return linkquisition.PluginMetadata{
+			Name:        pluginDisplayName(pluginPath),
+			Description: "(unable to read plugin metadata)",
+		}
+	}
+
+	return meta
+}
+
+func (c *Configurator) resolvePluginPath(pluginPath string) string {
+	if !strings.HasSuffix(pluginPath, ".so") {
+		pluginPath += ".so"
+	}
+
+	if _, err := os.Stat(pluginPath); err == nil {
+		return pluginPath
+	}
+
+	resolved := filepath.Join(c.settingsService.GetPluginFolderPath(), pluginPath)
+	if _, err := os.Stat(resolved); err == nil {
+		return resolved
+	}
+
+	return ""
+}
+
+func (c *Configurator) movePlugin(idx, direction int, listContainer *fyne.Container) {
+	settings := c.settingsService.GetSettings()
+	newIdx := idx + direction
+
+	if newIdx < 0 || newIdx >= len(settings.Plugins) {
+		return
+	}
+
+	settings.Plugins[idx], settings.Plugins[newIdx] = settings.Plugins[newIdx], settings.Plugins[idx]
+
+	if err := c.settingsService.WriteSettings(settings); err != nil {
+		c.logger.Error("Error saving plugin order", "error", err)
+		return
+	}
+
+	c.rebuildPluginsList(listContainer)
+}
+
+func (c *Configurator) addPlugin(name string, listContainer *fyne.Container) {
+	settings := c.settingsService.GetSettings()
+
+	settings.Plugins = append(settings.Plugins, linkquisition.PluginSettings{
+		Path:       name + ".so",
+		IsDisabled: false,
+	})
+
+	if err := c.settingsService.WriteSettings(settings); err != nil {
+		c.logger.Error("Error adding plugin", "error", err, "plugin", name)
+		return
+	}
+
+	c.rebuildPluginsList(listContainer)
+}
+
+func (c *Configurator) discoverUnconfiguredPlugins(settings *linkquisition.Settings) []string {
+	pluginDir := c.settingsService.GetPluginFolderPath()
+
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		return nil
+	}
+
+	configured := make(map[string]bool, len(settings.Plugins))
+	for _, p := range settings.Plugins {
+		configured[strings.ToLower(pluginDisplayName(p.Path))] = true
+	}
+
+	var available []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".so") {
+			continue
+		}
+		baseName := strings.TrimSuffix(entry.Name(), ".so")
+		if !configured[strings.ToLower(baseName)] {
+			available = append(available, baseName)
+		}
+	}
+
+	return available
+}

--- a/cmd/configurator_plugins.go
+++ b/cmd/configurator_plugins.go
@@ -122,7 +122,7 @@ func (c *Configurator) buildPluginCard(
 
 func (c *Configurator) buildAvailablePluginRow(name string, listContainer *fyne.Container) fyne.CanvasObject {
 	pluginName := name
-	meta := c.getPluginMetadata(pluginName + ".so")
+	meta := c.getPluginMetadata(pluginName + pluginExtension)
 
 	title := widget.NewLabel(meta.Name)
 	title.TextStyle = fyne.TextStyle{Bold: true}
@@ -162,8 +162,8 @@ func (c *Configurator) getPluginMetadata(pluginPath string) linkquisition.Plugin
 }
 
 func (c *Configurator) resolvePluginPath(pluginPath string) string {
-	if !strings.HasSuffix(pluginPath, ".so") {
-		pluginPath += ".so"
+	if !strings.HasSuffix(pluginPath, pluginExtension) {
+		pluginPath += pluginExtension
 	}
 
 	if _, err := os.Stat(pluginPath); err == nil {
@@ -200,7 +200,7 @@ func (c *Configurator) addPlugin(name string, listContainer *fyne.Container) {
 	settings := c.settingsService.GetSettings()
 
 	settings.Plugins = append(settings.Plugins, linkquisition.PluginSettings{
-		Path:       name + ".so",
+		Path:       name + pluginExtension,
 		IsDisabled: false,
 	})
 
@@ -227,10 +227,10 @@ func (c *Configurator) discoverUnconfiguredPlugins(settings *linkquisition.Setti
 
 	var available []string
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".so") {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), pluginExtension) {
 			continue
 		}
-		baseName := strings.TrimSuffix(entry.Name(), ".so")
+		baseName := strings.TrimSuffix(entry.Name(), pluginExtension)
 		if !configured[strings.ToLower(baseName)] {
 			available = append(available, baseName)
 		}

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -106,5 +106,41 @@
   },
   "plugin.warn_proceed": {
     "other": "Open anyway"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Enabled"
+  },
+  "config.plugins_configure": {
+    "other": "Configure..."
+  },
+  "config.plugins_add": {
+    "other": "Add"
+  },
+  "config.plugins_available": {
+    "other": "Available (not configured):"
+  },
+  "config.plugins_none_available": {
+    "other": "No additional plugins available."
+  },
+  "config.plugins_settings_title": {
+    "other": "{{.Name}} Settings"
+  },
+  "config.plugins_save": {
+    "other": "Save"
+  },
+  "config.plugins_cancel": {
+    "other": "Cancel"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Plugin changes take effect on next URL open."
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -106,5 +106,41 @@
   },
   "plugin.warn_proceed": {
     "other": "Abrir de todos modos"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Activado"
+  },
+  "config.plugins_configure": {
+    "other": "Configurar..."
+  },
+  "config.plugins_add": {
+    "other": "Añadir"
+  },
+  "config.plugins_available": {
+    "other": "Disponibles (no configurados):"
+  },
+  "config.plugins_none_available": {
+    "other": "No hay plugins adicionales disponibles."
+  },
+  "config.plugins_settings_title": {
+    "other": "Ajustes de {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Guardar"
+  },
+  "config.plugins_cancel": {
+    "other": "Cancelar"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Los cambios de plugins se aplican en la próxima apertura de URL."
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -106,5 +106,41 @@
   },
   "plugin.warn_proceed": {
     "other": "Avaa silti"
+  },
+  "config.tab_plugins": {
+    "other": "Lisäosat"
+  },
+  "config.plugins_enabled": {
+    "other": "Käytössä"
+  },
+  "config.plugins_configure": {
+    "other": "Asetukset..."
+  },
+  "config.plugins_add": {
+    "other": "Lisää"
+  },
+  "config.plugins_available": {
+    "other": "Saatavilla (ei määritetty):"
+  },
+  "config.plugins_none_available": {
+    "other": "Ei lisäosia saatavilla."
+  },
+  "config.plugins_settings_title": {
+    "other": "{{.Name}} — asetukset"
+  },
+  "config.plugins_save": {
+    "other": "Tallenna"
+  },
+  "config.plugins_cancel": {
+    "other": "Peruuta"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Muutokset tulevat voimaan seuraavalla URL-avauksella."
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -106,5 +106,41 @@
   },
   "plugin.warn_proceed": {
     "other": "Öppna ändå"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Aktiverad"
+  },
+  "config.plugins_configure": {
+    "other": "Konfigurera..."
+  },
+  "config.plugins_add": {
+    "other": "Lägg till"
+  },
+  "config.plugins_available": {
+    "other": "Tillgängliga (ej konfigurerade):"
+  },
+  "config.plugins_none_available": {
+    "other": "Inga ytterligare plugins tillgängliga."
+  },
+  "config.plugins_settings_title": {
+    "other": "Inställningar för {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Spara"
+  },
+  "config.plugins_cancel": {
+    "other": "Avbryt"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Pluginändringar träder i kraft vid nästa URL-öppning."
   }
 }


### PR DESCRIPTION
## Summary

Adds a "Plugins" tab to the configurator GUI, allowing users to manage and configure plugins without editing `config.json` manually.

## Features

- **Plugin list** — shows all configured plugins as cards with name, description (probed from the `.so` metadata), and an enable/disable toggle
- **Plugin settings** — "Configure..." opens a dialog with auto-generated form widgets based on `PluginSettingDescriptor` metadata:
  - `Bool` → checkbox
  - `Choice` → dropdown select
  - `Int` → validated number entry
  - `String` / `Duration` → text entry (with placeholder for durations)
  - `StringList` → multi-line text entry (one item per line)
- **Reorder** — ▲/▼ buttons to change plugin processing order
- **Add plugins** — unconfigured `.so` files in the plugin folder are listed with metadata and an "Add" button
- **Vertical-only scrolling** — no horizontal scroll anywhere

## Technical details

- `probePluginMetadata()` opens a `.so` and calls `Metadata()` without invoking `Setup()` — safe for the configurator which doesn't process URLs
- Settings dialog uses `container.NewVScroll` with a minimum width to prevent content clipping
- Configurator window is now resizable (650×550 default) to accommodate plugin list scrolling
- All buttons use default importance for consistent visibility in dark/light themes

## Commits

1. `feat: add Plugins tab to configurator GUI` — core implementation
2. `docs: add commit conventions section to AGENTS.md`
3. `fix: improve plugin tab button visibility and available list layout` — dark mode fix, available plugins as cards

## Checklist

- [x] Builds cleanly
- [x] All existing tests pass
- [x] i18n keys added (en, fi, es, sv)
- [x] Buttons visible in both light and dark themes
- [x] No horizontal scrolling
- [x] Plugin changes take effect on next URL open (no restart required)