### PR TITLE
fix(ci): remove nfpms meta flag so arch resolves to amd64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,8 +95,7 @@ builds:
       - -X main.buildDate={{.Date}}
 
 nfpms:
-  - meta: true
-    package_name: linkquisition
+  - package_name: linkquisition
     homepage: https://github.com/Strobotti/linkquisition
     maintainer: Juha Jantunen <juha@strobotti.com>
     description: |-


### PR DESCRIPTION
With `meta: true`, GoReleaser treats the nfpm package as architecture- independent, resolving {{ .Arch }} to "all" instead of "amd64". This causes content paths like `application_linux_all_v1/` to not match the actual build output at `application_linux_amd64_v1/`.

Remove the flag since this package contains actual binaries.