### PR TITLE
feat: universal macOS binary and Homebrew tap distribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,9 +66,9 @@ jobs:
           - target: linux-amd64
             os: ubuntu-latest
             artifact: linkquisition-linux-amd64
-          - target: darwin-arm64
+          - target: darwin-universal
             os: macos-latest
-            artifact: Linkquisition_macOS_arm64.zip
+            artifact: Linkquisition_macOS_universal.zip
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -112,12 +112,11 @@ jobs:
           VERSION: v${{ needs.version.outputs.version }}
 
       - name: Package macOS .app
-        if: matrix.target == 'darwin-arm64'
+        if: matrix.target == 'darwin-universal'
         run: |
           task package:app
-          task build:plugins-darwin
           codesign --force --deep --sign - dist/Linkquisition.app
-          cd dist && ditto -c -k --keepParent Linkquisition.app Linkquisition_macOS_arm64.zip
+          cd dist && ditto -c -k --keepParent Linkquisition.app Linkquisition_macOS_universal.zip
         env:
           VERSION: ${{ needs.version.outputs.version }}
 
@@ -162,7 +161,7 @@ jobs:
       - name: Download macOS artifact
         uses: actions/download-artifact@v8
         with:
-          name: darwin-arm64
+          name: darwin-universal
           path: artifacts/
 
       - uses: go-semantic-release/action@v1
@@ -176,9 +175,44 @@ jobs:
 
       - name: Upload macOS asset to release
         if: steps.semrel.outputs.version != ''
-        run: gh release upload "v${{ steps.semrel.outputs.version }}" artifacts/Linkquisition_macOS_arm64.zip --clobber
+        run: gh release upload "v${{ steps.semrel.outputs.version }}" artifacts/Linkquisition_macOS_universal.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Tap
+    needs: [ version, release ]
+    if: needs.version.outputs.new_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: darwin-universal
+          path: artifacts/
+
+      - name: Update Homebrew Cask
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          SHA256=$(sha256sum artifacts/Linkquisition_macOS_universal.zip | awk '{print $1}')
+
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/Strobotti/homebrew-linkquisition.git tap
+          cd tap
+
+          mkdir -p Casks
+          sed -e "s/\${VERSION}/${VERSION}/g" \
+              -e "s/\${SHA256}/${SHA256}/g" \
+              ../homebrew/Casks/linkquisition.rb > Casks/linkquisition.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/linkquisition.rb
+          git commit -m "Update linkquisition to v${VERSION}" || echo "No changes to commit"
+          git push
 
   coverage:
     name: Coverage Badge

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           SHA256=$(sha256sum artifacts/Linkquisition_macOS_universal.zip | awk '{print $1}')
 
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/Strobotti/homebrew-linkquisition.git tap
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/Strobotti/homebrew-tap.git tap
           cd tap
 
           mkdir -p Casks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@ When making changes, ensure ALL relevant documentation is updated:
 - [ ] Update the "Command-line interface" section in `README.md`
 - [ ] Add new subcommands via `rootCmd.AddCommand()` in `cmd/root.go` `initRootCmd()`
 
