### PR TITLE
fix(ci): use gh CLI for asset uploads instead of GoReleaser publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,11 +149,11 @@ jobs:
       - name: Package files for Linux
         run: task package:linux
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (build only)
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
-          args: release --clean
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
@@ -170,15 +170,17 @@ jobs:
           name: linux-amd64
           path: artifacts/
 
-      - name: Upload macOS asset to release
-        run: gh release upload "${{ github.ref_name }}" artifacts/Linkquisition_macOS_universal.zip --clobber
+      - name: Upload all assets to release
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
-
-      - name: Upload AppImage to release
-        run: gh release upload "${{ github.ref_name }}" artifacts/Linkquisition-*.AppImage --clobber
-        env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          # GoReleaser outputs (deb, rpm, tar.gz, checksums, sbom)
+          gh release upload "$TAG" dist/*.deb dist/*.rpm dist/*.tar.gz dist/checksums.txt dist/*.sbom.json --clobber 2>/dev/null || true
+          # macOS universal binary
+          gh release upload "$TAG" artifacts/Linkquisition_macOS_universal.zip --clobber
+          # AppImage
+          gh release upload "$TAG" artifacts/Linkquisition-*.AppImage --clobber
 
   update-homebrew:
     name: Update Homebrew Tap

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
 version: 2
 
-release:
-  mode: append
-
 builds:
   - id: "application"
     binary: "linkquisition"


### PR DESCRIPTION
GoReleaser's publish step was not uploading assets to the pre-existing release created by release-please. Rather than debugging the interaction between GoReleaser's release publisher and release-please's releases, skip GoReleaser's publish entirely (--skip=publish) and use the gh CLI to upload all assets explicitly.

This gives us full control over what gets uploaded and clear error messages if something fails. GoReleaser still handles building, packaging (.deb, .rpm, tarball), checksums, and SBOMs.