### PR TITLE
chore: update Flatpak metainfo for v2.4.0

### DIFF
--- a/flatpak/io.github.strobotti.linkquisition.metainfo.xml
+++ b/flatpak/io.github.strobotti.linkquisition.metainfo.xml
@@ -49,6 +49,11 @@
     <content_rating type="oars-1.1"/>
 
     <releases>
+    <release version="2.4.0" date="2026-07-07">
+      <description>
+        <p>See https://github.com/Strobotti/linkquisition/releases/tag/v2.4.0 for details.</p>
+      </description>
+    </release>
     </releases>
 
     <screenshots>


### PR DESCRIPTION
Automated update of the Flatpak metainfo release entry for v2.4.0.