### PR TITLE
fix(ci): Fix CI release workflow and move metainfo update to Release PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -215,48 +215,6 @@ jobs:
           git commit -m "Update linkquisition to v${VERSION}" || echo "No changes to commit"
           git push
 
-  update-metainfo:
-    name: Update Flatpak Metainfo
-    needs: [ upload-assets ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: main
-
-      - name: Update metainfo and create PR
-        env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
-        run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"
-          DATE=$(date +%Y-%m-%d)
-          BRANCH="chore/release-metadata-v${VERSION}"
-          METAINFO="flatpak/io.github.strobotti.linkquisition.metainfo.xml"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git checkout -b "$BRANCH"
-
-          # Insert a new <release> entry after the <releases> tag
-          sed -i "s|<releases>|<releases>\n    <release version=\"${VERSION}\" date=\"${DATE}\">\n      <description>\n        <p>See https://github.com/Strobotti/linkquisition/releases/tag/v${VERSION} for details.</p>\n      </description>\n    </release>|" "$METAINFO"
-
-          git add "$METAINFO"
-          git commit -m "chore: update Flatpak metainfo for v${VERSION}"
-          git push -u origin "$BRANCH"
-
-          gh pr create \
-            --title "chore: update Flatpak metainfo for v${VERSION}" \
-            --body "Automated update of the Flatpak metainfo release entry for v${VERSION}." \
-            --base main \
-            --head "$BRANCH"
-
-          gh pr merge "$BRANCH" --auto --squash
-
   coverage:
     name: Coverage Badge
     needs: [ test ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish
 
 on:
-  release:
-    types: [ created ]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   test:
@@ -73,7 +74,7 @@ jobs:
       - name: Build
         run: task build:${{ matrix.target }}
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.ref_name }}
 
       - name: Package Linux .deb
         if: matrix.target == 'linux-amd64'
