### PR TITLE
Fix browser icon loading for user-installed browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ the [releases page](https://github.com/Strobotti/linkquisition/releases).
 
 #### .deb package (Ubuntu/Debian)
 
-The `.deb` package contains everything needed to launch the application using the desktop-environment, e.g. you should be
+The `.deb` package contains everything needed to launch the application using the desktop-environment, e.g. you should
+be
 able to press `Super`-key in Ubuntu and type "Linkquisition" to see the launcher. To do the same in terminal just run
 `linkquisition` command. Launching the application without any arguments will show the configuration screen which allows
 you to set it as the default browser and scan for installed browsers for faster startup and easier configuration.
@@ -114,6 +115,7 @@ it will be treated as a different browser and might be removed if not safe-guard
     {
       "name": "Microsoft Edge",
       "command": "/usr/bin/microsoft-edge-stable %U",
+      "iconPath": "/usr/share/icons/hicolor/128x128/apps/microsoft-edge.png",
       "hidden": false,
       "source": "auto",
       "matches": [
@@ -126,6 +128,7 @@ it will be treated as a different browser and might be removed if not safe-guard
     {
       "name": "Firefox",
       "command": "firefox %u",
+      "iconPath": "/usr/share/icons/hicolor/128x128/apps/firefox.png",
       "hidden": false,
       "source": "auto",
       "matches": [

--- a/browser_service.go
+++ b/browser_service.go
@@ -1,8 +1,9 @@
 package linkquisition
 
 type Browser struct {
-	Name    string
-	Command string
+	Name     string
+	Command  string
+	IconPath string
 }
 
 type BrowserService interface {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
+	"github.com/strobotti/linkquisition/resources"
 
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
@@ -152,10 +153,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	w.SetFixedSize(true)
 	w.Resize(fyne.NewSize(600, 50)) //nolint:mnd
 	w.CenterOnScreen()
-
-	if icon, err := fyne.LoadResourceFromPath("Icon.png"); err == nil {
-		w.SetIcon(icon)
-	}
+	w.SetIcon(resources.LinkquisitionIcon)
 
 	w.SetContent(container.NewVBox(widgets...))
 

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -11,10 +11,10 @@ import (
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
-	"github.com/strobotti/linkquisition/resources"
 
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
+	"github.com/strobotti/linkquisition/resources"
 )
 
 type BrowserPicker struct {

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -65,7 +65,7 @@ func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
 	content.Refresh()
 }
 
-func (c *Configurator) buildBrowserIconPreview(b linkquisition.BrowserSettings) fyne.CanvasObject {
+func (c *Configurator) buildBrowserIconPreview(b *linkquisition.BrowserSettings) fyne.CanvasObject {
 	browser := linkquisition.Browser{
 		Name:     b.Name,
 		Command:  b.Command,
@@ -88,7 +88,7 @@ func (c *Configurator) buildBrowserCard(
 	b := settings.Browsers[idx]
 
 	// Icon preview
-	iconWidget := c.buildBrowserIconPreview(b)
+	iconWidget := c.buildBrowserIconPreview(&b)
 
 	// Title
 	title := widget.NewLabel(b.Name)

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
@@ -68,6 +69,22 @@ func (c *Configurator) buildBrowserCard(
 	settings *linkquisition.Settings, idx int, listContainer *fyne.Container,
 ) fyne.CanvasObject {
 	b := settings.Browsers[idx]
+
+	// Icon preview
+	var iconWidget fyne.CanvasObject
+	browser := linkquisition.Browser{
+		Name:     b.Name,
+		Command:  b.Command,
+		IconPath: b.IconPath,
+	}
+	iconBytes, err := c.browserService.GetIconForBrowser(browser)
+	if err == nil && len(iconBytes) > 0 {
+		iconRes := fyne.NewStaticResource("browser-icon.png", iconBytes)
+		img := canvas.NewImageFromResource(iconRes)
+		img.SetMinSize(fyne.NewSize(32, 32)) //nolint:mnd
+		img.FillMode = canvas.ImageFillContain
+		iconWidget = img
+	}
 
 	// Title
 	title := widget.NewLabel(b.Name)
@@ -135,14 +152,32 @@ func (c *Configurator) buildBrowserCard(
 		rulesLabel.TextStyle = fyne.TextStyle{Italic: true}
 	}
 
+	// Icon path (read-only display)
+	var iconPathLabel *widget.Label
+	if b.IconPath != "" {
+		iconPathLabel = widget.NewLabel(b.IconPath)
+		iconPathLabel.TextStyle = fyne.TextStyle{Italic: true}
+		iconPathLabel.Truncation = fyne.TextTruncateEllipsis
+	}
+
 	// Layout
+	var titleRow fyne.CanvasObject
+	if iconWidget != nil {
+		titleRow = container.NewHBox(iconWidget, title, sourceLabel)
+	} else {
+		titleRow = container.NewHBox(title, sourceLabel)
+	}
+
 	headerRow := container.NewBorder(
 		nil, nil,
-		container.NewHBox(title, sourceLabel),
+		titleRow,
 		container.NewHBox(upBtn, downBtn),
 	)
 
 	cardContent := container.NewVBox(headerRow, command)
+	if iconPathLabel != nil {
+		cardContent.Add(iconPathLabel)
+	}
 	if rulesLabel != nil {
 		cardContent.Add(rulesLabel)
 	}
@@ -176,9 +211,13 @@ func (c *Configurator) showAddBrowserDialog(listContainer *fyne.Container) {
 	commandEntry := widget.NewEntry()
 	commandEntry.SetPlaceHolder(i18n.T("config.browsers_command_placeholder"))
 
+	iconPathEntry := widget.NewEntry()
+	iconPathEntry.SetPlaceHolder(i18n.T("config.browsers_icon_path_placeholder"))
+
 	form := widget.NewForm(
 		widget.NewFormItem(i18n.T("config.browsers_name"), nameEntry),
 		widget.NewFormItem(i18n.T("config.browsers_command"), commandEntry),
+		widget.NewFormItem(i18n.T("config.browsers_icon_path"), iconPathEntry),
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -199,22 +238,23 @@ func (c *Configurator) showAddBrowserDialog(listContainer *fyne.Container) {
 			if nameEntry.Text == "" || commandEntry.Text == "" {
 				return
 			}
-			c.addManualBrowser(nameEntry.Text, commandEntry.Text, listContainer)
+			c.addManualBrowser(nameEntry.Text, commandEntry.Text, iconPathEntry.Text, listContainer)
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 250)) //nolint:mnd
 	d.Show()
 }
 
-func (c *Configurator) addManualBrowser(name, command string, listContainer *fyne.Container) {
+func (c *Configurator) addManualBrowser(name, command, iconPath string, listContainer *fyne.Container) {
 	settings := c.settingsService.GetSettings()
 
 	settings.Browsers = append(settings.Browsers, linkquisition.BrowserSettings{
-		Name:    name,
-		Command: command,
-		Hidden:  false,
-		Source:  linkquisition.SourceManual,
+		Name:     name,
+		Command:  command,
+		IconPath: iconPath,
+		Hidden:   false,
+		Source:   linkquisition.SourceManual,
 	})
 
 	if err := c.settingsService.WriteSettings(settings); err != nil {
@@ -235,9 +275,14 @@ func (c *Configurator) showEditBrowserDialog(idx int, listContainer *fyne.Contai
 	commandEntry := widget.NewEntry()
 	commandEntry.SetText(b.Command)
 
+	iconPathEntry := widget.NewEntry()
+	iconPathEntry.SetPlaceHolder(i18n.T("config.browsers_icon_path_placeholder"))
+	iconPathEntry.SetText(b.IconPath)
+
 	form := widget.NewForm(
 		widget.NewFormItem(i18n.T("config.browsers_name"), nameEntry),
 		widget.NewFormItem(i18n.T("config.browsers_command"), commandEntry),
+		widget.NewFormItem(i18n.T("config.browsers_icon_path"), iconPathEntry),
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -261,6 +306,7 @@ func (c *Configurator) showEditBrowserDialog(idx int, listContainer *fyne.Contai
 			s := c.settingsService.GetSettings()
 			s.Browsers[idx].Name = nameEntry.Text
 			s.Browsers[idx].Command = commandEntry.Text
+			s.Browsers[idx].IconPath = iconPathEntry.Text
 			if err := c.settingsService.WriteSettings(s); err != nil {
 				c.logger.Error("Error saving browser edit", "error", err)
 				return
@@ -269,7 +315,7 @@ func (c *Configurator) showEditBrowserDialog(idx int, listContainer *fyne.Contai
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 250)) //nolint:mnd
 	d.Show()
 }
 

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -65,26 +65,30 @@ func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
 	content.Refresh()
 }
 
-func (c *Configurator) buildBrowserCard(
-	settings *linkquisition.Settings, idx int, listContainer *fyne.Container,
-) fyne.CanvasObject {
-	b := settings.Browsers[idx]
-
-	// Icon preview
-	var iconWidget fyne.CanvasObject
+func (c *Configurator) buildBrowserIconPreview(b linkquisition.BrowserSettings) fyne.CanvasObject {
 	browser := linkquisition.Browser{
 		Name:     b.Name,
 		Command:  b.Command,
 		IconPath: b.IconPath,
 	}
 	iconBytes, err := c.browserService.GetIconForBrowser(browser)
-	if err == nil && len(iconBytes) > 0 {
-		iconRes := fyne.NewStaticResource("browser-icon.png", iconBytes)
-		img := canvas.NewImageFromResource(iconRes)
-		img.SetMinSize(fyne.NewSize(32, 32)) //nolint:mnd
-		img.FillMode = canvas.ImageFillContain
-		iconWidget = img
+	if err != nil || len(iconBytes) == 0 {
+		return nil
 	}
+	iconRes := fyne.NewStaticResource("browser-icon.png", iconBytes)
+	img := canvas.NewImageFromResource(iconRes)
+	img.SetMinSize(fyne.NewSize(32, 32)) //nolint:mnd
+	img.FillMode = canvas.ImageFillContain
+	return img
+}
+
+func (c *Configurator) buildBrowserCard(
+	settings *linkquisition.Settings, idx int, listContainer *fyne.Container,
+) fyne.CanvasObject {
+	b := settings.Browsers[idx]
+
+	// Icon preview
+	iconWidget := c.buildBrowserIconPreview(b)
 
 	// Title
 	title := widget.NewLabel(b.Name)

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
@@ -26,9 +28,10 @@ func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
 		emptyLabel := widget.NewLabel(i18n.T("config.browsers_empty"))
 		emptyLabel.Wrapping = fyne.TextWrapWord
 
-		scanBtn := widget.NewButton(i18n.T("config.scan_browsers"), func() {
-			c.scanBrowsersAndRebuild(content)
-		})
+		scanBtn := widget.NewButton(i18n.T("config.scan_browsers"), nil)
+		scanBtn.OnTapped = func() {
+			c.scanBrowsersAndRebuild(content, scanBtn)
+		}
 		scanBtn.Importance = widget.HighImportance
 
 		content.Add(emptyLabel)
@@ -48,9 +51,10 @@ func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
 	// Action buttons at the bottom
 	content.Add(layout.NewSpacer())
 
-	scanBtn := widget.NewButton(i18n.T("config.rescan_browsers"), func() {
-		c.scanBrowsersAndRebuild(content)
-	})
+	scanBtn := widget.NewButton(i18n.T("config.rescan_browsers"), nil)
+	scanBtn.OnTapped = func() {
+		c.scanBrowsersAndRebuild(content, scanBtn)
+	}
 
 	addBtn := widget.NewButton(i18n.T("config.browsers_add"), func() {
 		c.showAddBrowserDialog(content)
@@ -298,12 +302,26 @@ func (c *Configurator) confirmDeleteBrowser(idx int, listContainer *fyne.Contain
 	)
 }
 
-func (c *Configurator) scanBrowsersAndRebuild(listContainer *fyne.Container) {
+func (c *Configurator) scanBrowsersAndRebuild(listContainer *fyne.Container, btn *widget.Button) {
+	originalText := btn.Text
+	btn.SetText(i18n.T("config.scan_browsers_scanning"))
+	btn.Disable()
+
 	go func() {
 		if err := c.settingsService.ScanBrowsers(); err != nil {
 			c.logger.Error("Error scanning browsers", "error", err)
+			btn.SetText(originalText)
+			btn.Enable()
+
+			windows := c.fapp.Driver().AllWindows()
+			if len(windows) > 0 {
+				dialog.ShowError(err, windows[0])
+			}
 			return
 		}
-		c.rebuildBrowsersList(listContainer)
+		btn.SetText(i18n.T("config.scan_browsers_done"))
+		time.AfterFunc(time.Second, func() {
+			c.rebuildBrowsersList(listContainer)
+		})
 	}()
 }

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -45,6 +45,12 @@ and *rule* subcommands).
 *command* (string)
 	Command to execute. Use _%U_ or _%u_ as the URL placeholder.
 
+*iconPath* (string, optional)
+	Absolute path to the browser icon file (e.g. _.png_). Populated
+	automatically during browser scan from the _.desktop_ file's _Icon=_
+	field. Can be set manually for custom browsers that are not discovered
+	by scan.
+
 *hidden* (boolean)
 	If _true_, the browser is not shown in the picker but rules still apply.
 
@@ -92,6 +98,7 @@ and *rule* subcommands).
     {
       "name": "Firefox",
       "command": "firefox %u",
+      "iconPath": "/usr/share/icons/hicolor/128x128/apps/firefox.png",
       "hidden": false,
       "source": "auto",
       "matches": [

--- a/internal/freedesktop/browser_icon_loader.go
+++ b/internal/freedesktop/browser_icon_loader.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/resources"
 )
 
 // BrowserIconLoader loads browser icons and resolves icon names to file paths.
@@ -44,13 +45,8 @@ func (l *DefaultBrowserIconLoader) LoadIcon(browser linkquisition.Browser) ([]by
 		}
 	}
 
-	// As a fallback we'll use the application icon
-	icon, err := fyne.LoadResourceFromPath("Icon.png")
-	if err != nil {
-		return nil, err
-	}
-
-	return icon.Content(), nil
+	// As a fallback we'll use the bundled application icon
+	return resources.LinkquisitionIcon.Content(), nil
 }
 
 // resolveIconPathForCommand finds the icon path for a browser command by looking up

--- a/internal/freedesktop/browser_icon_loader.go
+++ b/internal/freedesktop/browser_icon_loader.go
@@ -12,38 +12,125 @@ import (
 	"github.com/strobotti/linkquisition"
 )
 
+// BrowserIconLoader loads browser icons and resolves icon names to file paths.
 type BrowserIconLoader interface {
 	LoadIcon(browser linkquisition.Browser) ([]byte, error)
+	// ResolveIconName resolves an icon name (from a .desktop file's Icon= field) to an
+	// absolute file path. If the name is already an absolute path and the file exists,
+	// it is returned as-is. Otherwise, it searches standard icon directories.
+	// Returns an empty string if the icon cannot be found.
+	ResolveIconName(iconName string) string
 }
 
+// DefaultBrowserIconLoader is the standard implementation of BrowserIconLoader.
 type DefaultBrowserIconLoader struct {
 	XdgService          *XdgService
 	DesktopEntryService *DesktopEntryService
 }
 
 func (l *DefaultBrowserIconLoader) LoadIcon(browser linkquisition.Browser) ([]byte, error) {
-	dePath, err := l.XdgService.GetDesktopEntryPathForBinary(browser.Command)
-	if err != nil {
-		return nil, err
-	}
-
-	desktopEntry, err := l.DesktopEntryService.CreateFromPath(dePath)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the icon field is already a full path, use it directly
-	if strings.HasPrefix(desktopEntry.Icon, "/") {
-		if icon, errLoad := fyne.LoadResourceFromPath(desktopEntry.Icon); errLoad == nil {
+	// If the browser has a cached icon path, use it directly
+	if browser.IconPath != "" {
+		if icon, errLoad := fyne.LoadResourceFromPath(browser.IconPath); errLoad == nil {
 			return icon.Content(), nil
 		}
 	}
 
-	// Search for the icon in /usr/share/icons
-	iconName := desktopEntry.Icon
+	// Fall back to resolving from .desktop entry
+	iconPath := l.resolveIconPathForCommand(browser.Command)
+	if iconPath != "" {
+		if icon, errLoad := fyne.LoadResourceFromPath(iconPath); errLoad == nil {
+			return icon.Content(), nil
+		}
+	}
+
+	// As a fallback we'll use the application icon
+	icon, err := fyne.LoadResourceFromPath("Icon.png")
+	if err != nil {
+		return nil, err
+	}
+
+	return icon.Content(), nil
+}
+
+// resolveIconPathForCommand finds the icon path for a browser command by looking up
+// the .desktop entry and resolving its Icon field to an absolute path.
+func (l *DefaultBrowserIconLoader) resolveIconPathForCommand(command string) string {
+	dePath, err := l.XdgService.GetDesktopEntryPathForBinary(command)
+	if err != nil {
+		return ""
+	}
+
+	desktopEntry, err := l.DesktopEntryService.CreateFromPath(dePath)
+	if err != nil {
+		return ""
+	}
+
+	return l.ResolveIconName(desktopEntry.Icon)
+}
+
+// ResolveIconName resolves an icon name (from a .desktop file's Icon= field) to an
+// absolute file path. If the name is already an absolute path and the file exists,
+// it is returned as-is. Otherwise, it searches standard icon directories.
+// Returns an empty string if the icon cannot be found.
+func (l *DefaultBrowserIconLoader) ResolveIconName(iconName string) string {
+	if iconName == "" {
+		return ""
+	}
+
+	// If the icon field is already a full path, use it directly if it exists
+	if filepath.IsAbs(iconName) {
+		if _, err := os.Stat(iconName); err == nil {
+			return iconName
+		}
+		return ""
+	}
+
+	// Search for the icon by name in standard icon directories
+	return findIconByName(iconName)
+}
+
+// findIconByName searches for an icon file matching the given name (without extension)
+// in standard icon directories, including user-local paths.
+func findIconByName(iconName string) string {
+	iconDirs := getIconSearchDirs()
+
+	for _, dir := range iconDirs {
+		if path := searchDirForIcon(dir, iconName); path != "" {
+			return path
+		}
+	}
+
+	return ""
+}
+
+// getIconSearchDirs returns the list of directories to search for icons,
+// including user-local directories.
+func getIconSearchDirs() []string {
+	var dirs []string
+
+	// User-local icons ($XDG_DATA_HOME/icons/)
+	dataHome, isset := os.LookupEnv("XDG_DATA_HOME")
+	if !isset {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataHome = filepath.Join(home, ".local", "share")
+		}
+	}
+	if dataHome != "" {
+		dirs = append(dirs, filepath.Join(dataHome, "icons"))
+	}
+
+	// System icon directories
+	dirs = append(dirs, "/usr/share/icons", "/usr/share/pixmaps")
+
+	return dirs
+}
+
+// searchDirForIcon walks a directory tree looking for an icon file matching the given name.
+func searchDirForIcon(dir, iconName string) string {
 	var foundPath string
 
-	_ = filepath.WalkDir("/usr/share/icons", func(path string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return filepath.SkipDir
 		}
@@ -62,17 +149,5 @@ func (l *DefaultBrowserIconLoader) LoadIcon(browser linkquisition.Browser) ([]by
 		return nil
 	})
 
-	if foundPath != "" {
-		if icon, errLoad := fyne.LoadResourceFromPath(foundPath); errLoad == nil {
-			return icon.Content(), nil
-		}
-	}
-
-	// As a fallback we'll use the application icon
-	icon, err := fyne.LoadResourceFromPath("Icon.png")
-	if err != nil {
-		return nil, err
-	}
-
-	return icon.Content(), nil
+	return foundPath
 }

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -60,8 +60,9 @@ func (b *BrowserService) GetAvailableBrowsers() ([]linkquisition.Browser, error)
 			}
 
 			browser := linkquisition.Browser{
-				Name:    desktopEntry.Name,
-				Command: desktopEntry.Exec,
+				Name:     desktopEntry.Name,
+				Command:  desktopEntry.Exec,
+				IconPath: b.BrowserIconLoader.ResolveIconName(desktopEntry.Icon),
 			}
 			browsers = append(browsers, browser)
 		}

--- a/internal/freedesktop/browser_service_test.go
+++ b/internal/freedesktop/browser_service_test.go
@@ -383,6 +383,13 @@ func TestExtractExecutable_ExpandsTilde(t *testing.T) {
 	assert.Equal(t, expected, extractExecutable("~/.local/share/firefox-dev/firefox --name firefox-dev %u"))
 }
 
+func TestExtractExecutable_ExpandsEnvVar(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	t.Setenv("HOME", home)
+	expected := filepath.Join(home, ".local/share/firefox-nightly/firefox")
+	assert.Equal(t, expected, extractExecutable("$HOME/.local/share/firefox-nightly/firefox --name firefox-nightly %u"))
+}
+
 func TestDesktopEntryExecMatches_CommandWithExtraArgs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "firefox-dev.desktop")

--- a/internal/freedesktop/browser_service_test.go
+++ b/internal/freedesktop/browser_service_test.go
@@ -379,14 +379,14 @@ func TestExtractExecutable_EmptyString(t *testing.T) {
 
 func TestExtractExecutable_ExpandsTilde(t *testing.T) {
 	home, _ := os.UserHomeDir()
-	expected := filepath.Join(home, ".local/share/firefox-dev/firefox")
+	expected := filepath.Join(home, ".local", "share", "firefox-dev", "firefox")
 	assert.Equal(t, expected, extractExecutable("~/.local/share/firefox-dev/firefox --name firefox-dev %u"))
 }
 
 func TestExtractExecutable_ExpandsEnvVar(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	t.Setenv("HOME", home)
-	expected := filepath.Join(home, ".local/share/firefox-nightly/firefox")
+	expected := filepath.Join(home, ".local", "share", "firefox-nightly", "firefox")
 	assert.Equal(t, expected, extractExecutable("$HOME/.local/share/firefox-nightly/firefox --name firefox-nightly %u"))
 }
 

--- a/internal/freedesktop/browser_service_test.go
+++ b/internal/freedesktop/browser_service_test.go
@@ -9,7 +9,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/strobotti/linkquisition"
 )
+
+type mockBrowserIconLoader struct{}
+
+func (m *mockBrowserIconLoader) LoadIcon(_ linkquisition.Browser) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockBrowserIconLoader) ResolveIconName(_ string) string {
+	return ""
+}
 
 func TestDesktopEntryHasCategory_MatchesWebBrowser(t *testing.T) {
 	dir := t.TempDir()
@@ -84,7 +96,7 @@ Type=Application
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/firefox", "firefox"))
+	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/firefox"))
 }
 
 func TestDesktopEntryExecMatches_BaseName(t *testing.T) {
@@ -98,7 +110,7 @@ Type=Application
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/google-chrome-stable", "google-chrome-stable"))
+	assert.True(t, desktopEntryExecMatches(path, "/usr/bin/google-chrome-stable"))
 }
 
 func TestDesktopEntryExecMatches_NoMatch(t *testing.T) {
@@ -112,7 +124,7 @@ Type=Application
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/chromium", "chromium"))
+	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/chromium"))
 }
 
 func TestDesktopEntryExecMatches_NoExecLine(t *testing.T) {
@@ -125,11 +137,11 @@ Type=Application
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/broken", "broken"))
+	assert.False(t, desktopEntryExecMatches(path, "/usr/bin/broken"))
 }
 
 func TestDesktopEntryExecMatches_MissingFile(t *testing.T) {
-	assert.False(t, desktopEntryExecMatches("/nonexistent/file.desktop", "/usr/bin/app", "app"))
+	assert.False(t, desktopEntryExecMatches("/nonexistent/file.desktop", "/usr/bin/app"))
 }
 
 func TestGetApplicationPaths_UsesXDGDataDirs(t *testing.T) {
@@ -169,6 +181,7 @@ func TestGetDesktopEntryPathForFilename_Found(t *testing.T) {
 	desktopFile := filepath.Join(appsDir, "firefox.desktop")
 	require.NoError(t, os.WriteFile(desktopFile, []byte("[Desktop Entry]\nName=Firefox\n"), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	xdg := &XdgService{}
@@ -183,6 +196,7 @@ func TestGetDesktopEntryPathForFilename_NotFound(t *testing.T) {
 	appsDir := filepath.Join(dir, "share", "applications")
 	require.NoError(t, os.MkdirAll(appsDir, 0755))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	xdg := &XdgService{}
@@ -206,6 +220,7 @@ Categories=Network;WebBrowser;
 	desktopFile := filepath.Join(appsDir, "firefox.desktop")
 	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	xdg := &XdgService{}
@@ -228,6 +243,7 @@ Type=Application
 	desktopFile := filepath.Join(appsDir, "chrome.desktop")
 	require.NoError(t, os.WriteFile(desktopFile, []byte(content), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	xdg := &XdgService{}
@@ -249,6 +265,7 @@ Type=Application
 `
 	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "firefox.desktop"), []byte(content), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	xdg := &XdgService{}
@@ -282,11 +299,13 @@ Categories=Development;TextEditor;
 `
 	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "editor.desktop"), []byte(editorContent), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	svc := &BrowserService{
 		XdgService:          &XdgService{},
 		DesktopEntryService: &DesktopEntryService{},
+		BrowserIconLoader:   &mockBrowserIconLoader{},
 	}
 
 	browsers, err := svc.GetAvailableBrowsers()
@@ -310,11 +329,13 @@ Categories=Network;WebBrowser;
 `
 	require.NoError(t, os.WriteFile(filepath.Join(appsDir, "linkquisition.desktop"), []byte(content), 0600))
 
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
 	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
 
 	svc := &BrowserService{
 		XdgService:          &XdgService{},
 		DesktopEntryService: &DesktopEntryService{},
+		BrowserIconLoader:   &mockBrowserIconLoader{},
 	}
 
 	browsers, err := svc.GetAvailableBrowsers()
@@ -325,15 +346,94 @@ Categories=Network;WebBrowser;
 
 func TestGetAvailableBrowsers_EmptyPaths(t *testing.T) {
 	// Point to a non-existent directory
+	t.Setenv("XDG_DATA_HOME", "/nonexistent/local")
 	t.Setenv("XDG_DATA_DIRS", "/nonexistent/path")
 
 	svc := &BrowserService{
 		XdgService:          &XdgService{},
 		DesktopEntryService: &DesktopEntryService{},
+		BrowserIconLoader:   &mockBrowserIconLoader{},
 	}
 
 	_, err := svc.GetAvailableBrowsers()
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no valid desktop entry paths")
+}
+
+func TestExtractExecutable_FullPath(t *testing.T) {
+	assert.Equal(t, "/usr/bin/firefox", extractExecutable("/usr/bin/firefox %u"))
+}
+
+func TestExtractExecutable_FullPathWithMultipleArgs(t *testing.T) {
+	assert.Equal(t, "/usr/bin/firefox", extractExecutable("/usr/bin/firefox --name firefox-nightly -P nightly %u"))
+}
+
+func TestExtractExecutable_BasenameOnly(t *testing.T) {
+	assert.Equal(t, "google-chrome-stable", extractExecutable("google-chrome-stable %U"))
+}
+
+func TestExtractExecutable_EmptyString(t *testing.T) {
+	assert.Equal(t, "", extractExecutable(""))
+}
+
+func TestExtractExecutable_ExpandsTilde(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".local/share/firefox-dev/firefox")
+	assert.Equal(t, expected, extractExecutable("~/.local/share/firefox-dev/firefox --name firefox-dev %u"))
+}
+
+func TestDesktopEntryExecMatches_CommandWithExtraArgs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "firefox-dev.desktop")
+
+	// .desktop file has a simpler Exec= than the user's config
+	content := `[Desktop Entry]
+Name=Firefox Developer
+Exec=/home/user/.local/share/firefox-dev/firefox --name firefox-dev %u
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	// User's config has extra args (-P nightly) not in the .desktop file
+	// Should still match because the executable is the same
+	assert.True(t, desktopEntryExecMatches(path, "/home/user/.local/share/firefox-dev/firefox --name firefox-dev -P nightly %u"))
+}
+
+func TestDesktopEntryExecMatches_EnvVarInCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "firefox-dev.desktop")
+
+	home, _ := os.UserHomeDir()
+	content := `[Desktop Entry]
+Name=Firefox Developer
+Exec=` + home + `/.local/share/firefox-dev/firefox --name firefox-dev %u
+Type=Application
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	// Command uses $HOME which should expand to the same path
+	t.Setenv("HOME", home)
+	assert.True(t, desktopEntryExecMatches(path, "$HOME/.local/share/firefox-dev/firefox --name firefox-dev %u"))
+}
+
+func TestGetApplicationPaths_IncludesUserLocal(t *testing.T) {
+	dir := t.TempDir()
+	localAppsDir := filepath.Join(dir, "local", "applications")
+	systemAppsDir := filepath.Join(dir, "share", "applications")
+	require.NoError(t, os.MkdirAll(localAppsDir, 0755))
+	require.NoError(t, os.MkdirAll(systemAppsDir, 0755))
+
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "local"))
+	t.Setenv("XDG_DATA_DIRS", filepath.Join(dir, "share"))
+
+	xdg := &XdgService{}
+	paths := xdg.GetApplicationPaths()
+
+	assert.Contains(t, paths, localAppsDir)
+	assert.Contains(t, paths, systemAppsDir)
+	// User-local should come first (higher priority)
+	if len(paths) >= 2 {
+		assert.Equal(t, localAppsDir, paths[0])
+	}
 }

--- a/internal/freedesktop/xdg_service.go
+++ b/internal/freedesktop/xdg_service.go
@@ -32,14 +32,12 @@ func (x *XdgService) GetDesktopEntryPathForFilename(name string) (string, error)
 	return "", fmt.Errorf("no .desktop entry found for %s", name)
 }
 
-func (x *XdgService) GetDesktopEntryPathForBinary(binary string) (string, error) {
+func (x *XdgService) GetDesktopEntryPathForBinary(command string) (string, error) {
 	paths := x.GetApplicationPaths()
 
 	if len(paths) == 0 {
 		return "", fmt.Errorf("no valid desktop entry paths found in $XDG_DATA_DIRS")
 	}
-
-	baseName := filepath.Base(binary)
 
 	for _, dir := range paths {
 		entries, err := os.ReadDir(dir)
@@ -53,22 +51,37 @@ func (x *XdgService) GetDesktopEntryPathForBinary(binary string) (string, error)
 			}
 
 			entryPath := filepath.Join(dir, entry.Name())
-			if desktopEntryExecMatches(entryPath, binary, baseName) {
+			if desktopEntryExecMatches(entryPath, command) {
 				return entryPath, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("no .desktop entry found for %s", binary)
+	return "", fmt.Errorf("no .desktop entry found for %s", command)
 }
 
 func (x *XdgService) GetApplicationPaths() []string {
+	var paths []string
+
+	// Include user-local applications directory ($XDG_DATA_HOME/applications/)
+	dataHome, isset := os.LookupEnv("XDG_DATA_HOME")
+	if !isset {
+		if home, err := os.UserHomeDir(); err == nil {
+			dataHome = filepath.Join(home, ".local", "share")
+		}
+	}
+	if dataHome != "" {
+		userAppsDir := filepath.Join(dataHome, "applications")
+		if _, err := os.Stat(userAppsDir); err == nil {
+			paths = append(paths, userAppsDir)
+		}
+	}
+
+	// Include system-wide application directories ($XDG_DATA_DIRS/applications/)
 	datadirs, isset := os.LookupEnv("XDG_DATA_DIRS")
 	if !isset {
 		datadirs = "/usr/local/share/:/usr/share/"
 	}
-
-	var paths []string
 
 	for _, datadir := range strings.Split(datadirs, ":") {
 		desktopEntryPath := filepath.Join(datadir, "applications")
@@ -110,14 +123,50 @@ func (x *XdgService) SettingsSet(property, value string) error {
 	return nil
 }
 
-// desktopEntryExecMatches checks if a .desktop file's Exec= line starts with
-// the given binary path or its basename.
-func desktopEntryExecMatches(path, binary, baseName string) bool {
+// extractExecutable parses a command string and returns the executable path.
+// It handles environment variable expansion ($HOME) and tilde expansion (~),
+// and strips any arguments or field codes (%u, %U, etc.).
+func extractExecutable(command string) string {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return ""
+	}
+
+	// Split into tokens and take the first one (the executable)
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	exe := fields[0]
+
+	// Expand environment variables (e.g. $HOME)
+	exe = os.ExpandEnv(exe)
+
+	// Expand tilde
+	if strings.HasPrefix(exe, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			exe = filepath.Join(home, exe[2:])
+		}
+	}
+
+	return exe
+}
+
+// desktopEntryExecMatches checks if a .desktop file's Exec= line uses
+// the same executable as the given command. It extracts the binary path
+// from both the command and the Exec= line and compares them by full path
+// or by basename.
+func desktopEntryExecMatches(path, command string) bool {
 	f, err := os.Open(path)
 	if err != nil {
 		return false
 	}
 	defer f.Close()
+
+	commandExe := extractExecutable(command)
+	if commandExe == "" {
+		return false
+	}
 
 	prefix := "Exec="
 	scanner := bufio.NewScanner(f)
@@ -125,7 +174,18 @@ func desktopEntryExecMatches(path, binary, baseName string) bool {
 		line := scanner.Text()
 		if strings.HasPrefix(line, prefix) {
 			execValue := strings.TrimPrefix(line, prefix)
-			return strings.HasPrefix(execValue, binary) || strings.HasPrefix(execValue, baseName)
+			entryExe := extractExecutable(execValue)
+			if entryExe == "" {
+				return false
+			}
+
+			// Compare full paths if both are absolute
+			if filepath.IsAbs(commandExe) && filepath.IsAbs(entryExe) {
+				return commandExe == entryExe
+			}
+
+			// Otherwise compare basenames
+			return filepath.Base(commandExe) == filepath.Base(entryExe)
 		}
 	}
 	return false

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -188,6 +188,12 @@
   "config.browsers_command_placeholder": {
     "other": "e.g. firefox --private-window %u"
   },
+  "config.browsers_icon_path": {
+    "other": "Icon"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/path/to/icon.png (optional)"
+  },
   "config.browsers_source_auto": {
     "other": "(auto)"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -38,6 +38,12 @@
   "config.rescan_browsers": {
     "other": "Re-scan browsers"
   },
+  "config.scan_browsers_scanning": {
+    "other": "Scanning\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Done"
+  },
   "config.scan_now": {
     "other": "Scan now"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -188,6 +188,12 @@
   "config.browsers_command_placeholder": {
     "other": "ej. firefox --private-window %u"
   },
+  "config.browsers_icon_path": {
+    "other": "Icono"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/ruta/al/icono.png (opcional)"
+  },
   "config.browsers_source_auto": {
     "other": "(automático)"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -38,6 +38,12 @@
   "config.rescan_browsers": {
     "other": "Volver a buscar navegadores"
   },
+  "config.scan_browsers_scanning": {
+    "other": "Buscando\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Listo"
+  },
   "config.scan_now": {
     "other": "Buscar ahora"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -38,6 +38,12 @@
   "config.rescan_browsers": {
     "other": "Hae selaimet uudelleen"
   },
+  "config.scan_browsers_scanning": {
+    "other": "Haetaan\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Valmis"
+  },
   "config.scan_now": {
     "other": "Hae nyt"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -188,6 +188,12 @@
   "config.browsers_command_placeholder": {
     "other": "esim. firefox --private-window %u"
   },
+  "config.browsers_icon_path": {
+    "other": "Kuvake"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/polku/kuvakkeeseen.png (valinnainen)"
+  },
   "config.browsers_source_auto": {
     "other": "(automaattinen)"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -188,6 +188,12 @@
   "config.browsers_command_placeholder": {
     "other": "t.ex. firefox --private-window %u"
   },
+  "config.browsers_icon_path": {
+    "other": "Ikon"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/sökväg/till/ikon.png (valfritt)"
+  },
   "config.browsers_source_auto": {
     "other": "(automatisk)"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -38,6 +38,12 @@
   "config.rescan_browsers": {
     "other": "Sök webbläsare igen"
   },
+  "config.scan_browsers_scanning": {
+    "other": "Söker\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Klart"
+  },
   "config.scan_now": {
     "other": "Sök nu"
   },

--- a/settings.go
+++ b/settings.go
@@ -33,10 +33,11 @@ type BrowserMatch struct {
 }
 
 type BrowserSettings struct {
-	Name    string `json:"name"`
-	Command string `json:"command"`
-	Hidden  bool   `json:"hidden"`
-	Source  string `json:"source"`
+	Name     string `json:"name"`
+	Command  string `json:"command"`
+	IconPath string `json:"iconPath,omitempty"`
+	Hidden   bool   `json:"hidden"`
+	Source   string `json:"source"`
 
 	Matches []BrowserMatch `json:"matches"`
 }
@@ -144,7 +145,10 @@ func (s *Settings) CompileAllRegexMatches() *Settings {
 }
 
 func (s *Settings) UpdateWithBrowsers(browsers []Browser) *Settings {
-	return s.dropAutoAddedBrowsersNoLongerPresent(browsers).addMissingBrowsers(browsers).NormalizeBrowsers()
+	return s.dropAutoAddedBrowsersNoLongerPresent(browsers).
+		addMissingBrowsers(browsers).
+		refreshIconPaths(browsers).
+		NormalizeBrowsers()
 }
 
 func (s *Settings) dropAutoAddedBrowsersNoLongerPresent(browsers []Browser) *Settings {
@@ -182,12 +186,35 @@ func (s *Settings) addMissingBrowsers(browsers []Browser) *Settings {
 		if !found {
 			s.Browsers = append(
 				s.Browsers, BrowserSettings{
-					Name:    browsers[i].Name,
-					Command: browsers[i].Command,
-					Hidden:  false,
-					Source:  SourceAuto,
+					Name:     browsers[i].Name,
+					Command:  browsers[i].Command,
+					IconPath: browsers[i].IconPath,
+					Hidden:   false,
+					Source:   SourceAuto,
 				},
 			)
+		}
+	}
+
+	return s
+}
+
+// refreshIconPaths updates the icon path for auto-discovered browsers that have
+// a newer icon path available. Manual browsers keep their existing icon path unless
+// it is empty and a new one was discovered.
+func (s *Settings) refreshIconPaths(browsers []Browser) *Settings {
+	for i := range s.Browsers {
+		for j := range browsers {
+			if s.Browsers[i].Command == browsers[j].Command {
+				// Update icon path for auto browsers unconditionally,
+				// for manual browsers only if currently empty
+				if s.Browsers[i].Source == SourceAuto || s.Browsers[i].IconPath == "" {
+					if browsers[j].IconPath != "" {
+						s.Browsers[i].IconPath = browsers[j].IconPath
+					}
+				}
+				break
+			}
 		}
 	}
 
@@ -203,8 +230,9 @@ func (s *Settings) GetSelectableBrowsers() []Browser {
 		}
 
 		browser := Browser{
-			Name:    s.Browsers[i].Name,
-			Command: s.Browsers[i].Command,
+			Name:     s.Browsers[i].Name,
+			Command:  s.Browsers[i].Command,
+			IconPath: s.Browsers[i].IconPath,
 		}
 		browsers = append(browsers, browser)
 	}
@@ -216,8 +244,9 @@ func (s *Settings) GetMatchingBrowser(u string) (*Browser, error) {
 	for i := range s.Browsers {
 		if s.Browsers[i].MatchesUrl(u) {
 			return &Browser{
-				Name:    s.Browsers[i].Name,
-				Command: s.Browsers[i].Command,
+				Name:     s.Browsers[i].Name,
+				Command:  s.Browsers[i].Command,
+				IconPath: s.Browsers[i].IconPath,
 			}, nil
 		}
 	}

--- a/settings_service_test.go
+++ b/settings_service_test.go
@@ -267,6 +267,22 @@ func TestFileSettingsService_ScanBrowsers_MergesWithExistingConfigOnRescan(t *te
 	assert.Equal(t, "Firefox", settings.Browsers[0].Name)
 }
 
+func TestFileSettingsService_ScanBrowsers_PersistsIconPath(t *testing.T) {
+	browsers := []Browser{
+		{Name: "Firefox", Command: "firefox", IconPath: "/usr/share/icons/firefox.png"},
+		{Name: "Chrome", Command: "chrome", IconPath: "/usr/share/icons/chrome.png"},
+	}
+	svc := newTestService(t, browsers)
+
+	require.NoError(t, svc.ScanBrowsers())
+
+	settings, err := svc.ReadSettings()
+	require.NoError(t, err)
+	assert.Len(t, settings.Browsers, 2)
+	assert.Equal(t, "/usr/share/icons/firefox.png", settings.Browsers[0].IconPath)
+	assert.Equal(t, "/usr/share/icons/chrome.png", settings.Browsers[1].IconPath)
+}
+
 func TestFileSettingsService_WriteSettings_ReturnsErrorForUnwritablePath(t *testing.T) {
 	tmpDir := t.TempDir()
 	readOnlyDir := filepath.Join(tmpDir, "readonly")

--- a/settings_test.go
+++ b/settings_test.go
@@ -666,14 +666,14 @@ func TestSettings_GetSelectableBrowsers(t *testing.T) {
 			name: "returns only visible browsers",
 			settings: Settings{
 				Browsers: []BrowserSettings{
-					{Name: "Firefox", Command: "firefox", Hidden: false},
+					{Name: "Firefox", Command: "firefox", IconPath: "/usr/share/icons/firefox.png", Hidden: false},
 					{Name: "Chromium", Command: "chromium", Hidden: true},
-					{Name: "Brave", Command: "brave", Hidden: false},
+					{Name: "Brave", Command: "brave", IconPath: "/usr/share/icons/brave.png", Hidden: false},
 				},
 			},
 			expected: []Browser{
-				{Name: "Firefox", Command: "firefox"},
-				{Name: "Brave", Command: "brave"},
+				{Name: "Firefox", Command: "firefox", IconPath: "/usr/share/icons/firefox.png"},
+				{Name: "Brave", Command: "brave", IconPath: "/usr/share/icons/brave.png"},
 			},
 		},
 		{
@@ -716,8 +716,9 @@ func TestSettings_GetMatchingBrowser(t *testing.T) {
 	settings := &Settings{
 		Browsers: []BrowserSettings{
 			{
-				Name:    "Firefox",
-				Command: "firefox",
+				Name:     "Firefox",
+				Command:  "firefox",
+				IconPath: "/usr/share/icons/firefox.png",
 				Matches: []BrowserMatch{
 					{Type: BrowserMatchTypeSite, Value: "www.facebook.com"},
 				},
@@ -737,6 +738,7 @@ func TestSettings_GetMatchingBrowser(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Firefox", browser.Name)
 		assert.Equal(t, "firefox", browser.Command)
+		assert.Equal(t, "/usr/share/icons/firefox.png", browser.IconPath)
 	})
 
 	t.Run("returns matching browser for domain rule", func(t *testing.T) {

--- a/settings_test.go
+++ b/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/strobotti/linkquisition"
 )
@@ -604,6 +605,55 @@ func TestSettings_UpdateWithBrowsers_PreservesNonBrowserFields(t *testing.T) {
 	assert.Equal(t, 1, len(result.Plugins))
 	assert.Equal(t, "/usr/lib/linkquisition/plugins/unwrap.so", result.Plugins[0].Path)
 	assert.True(t, result.Ui.HideKeyboardGuideLabel)
+}
+
+func TestSettings_UpdateWithBrowsers_RefreshesIconPaths(t *testing.T) {
+	settings := &Settings{
+		Browsers: []BrowserSettings{
+			{Name: "Firefox", Command: "firefox", Source: SourceAuto, IconPath: ""},
+			{Name: "Custom", Command: "custom", Source: SourceManual, IconPath: ""},
+		},
+	}
+
+	result := settings.UpdateWithBrowsers([]Browser{
+		{Name: "Firefox", Command: "firefox", IconPath: "/usr/share/icons/firefox.png"},
+		{Name: "Custom", Command: "custom", IconPath: "/usr/share/icons/custom.png"},
+	})
+
+	// Auto browser should get its icon path updated
+	assert.Equal(t, "/usr/share/icons/firefox.png", result.Browsers[0].IconPath)
+	// Manual browser with empty icon path should also get populated
+	assert.Equal(t, "/usr/share/icons/custom.png", result.Browsers[1].IconPath)
+}
+
+func TestSettings_UpdateWithBrowsers_PreservesManualIconPath(t *testing.T) {
+	settings := &Settings{
+		Browsers: []BrowserSettings{
+			{Name: "Custom", Command: "custom", Source: SourceManual, IconPath: "/my/custom/icon.png"},
+		},
+	}
+
+	result := settings.UpdateWithBrowsers([]Browser{
+		{Name: "Custom", Command: "custom", IconPath: "/usr/share/icons/auto.png"},
+	})
+
+	// Manual browser with existing icon path should keep it
+	assert.Equal(t, "/my/custom/icon.png", result.Browsers[0].IconPath)
+}
+
+func TestSettings_UpdateWithBrowsers_NewBrowserGetsIconPath(t *testing.T) {
+	settings := &Settings{
+		Browsers: []BrowserSettings{},
+	}
+
+	result := settings.UpdateWithBrowsers([]Browser{
+		{Name: "Firefox", Command: "firefox", IconPath: "/usr/share/icons/firefox.png"},
+	})
+
+	require.Len(t, result.Browsers, 1)
+	assert.Equal(t, "Firefox", result.Browsers[0].Name)
+	assert.Equal(t, "/usr/share/icons/firefox.png", result.Browsers[0].IconPath)
+	assert.Equal(t, SourceAuto, result.Browsers[0].Source)
 }
 
 func TestSettings_GetSelectableBrowsers(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes icon loading for browsers installed per-user (e.g. Firefox Dev/Nightly channels) and adds `iconPath` to the config as the single source of truth for browser icons.

Closes #36 

## Changes

### Icon resolution fixes (`fix`)
- **Parse commands properly** — extract the executable from full command strings with arguments (`-P nightly`, `--name firefox-dev`, `%u`) using `$HOME`/`~` expansion
- **Search `~/.local/share/applications/`** — include `$XDG_DATA_HOME` in `.desktop` file lookup so user-installed browsers are found
- **Compare executable paths** — match by resolved binary path instead of prefix-matching the full `Exec=` line
- **Search user icon directories** — look in `~/.local/share/icons/` and `/usr/share/pixmaps/` in addition to `/usr/share/icons/`
- **Use bundled app icon** — replace `fyne.LoadResourceFromPath("Icon.png")` (broken outside source dir) with the compiled-in resource

### Icon path in config (`feat`)
- Add `iconPath` field to `BrowserSettings` — populated automatically on scan, editable for manual browsers
- `refreshIconPaths` step during scan keeps auto-browser icons up to date and fills empty paths for manual browsers
- Configurator shows a 32×32 icon preview and the resolved path on each browser card
- Add/edit dialogs include an optional icon path field

### UX improvements (`feat`)
- Scan button shows "Scanning…" (disabled) → "✓ Done" before rebuilding the list
- Error dialog on scan failure shows the actual error message

### Documentation & tests
- Updated `doc/linkquisition.5.scd` man page and `README.md` example config
- Added tests for `extractExecutable`, env var / tilde expansion, `XDG_DATA_HOME` inclusion, `IconPath` propagation through settings, and persistence via `ScanBrowsers`