### PR TITLE
fix(ci): remove explicit binary from nfpms contents (content collision)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,8 +108,6 @@ nfpms:
     dependencies:
       - libgl1
     contents:
-      - src: ./dist/application_{{ .Os }}_{{ .Arch }}_v1/linkquisition
-        dst: /usr/bin/linkquisition
       - src: ./dist/unwrap-plugin_{{ .Os }}_{{ .Arch }}_v1/plugins/unwrap.so
         dst: /usr/lib/linkquisition/plugins/unwrap.so
       - src: ./dist/terminus-plugin_{{ .Os }}_{{ .Arch }}_v1/plugins/terminus.so


### PR DESCRIPTION
Without `meta: true`, GoReleaser automatically includes the build binary in the nfpm package. The explicit contents entry for the same binary at /usr/bin/linkquisition causes a "content collision" error.

Remove the manual binary entry — GoReleaser handles it. Keep the plugin .so files and package/linux tree which are extra content not part of the build output.