@@ -85,13 +86,13 @@ jobs:
           cp bin/linkquisition-linux-amd64 package/linux/usr/bin/linkquisition
           cp package/linux/usr/lib/linkquisition/plugins/*.so package/linux/usr/lib/linkquisition/plugins/ 2>/dev/null || true
           cp templates/DEBIAN/control.tpl package/linux/DEBIAN/control
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           sed -i "s/{{VERSION}}/${VERSION}/g" package/linux/DEBIAN/control
           sed -i "s/{{ARCH}}/amd64/g" package/linux/DEBIAN/control
           dpkg-deb --build package/linux dist/linkquisition_${VERSION}_amd64.deb
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.ref_name }}
 
       - name: Build AppImage
         if: matrix.target == 'linux-amd64'
@@ -99,7 +100,7 @@ jobs:
           task package:manpages
           ./scripts/build-appimage.sh
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.ref_name }}
 
       - name: Package macOS .app
         if: matrix.target == 'darwin-universal'
@@ -108,7 +109,7 @@ jobs:
           codesign --force --deep --sign - dist/Linkquisition.app
           cd dist && ditto -c -k --keepParent Linkquisition.app Linkquisition_macOS_universal.zip
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.ref_name }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -167,15 +168,15 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.event.release.tag_name }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload macOS asset to release
-        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/Linkquisition_macOS_universal.zip --clobber
+        run: gh release upload "${{ github.ref_name }}" artifacts/Linkquisition_macOS_universal.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Upload AppImage to release
-        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/Linkquisition-*.AppImage --clobber
+        run: gh release upload "${{ github.ref_name }}" artifacts/Linkquisition-*.AppImage --clobber
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
 
@@ -196,7 +197,7 @@ jobs:
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           SHA256=$(sha256sum artifacts/Linkquisition_macOS_universal.zip | awk '{print $1}')
 
@@ -223,12 +224,14 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: main
 
       - name: Update metainfo and create PR
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           DATE=$(date +%Y-%m-%d)
           BRANCH="chore/release-metadata-v${VERSION}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,41 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.DEPENDABOT_TOKEN }}
+
+  update-metainfo:
+    name: Update Flatpak Metainfo in Release PR
+    needs: [ release-please ]
+    if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.DEPENDABOT_TOKEN }}
+          ref: release-please--branches--main
+
+      - name: Update metainfo XML
+        run: |
+          VERSION="${{ needs.release-please.outputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          METAINFO="flatpak/io.github.strobotti.linkquisition.metainfo.xml"
+
+          # Check if this version is already in the metainfo
+          if grep -q "version=\"${VERSION}\"" "$METAINFO"; then
+            echo "Version ${VERSION} already in metainfo, skipping"
+            exit 0
+          fi
+
+          # Insert a new <release> entry after the <releases> tag
+          sed -i "s|<releases>|<releases>\n    <release version=\"${VERSION}\" date=\"${DATE}\">\n      <description>\n        <p>See https://github.com/Strobotti/linkquisition/releases/tag/v${VERSION} for details.</p>\n      </description>\n    </release>|" "$METAINFO"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$METAINFO"
+          git commit -m "chore: update Flatpak metainfo for v${VERSION}" || echo "No changes to commit"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,37 @@ should ideally do one thing and be independently reviewable. If a feature requir
 multiple steps (e.g. interface change + migration + tests + docs), split them into
 separate commits on the same branch rather than squashing everything together.
 
+## Branching and pull requests
+
+Always work on a **feature branch** — never commit directly to `main`. Branch naming:
+
+- `feat/<short-description>` — new features
+- `fix/<short-description>` — bug fixes
+- `chore/<short-description>` — maintenance, CI, docs-only
+- `refactor/<short-description>` — code restructuring
+
+Push the branch and open a **pull request** for review. PRs are merged via GitHub
+(squash or merge commit, depending on the number of meaningful commits). The `main`
+branch is protected and triggers the release-please flow on every push.
+
+## Release flow (CI)
+
+The project uses [release-please](https://github.com/googleapis/release-please-action)
+for automated releases:
+
+1. Push to `main` → `release-please.yml` creates/updates a **Release PR** with a
+   changelog and version bump based on conventional commit types
+2. The same workflow updates the Flatpak metainfo XML on the Release PR branch
+3. Merge the Release PR → release-please creates a GitHub release + pushes a tag
+4. Tag push (`v*`) triggers `publish.yml` → test → build → upload assets (`.deb`,
+   `.rpm`, AppImage, macOS `.zip`) → update Homebrew tap → update coverage badge
+
+Key files:
+
+- `.github/workflows/release-please.yml` — Release PR + metainfo update
+- `.github/workflows/publish.yml` — build/package/upload on tag push
+- `release-please-config.json` + `.release-please-manifest.json` — release-please config
+
 ## Documentation surfaces to keep in sync
 
 When making changes, ensure ALL relevant documentation is updated:


### PR DESCRIPTION
## Problem

The v2.5.0 release had two issues:
1. **No assets uploaded** — only source archives appeared on the release page (no `.deb`, AppImage, or macOS `.zip`)
2. **Flatpak metainfo not updated** — the `update-metainfo` job never ran

Both caused by the `publish.yml` workflow not triggering when release-please created the release.

## Changes

### Fix publish trigger (`fix(ci)`)
- Switch `publish.yml` from `on: release: types: [created]` to `on: push: tags: ['v*']`
- Replace `github.event.release.tag_name` → `github.ref_name` throughout

### Move metainfo update into Release PR (`ci`)
- Remove the post-release `update-metainfo` job from `publish.yml`
- Add an `update-metainfo` job to `release-please.yml` that commits the metainfo update directly to the Release PR branch
- Idempotent: skips if the version entry already exists
- The metainfo change is now reviewed as part of the Release PR, not a trailing separate PR

### Document the workflow (`docs`)
- Add "Branching and pull requests" section to `AGENTS.md`
- Add "Release flow (CI)" section documenting the full pipeline

## New release flow

```
push to main
  → release-please.yml
    → creates/updates Release PR (changelog + version bump)
    → commits Flatpak metainfo update to the PR branch
  → merge Release PR
    → release-please creates GitHub release + pushes tag
      → publish.yml (triggered by v* tag push)
        → test → build → upload assets → update Homebrew → coverage badge
```
