### PR TITLE
fix(ci): fix GoReleaser config version and dirty state error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,15 @@ jobs:
       - name: Package files for Linux
         run: task package:linux
 
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
       - name: Download macOS artifact
         uses: actions/download-artifact@v8
         with:
@@ -160,15 +169,6 @@ jobs:
         with:
           name: linux-amd64
           path: artifacts/
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          version: '~> v2'
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Upload macOS asset to release
         run: gh release upload "${{ github.ref_name }}" artifacts/Linkquisition_macOS_universal.zip --clobber

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 release:
   mode: append
 


### PR DESCRIPTION
## Problem

The publish workflow failed on v2.5.1 release with:

```
only version: 2 configuration files are supported, yours is version: 0
git is in a dirty state
?? artifacts/
```

## Fixes

1. **Add `version: 2`** to `.goreleaser.yaml` — required by GoReleaser v2 (the action installs `~> v2`)

2. **Move artifact downloads after GoReleaser** — the `download-artifact` steps created an `artifacts/` directory before GoReleaser ran, making the working tree dirty. These artifacts are only used by the subsequent `gh release upload` steps, not by GoReleaser itself.