+### When changing macOS packaging or app identity
+
+- [ ] Update `package/darwin/Info.plist` — bundle metadata, URL schemes, version keys
+- [ ] If adding new URL schemes or entitlements, update the plist accordingly
+- [ ] If changing the minimum macOS version, update `LSMinimumSystemVersion`
+- [ ] Update `homebrew/Casks/linkquisition.rb` if install paths or dependencies change
+
 ## Plugin system conventions
 
 - Plugins export `var Plugin <type>` as a package-level variable (value type, not pointer)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ you to set it as the default browser and scan for installed browsers for faster 
 #### Via Homebrew (recommended)
 
 ```bash
-brew tap strobotti/linkquisition
+brew tap strobotti/tap
 brew install --cask linkquisition
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,28 @@ able to press `Super`-key in Ubuntu and type "Linkquisition" to see the launcher
 `linkquisition` command. Launching the application without any arguments will show the configuration screen which allows
 you to set it as the default browser and scan for installed browsers for faster startup and easier configuration.
 
-### macOS (experimental)
+### macOS
 
-Download the latest `Linkquisition_macOS_arm64.zip` from
+#### Via Homebrew (recommended)
+
+```bash
+brew tap strobotti/linkquisition
+brew install --cask linkquisition
+```
+
+Since the app is not notarized with Apple, macOS will block it on first launch. To fix this, run:
+
+```bash
+xattr -cr /Applications/Linkquisition.app
+```
+
+#### Manual installation
+
+Download the latest `Linkquisition_macOS_universal.zip` from
 the [releases page](https://github.com/Strobotti/linkquisition/releases), unzip it, and move
 `Linkquisition.app` to `/Applications`.
+
+The universal binary supports both Apple Silicon (arm64) and Intel (amd64) Macs.
 
 Since the app is not notarized with Apple, macOS will block it on first launch. To fix this, run:
 

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -10,11 +10,12 @@ tasks:
     vars:
       OUTPUT: '{{default "linkquisition" .OUTPUT}}'
       TARGET: '{{default "linux" .TARGET}}'
+      ARCH: '{{default "" .ARCH}}'
       VERSION:
         sh: echo ${VERSION:-v0.0.0}
       OPTIONS: '{{default "" .DEVOPTIONS}}'
     cmds:
-      - CGO_ENABLED=1 GOOS={{.TARGET}} go build -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
+      - CGO_ENABLED=1 GOOS={{.TARGET}} {{if .ARCH}}GOARCH={{.ARCH}}{{end}} go build -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
       - echo "bin/{{.OUTPUT}}{{exeExt}} created successfully"
     sources:
       - ./**/*.go
@@ -29,6 +30,7 @@ tasks:
         vars:
           OUTPUT: "linkquisition-linux-amd64"
           TARGET: "linux"
+          ARCH: "amd64"
 
   darwin-arm64:
     cmds:
@@ -36,6 +38,7 @@ tasks:
         vars:
           OUTPUT: "linkquisition-darwin-arm64"
           TARGET: "darwin"
+          ARCH: "arm64"
 
   darwin-amd64:
     cmds:
@@ -43,6 +46,15 @@ tasks:
         vars:
           OUTPUT: "linkquisition-darwin-amd64"
           TARGET: "darwin"
+          ARCH: "amd64"
+
+  darwin-universal:
+    description: "Builds a universal macOS binary (arm64 + amd64) using lipo"
+    cmds:
+      - task: darwin-arm64
+      - task: darwin-amd64
+      - lipo -create -output bin/linkquisition-darwin-universal bin/linkquisition-darwin-arm64 bin/linkquisition-darwin-amd64
+      - echo "bin/linkquisition-darwin-universal created successfully"
 
   plugins:
     cmds:

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -38,13 +38,13 @@ tasks:
       - dpkg-deb --build package/linux dist/linkquisition_{{.VERSION}}_linux_amd64.deb
 
   app:
-    description: "Builds a macOS .app bundle and optionally installs it"
+    description: "Builds a macOS .app bundle with a universal binary (arm64 + amd64)"
     cmds:
-      - task build:darwin-arm64
+      - task build:darwin-universal
       - rm -rf dist/Linkquisition.app
       - mkdir -p dist/Linkquisition.app/Contents/MacOS
       - mkdir -p dist/Linkquisition.app/Contents/Resources
-      - cp bin/linkquisition-darwin-arm64 dist/Linkquisition.app/Contents/MacOS/linkquisition
+      - cp bin/linkquisition-darwin-universal dist/Linkquisition.app/Contents/MacOS/linkquisition
       - task build:plugins-darwin
       - sed 's/${VERSION}/{{.VERSION}}/g' package/darwin/Info.plist > dist/Linkquisition.app/Contents/Info.plist
       - sips -s format icns Icon.png --out dist/Linkquisition.app/Contents/Resources/Icon.icns 2>/dev/null || cp Icon.png dist/Linkquisition.app/Contents/Resources/Icon.icns

--- a/homebrew/Casks/linkquisition.rb
+++ b/homebrew/Casks/linkquisition.rb
@@ -1,0 +1,25 @@
+cask "linkquisition" do
+  version "${VERSION}"
+  sha256 "${SHA256}"
+
+  url "https://github.com/Strobotti/linkquisition/releases/download/v#{version}/Linkquisition_macOS_universal.zip"
+  name "Linkquisition"
+  desc "Fast, configurable browser-picker for macOS and Linux"
+  homepage "https://github.com/Strobotti/linkquisition"
+
+  depends_on macos: ">= :big_sur"
+
+  app "Linkquisition.app"
+
+  binary "#{appdir}/Linkquisition.app/Contents/MacOS/linkquisition"
+
+  zap trash: [
+    "~/Library/Application Support/linkquisition",
+    "~/Library/Logs/linkquisition",
+  ]
+
+  caveats <<~EOS
+    This app is not notarized by Apple. After installation, run:
+      xattr -cr /Applications/Linkquisition.app
+  EOS
+end

--- a/package/darwin/Info.plist
+++ b/package/darwin/Info.plist
@@ -10,6 +10,8 @@
     <string>Linkquisition</string>
     <key>CFBundleDisplayName</key>
     <string>Linkquisition</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
     <key>CFBundleVersion</key>
     <string>${VERSION}</string>
     <key>CFBundleShortVersionString</key>
@@ -18,6 +20,10 @@
     <string>Icon.icns</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.utilities</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © Juha Jantunen. All rights reserved.</string>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>
@@ -33,6 +39,10 @@
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
     <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticTermination</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Adds Intel Mac support and sets up automated Homebrew cask distribution.

## Changes

- Build a universal macOS binary (arm64 + amd64) using `lipo`
- Add `build:darwin-universal` task and update `package:app` to use it
- Release artifact renamed from `Linkquisition_macOS_arm64.zip` to `Linkquisition_macOS_universal.zip`
- Add Homebrew cask formula template (`homebrew/Casks/linkquisition.rb`)
- Add `update-homebrew` CI job that pushes to `Strobotti/homebrew-tap` on release
- Enrich `Info.plist` with missing Apple metadata
- Document macOS packaging checklist in `AGENTS.md`

## Installation (after first release)

```bash
brew tap strobotti/tap
brew install --cask linkquisition
```

## Setup required

- [x] Create `Strobotti/homebrew-tap` repo
- [x] Add `TAP_GITHUB_TOKEN` secret (fine-grained PAT with Contents write access to the tap repo)

## Notes

- The tap is updated automatically on each semantic-release
- The app is not notarized — cask includes a `caveats` block instructing users to run `xattr -cr`