### PR TITLE
feat: add configurable horizontal button layout for browser picker

### DIFF
--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -110,19 +110,20 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		widgets = append(widgets, picker.buildKeyboardGuide()...)
 	}
 
-	w.SetFixedSize(true)
 	w.SetIcon(resources.LinkquisitionIcon)
-	w.SetContent(container.NewVBox(widgets...))
 
 	if pickerLayout == linkquisition.PickerLayoutHorizontal {
 		cols := min(len(buttons), settings.Ui.GetMaxItemsPerRow())
 		rows := (len(buttons) + cols - 1) / cols
-		width := float32(cols*horizontalButtonWidth) + 32    //nolint:mnd
-		height := float32(rows*horizontalButtonHeight) + 140 //nolint:mnd
+		width := float32(cols+1) * horizontalButtonWidth     //nolint:mnd
+		height := float32(rows*horizontalButtonHeight) + 180 //nolint:mnd
 		w.Resize(fyne.NewSize(width, height))
 	} else {
 		w.Resize(fyne.NewSize(verticalWindowWidth, verticalWindowMinHeight))
 	}
+
+	w.SetFixedSize(true)
+	w.SetContent(container.NewVBox(widgets...))
 	w.CenterOnScreen()
 
 	w.ShowAndRun()
@@ -180,10 +181,8 @@ func (picker *BrowserPicker) tapButton(obj fyne.CanvasObject) {
 }
 
 func (picker *BrowserPicker) buildHorizontalGrid(buttons []fyne.CanvasObject, maxPerRow int) fyne.CanvasObject {
-	_ = maxPerRow // column count is controlled by window width + cell size
-	cellSize := fyne.NewSize(horizontalButtonWidth, horizontalButtonHeight)
-	grid := container.New(layout.NewGridWrapLayout(cellSize), buttons...)
-	return container.NewPadded(grid)
+	cols := min(len(buttons), maxPerRow)
+	return container.NewGridWithColumns(cols, buttons...)
 }
 
 func (picker *BrowserPicker) buildURLDisplay(urlToOpen string) []fyne.CanvasObject {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/layout"
@@ -15,6 +16,14 @@ import (
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
 	"github.com/strobotti/linkquisition/resources"
+)
+
+const (
+	horizontalButtonIconSize = 64
+	horizontalButtonWidth    = 100
+	horizontalButtonHeight   = 100
+	verticalWindowWidth      = 600
+	verticalWindowMinHeight  = 50
 )
 
 type BrowserPicker struct {
@@ -41,7 +50,7 @@ func NewBrowserPicker(
 	}
 }
 
-//nolint:funlen
+//nolint:funlen,cyclop
 func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	var buttons []fyne.CanvasObject
 	remember := binding.NewBool()
@@ -50,11 +59,23 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	// TODO give user the option to choose between site and domain (and later on regex, too)
 	_ = rememberMatchType.Set(linkquisition.BrowserMatchTypeSite)
 
+	settings := picker.settingsService.GetSettings()
+	pickerLayout := settings.Ui.GetPickerLayout()
+
 	for i := range picker.browsers {
-		buttons = append(
-			buttons,
-			picker.makeBrowserButton(picker.browsers[i], urlToOpen, remember, rememberMatchType),
-		)
+		if pickerLayout == linkquisition.PickerLayoutHorizontal {
+			buttons = append(
+				buttons,
+				picker.makeHorizontalBrowserButton(
+					picker.browsers[i], urlToOpen, remember, rememberMatchType,
+				),
+			)
+		} else {
+			buttons = append(
+				buttons,
+				picker.makeBrowserButton(picker.browsers[i], urlToOpen, remember, rememberMatchType),
+			)
+		}
 	}
 
 	w := picker.fapp.NewWindow(i18n.T("picker.window_title"))
@@ -70,6 +91,44 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		},
 	)
 
+	picker.setupKeyboardShortcuts(w, buttons)
+
+	var widgets []fyne.CanvasObject
+
+	if pickerLayout == linkquisition.PickerLayoutHorizontal {
+		widgets = append(widgets, picker.buildHorizontalGrid(buttons, settings.Ui.GetMaxItemsPerRow()))
+	} else {
+		widgets = append(widgets, buttons...)
+	}
+
+	widgets = append(widgets, picker.buildURLDisplay(urlToOpen)...)
+	widgets = append(widgets, picker.buildRememberCheck(urlToOpen, remember)...)
+
+	if !settings.Ui.HideKeyboardGuideLabel {
+		widgets = append(widgets, picker.buildKeyboardGuide()...)
+	}
+
+	w.SetFixedSize(true)
+	if pickerLayout == linkquisition.PickerLayoutHorizontal {
+		cols := min(len(buttons), settings.Ui.GetMaxItemsPerRow())
+		rows := (len(buttons) + cols - 1) / cols
+		width := float32(cols*horizontalButtonWidth) + float32(cols+1)*10         //nolint:mnd
+		height := float32(rows*horizontalButtonHeight) + float32(rows+1)*10 + 120 //nolint:mnd
+		w.Resize(fyne.NewSize(max(width, verticalWindowWidth), height))
+	} else {
+		w.Resize(fyne.NewSize(verticalWindowWidth, verticalWindowMinHeight))
+	}
+	w.CenterOnScreen()
+	w.SetIcon(resources.LinkquisitionIcon)
+
+	w.SetContent(container.NewVBox(widgets...))
+
+	w.ShowAndRun()
+
+	return nil
+}
+
+func (picker *BrowserPicker) setupKeyboardShortcuts(w fyne.Window, buttons []fyne.CanvasObject) {
 	w.Canvas().SetOnTypedKey(
 		func(keyEvent *fyne.KeyEvent) {
 			if keyEvent.Name == fyne.KeyEscape {
@@ -77,7 +136,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 			}
 			if len(buttons) > 0 {
 				if keyEvent.Name == fyne.KeyReturn {
-					buttons[0].(*widget.Button).OnTapped()
+					picker.tapButton(buttons[0])
 					return
 				}
 
@@ -96,19 +155,37 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 
 				for i := range buttons {
 					if keyEvent.Name == numkeyNames[i] {
-						buttons[i].(*widget.Button).OnTapped()
+						picker.tapButton(buttons[i])
 						return
 					}
 				}
 			}
 		},
 	)
+}
 
-	var widgets []fyne.CanvasObject
+// tapButton triggers the OnTapped handler for a button canvas object.
+// Supports both widget.Button (vertical layout) and the tappable container (horizontal layout).
+func (picker *BrowserPicker) tapButton(obj fyne.CanvasObject) {
+	if btn, ok := obj.(*widget.Button); ok {
+		btn.OnTapped()
+		return
+	}
+	// For horizontal layout, the tappable wrapper holds the callback
+	if tappable, ok := obj.(*tappableContainer); ok {
+		tappable.onTapped()
+	}
+}
 
-	widgets = append(widgets, buttons...)
+func (picker *BrowserPicker) buildHorizontalGrid(buttons []fyne.CanvasObject, maxPerRow int) fyne.CanvasObject {
+	cols := min(len(buttons), maxPerRow)
+	cellSize := fyne.NewSize(horizontalButtonWidth, horizontalButtonHeight)
+	grid := container.New(layout.NewGridWrapLayout(cellSize), buttons...)
+	_ = cols // cols is implicitly handled by GridWrap based on container width
+	return grid
+}
 
-	// if the text is too long, it will be truncated
+func (picker *BrowserPicker) buildURLDisplay(urlToOpen string) []fyne.CanvasObject {
 	text := urlToOpen
 	if len(urlToOpen) > 75 { //nolint:mnd
 		text = urlToOpen[:75] + "..."
@@ -118,11 +195,12 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	input.SetText(text)
 	input.Disable()
 
-	widgets = append(
-		widgets,
+	return []fyne.CanvasObject{
 		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("picker.open_label")), nil, input),
-	)
+	}
+}
 
+func (picker *BrowserPicker) buildRememberCheck(urlToOpen string, remember binding.Bool) []fyne.CanvasObject {
 	uto := linkquisition.NewURL(urlToOpen)
 	site, _ := uto.GetSite()
 	check := widget.NewCheckWithData(
@@ -130,36 +208,21 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		remember,
 	)
 
-	widgets = append(
-		widgets,
-		check,
-	)
+	return []fyne.CanvasObject{check}
+}
 
-	if !picker.settingsService.GetSettings().Ui.HideKeyboardGuideLabel {
-		copyShortcut := "Ctrl+C"
-		if runtime.GOOS == "darwin" {
-			copyShortcut = "⌘+C"
-		}
-
-		widgets = append(
-			widgets,
-			layout.NewSpacer(),
-			widget.NewLabel(i18n.T("picker.keyboard_guide", map[string]interface{}{
-				"CopyShortcut": copyShortcut,
-			})),
-		)
+func (picker *BrowserPicker) buildKeyboardGuide() []fyne.CanvasObject {
+	copyShortcut := "Ctrl+C"
+	if runtime.GOOS == "darwin" {
+		copyShortcut = "⌘+C"
 	}
 
-	w.SetFixedSize(true)
-	w.Resize(fyne.NewSize(600, 50)) //nolint:mnd
-	w.CenterOnScreen()
-	w.SetIcon(resources.LinkquisitionIcon)
-
-	w.SetContent(container.NewVBox(widgets...))
-
-	w.ShowAndRun()
-
-	return nil
+	return []fyne.CanvasObject{
+		layout.NewSpacer(),
+		widget.NewLabel(i18n.T("picker.keyboard_guide", map[string]interface{}{
+			"CopyShortcut": copyShortcut,
+		})),
+	}
 }
 
 func (picker *BrowserPicker) makeBrowserButton(
@@ -180,31 +243,99 @@ func (picker *BrowserPicker) makeBrowserButton(
 	return widget.NewButtonWithIcon(
 		browser.Name,
 		icon,
-		func() {
-			rem, _ := remember.Get()
-			picker.logger.Debug("Opening URL with browser", "browser", browser.Name, "remember", rem)
+		picker.browserOpenCallback(browser, urlToOpen, remember, rememberMatchType),
+	)
+}
 
-			settings := picker.settingsService.GetSettings()
-			remType, _ := rememberMatchType.Get()
+func (picker *BrowserPicker) makeHorizontalBrowserButton(
+	browser linkquisition.Browser,
+	urlToOpen string,
+	remember binding.Bool,
+	rememberMatchType binding.String,
+) fyne.CanvasObject {
+	callback := picker.browserOpenCallback(browser, urlToOpen, remember, rememberMatchType)
 
-			if rem {
-				uto := linkquisition.NewURL(urlToOpen)
-				matchValue, _ := uto.GetDomain()
+	var iconWidget fyne.CanvasObject
+	iconBytes, err := picker.browserService.GetIconForBrowser(browser)
+	if err != nil {
+		picker.logger.Debug("Failed to load browser icon", "browser", browser.Name, "error", err)
+		iconWidget = layout.NewSpacer()
+	} else {
+		res := fyne.NewStaticResource("icon.png", iconBytes)
+		img := canvas.NewImageFromResource(res)
+		img.FillMode = canvas.ImageFillContain
+		img.SetMinSize(fyne.NewSize(horizontalButtonIconSize, horizontalButtonIconSize))
+		iconWidget = img
+	}
 
-				if remType == linkquisition.BrowserMatchTypeSite {
-					matchValue, _ = uto.GetSite()
-				}
+	nameLabel := widget.NewLabel(browser.Name)
+	nameLabel.Alignment = fyne.TextAlignCenter
+	nameLabel.Truncation = fyne.TextTruncateEllipsis
 
-				settings.AddRuleToBrowser(&browser, remType, matchValue)
-				if writeErr := picker.settingsService.WriteSettings(settings); writeErr != nil {
-					picker.logger.Error("Failed to write settings", "error", writeErr)
-				}
+	content := container.NewVBox(
+		iconWidget,
+		nameLabel,
+	)
+
+	return newTappableContainer(content, callback)
+}
+
+func (picker *BrowserPicker) browserOpenCallback(
+	browser linkquisition.Browser,
+	urlToOpen string,
+	remember binding.Bool,
+	rememberMatchType binding.String,
+) func() {
+	return func() {
+		rem, _ := remember.Get()
+		picker.logger.Debug("Opening URL with browser", "browser", browser.Name, "remember", rem)
+
+		settings := picker.settingsService.GetSettings()
+		remType, _ := rememberMatchType.Get()
+
+		if rem {
+			uto := linkquisition.NewURL(urlToOpen)
+			matchValue, _ := uto.GetDomain()
+
+			if remType == linkquisition.BrowserMatchTypeSite {
+				matchValue, _ = uto.GetSite()
 			}
 
-			go func() {
-				_ = picker.browserService.OpenUrlWithBrowser(urlToOpen, &browser)
-			}()
-			picker.fapp.Quit()
-		},
-	)
+			settings.AddRuleToBrowser(&browser, remType, matchValue)
+			if writeErr := picker.settingsService.WriteSettings(settings); writeErr != nil {
+				picker.logger.Error("Failed to write settings", "error", writeErr)
+			}
+		}
+
+		go func() {
+			_ = picker.browserService.OpenUrlWithBrowser(urlToOpen, &browser)
+		}()
+		picker.fapp.Quit()
+	}
+}
+
+// tappableContainer wraps a canvas object to make it respond to tap events.
+type tappableContainer struct {
+	widget.BaseWidget
+	content  fyne.CanvasObject
+	onTapped func()
+}
+
+func newTappableContainer(content fyne.CanvasObject, onTapped func()) *tappableContainer {
+	t := &tappableContainer{
+		content:  content,
+		onTapped: onTapped,
+	}
+	t.ExtendBaseWidget(t)
+	return t
+}
+
+func (t *tappableContainer) Tapped(_ *fyne.PointEvent) {
+	if t.onTapped != nil {
+		t.onTapped()
+	}
+}
+
+func (t *tappableContainer) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(t.content)
 }

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"image/color"
 	"log/slog"
 	"runtime"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/binding"
+	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 
@@ -19,9 +21,9 @@ import (
 )
 
 const (
-	horizontalButtonIconSize = 64
-	horizontalButtonWidth    = 100
-	horizontalButtonHeight   = 100
+	horizontalButtonIconSize = 96
+	horizontalButtonWidth    = 148
+	horizontalButtonHeight   = 148
 	verticalWindowWidth      = 600
 	verticalWindowMinHeight  = 50
 )
@@ -109,19 +111,19 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	}
 
 	w.SetFixedSize(true)
+	w.SetIcon(resources.LinkquisitionIcon)
+	w.SetContent(container.NewVBox(widgets...))
+
 	if pickerLayout == linkquisition.PickerLayoutHorizontal {
 		cols := min(len(buttons), settings.Ui.GetMaxItemsPerRow())
 		rows := (len(buttons) + cols - 1) / cols
-		width := float32(cols*horizontalButtonWidth) + float32(cols+1)*10         //nolint:mnd
-		height := float32(rows*horizontalButtonHeight) + float32(rows+1)*10 + 120 //nolint:mnd
-		w.Resize(fyne.NewSize(max(width, verticalWindowWidth), height))
+		width := float32(cols*horizontalButtonWidth) + 32    //nolint:mnd
+		height := float32(rows*horizontalButtonHeight) + 140 //nolint:mnd
+		w.Resize(fyne.NewSize(width, height))
 	} else {
 		w.Resize(fyne.NewSize(verticalWindowWidth, verticalWindowMinHeight))
 	}
 	w.CenterOnScreen()
-	w.SetIcon(resources.LinkquisitionIcon)
-
-	w.SetContent(container.NewVBox(widgets...))
 
 	w.ShowAndRun()
 
@@ -178,11 +180,10 @@ func (picker *BrowserPicker) tapButton(obj fyne.CanvasObject) {
 }
 
 func (picker *BrowserPicker) buildHorizontalGrid(buttons []fyne.CanvasObject, maxPerRow int) fyne.CanvasObject {
-	cols := min(len(buttons), maxPerRow)
+	_ = maxPerRow // column count is controlled by window width + cell size
 	cellSize := fyne.NewSize(horizontalButtonWidth, horizontalButtonHeight)
 	grid := container.New(layout.NewGridWrapLayout(cellSize), buttons...)
-	_ = cols // cols is implicitly handled by GridWrap based on container width
-	return grid
+	return container.NewPadded(grid)
 }
 
 func (picker *BrowserPicker) buildURLDisplay(urlToOpen string) []fyne.CanvasObject {
@@ -259,7 +260,14 @@ func (picker *BrowserPicker) makeHorizontalBrowserButton(
 	iconBytes, err := picker.browserService.GetIconForBrowser(browser)
 	if err != nil {
 		picker.logger.Debug("Failed to load browser icon", "browser", browser.Name, "error", err)
-		iconWidget = layout.NewSpacer()
+		// Show a placeholder with the first letter when no icon is available
+		bg := canvas.NewRectangle(color.NRGBA{R: 200, G: 200, B: 200, A: 40}) //nolint:mnd
+		bg.SetMinSize(fyne.NewSize(horizontalButtonIconSize, horizontalButtonIconSize))
+		placeholder := canvas.NewText(string([]rune(browser.Name)[0]), color.NRGBA{R: 80, G: 80, B: 80, A: 255}) //nolint:mnd,lll
+		placeholder.TextSize = 36                                                                                //nolint:mnd
+		placeholder.TextStyle = fyne.TextStyle{Bold: true}
+		placeholder.Alignment = fyne.TextAlignCenter
+		iconWidget = container.NewStack(bg, container.NewCenter(placeholder))
 	} else {
 		res := fyne.NewStaticResource("icon.png", iconBytes)
 		img := canvas.NewImageFromResource(res)
@@ -273,7 +281,7 @@ func (picker *BrowserPicker) makeHorizontalBrowserButton(
 	nameLabel.Truncation = fyne.TextTruncateEllipsis
 
 	content := container.NewVBox(
-		iconWidget,
+		container.NewCenter(iconWidget),
 		nameLabel,
 	)
 
@@ -314,16 +322,26 @@ func (picker *BrowserPicker) browserOpenCallback(
 	}
 }
 
-// tappableContainer wraps a canvas object to make it respond to tap events.
+// tappableContainer wraps a canvas object to make it respond to tap and hover events.
 type tappableContainer struct {
 	widget.BaseWidget
 	content  fyne.CanvasObject
+	bg       *canvas.Rectangle
 	onTapped func()
 }
 
+// Compile-time interface checks.
+var (
+	_ fyne.Tappable     = (*tappableContainer)(nil)
+	_ desktop.Hoverable = (*tappableContainer)(nil)
+)
+
 func newTappableContainer(content fyne.CanvasObject, onTapped func()) *tappableContainer {
+	bg := canvas.NewRectangle(color.Transparent)
+	bg.CornerRadius = 8 //nolint:mnd
 	t := &tappableContainer{
 		content:  content,
+		bg:       bg,
 		onTapped: onTapped,
 	}
 	t.ExtendBaseWidget(t)
@@ -336,6 +354,18 @@ func (t *tappableContainer) Tapped(_ *fyne.PointEvent) {
 	}
 }
 
+func (t *tappableContainer) MouseIn(_ *desktop.MouseEvent) {
+	t.bg.FillColor = color.NRGBA{R: 150, G: 150, B: 150, A: 30} //nolint:mnd
+	t.bg.Refresh()
+}
+
+func (t *tappableContainer) MouseMoved(_ *desktop.MouseEvent) {}
+
+func (t *tappableContainer) MouseOut() {
+	t.bg.FillColor = color.Transparent
+	t.bg.Refresh()
+}
+
 func (t *tappableContainer) CreateRenderer() fyne.WidgetRenderer {
-	return widget.NewSimpleRenderer(t.content)
+	return widget.NewSimpleRenderer(container.NewStack(t.bg, t.content))
 }

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"runtime"
 	"time"
+	"unicode/utf8"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -52,7 +53,7 @@ func NewBrowserPicker(
 	}
 }
 
-//nolint:funlen,cyclop
+//nolint:cyclop
 func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	var buttons []fyne.CanvasObject
 	remember := binding.NewBool()
@@ -115,8 +116,8 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	if pickerLayout == linkquisition.PickerLayoutHorizontal {
 		cols := min(len(buttons), settings.Ui.GetMaxItemsPerRow())
 		rows := (len(buttons) + cols - 1) / cols
-		width := float32(cols+1) * horizontalButtonWidth     //nolint:mnd
-		height := float32(rows*horizontalButtonHeight) + 180 //nolint:mnd
+		width := float32(cols+1) * horizontalButtonWidth
+		height := float32(rows*horizontalButtonHeight) + 180
 		w.Resize(fyne.NewSize(width, height))
 	} else {
 		w.Resize(fyne.NewSize(verticalWindowWidth, verticalWindowMinHeight))
@@ -260,10 +261,11 @@ func (picker *BrowserPicker) makeHorizontalBrowserButton(
 	if err != nil {
 		picker.logger.Debug("Failed to load browser icon", "browser", browser.Name, "error", err)
 		// Show a placeholder with the first letter when no icon is available
-		bg := canvas.NewRectangle(color.NRGBA{R: 200, G: 200, B: 200, A: 40}) //nolint:mnd
+		bg := canvas.NewRectangle(color.NRGBA{R: 200, G: 200, B: 200, A: 40})
 		bg.SetMinSize(fyne.NewSize(horizontalButtonIconSize, horizontalButtonIconSize))
-		placeholder := canvas.NewText(string([]rune(browser.Name)[0]), color.NRGBA{R: 80, G: 80, B: 80, A: 255}) //nolint:mnd,lll
-		placeholder.TextSize = 36                                                                                //nolint:mnd
+		firstRune, _ := utf8.DecodeRuneInString(browser.Name)
+		placeholder := canvas.NewText(string(firstRune), color.NRGBA{R: 80, G: 80, B: 80, A: 255})
+		placeholder.TextSize = 36
 		placeholder.TextStyle = fyne.TextStyle{Bold: true}
 		placeholder.Alignment = fyne.TextAlignCenter
 		iconWidget = container.NewStack(bg, container.NewCenter(placeholder))
@@ -337,7 +339,7 @@ var (
 
 func newTappableContainer(content fyne.CanvasObject, onTapped func()) *tappableContainer {
 	bg := canvas.NewRectangle(color.Transparent)
-	bg.CornerRadius = 8 //nolint:mnd
+	bg.CornerRadius = 8
 	t := &tappableContainer{
 		content:  content,
 		bg:       bg,
@@ -354,7 +356,7 @@ func (t *tappableContainer) Tapped(_ *fyne.PointEvent) {
 }
 
 func (t *tappableContainer) MouseIn(_ *desktop.MouseEvent) {
-	t.bg.FillColor = color.NRGBA{R: 150, G: 150, B: 150, A: 30} //nolint:mnd
+	t.bg.FillColor = color.NRGBA{R: 150, G: 150, B: 150, A: 30}
 	t.bg.Refresh()
 }
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -214,7 +214,72 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 	})
 	hideGuideCheck.Checked = settings.Ui.HideKeyboardGuideLabel
 
-	return container.NewVBox(hideGuideCheck)
+	// Picker layout selector
+	layoutOptions := []string{
+		i18n.T("config.picker_layout_vertical"),
+		i18n.T("config.picker_layout_horizontal"),
+	}
+
+	currentLayout := settings.Ui.GetPickerLayout()
+	selectedLayout := layoutOptions[0]
+	if currentLayout == linkquisition.PickerLayoutHorizontal {
+		selectedLayout = layoutOptions[1]
+	}
+
+	// Max items per row entry (only relevant for horizontal layout)
+	maxItemsEntry := widget.NewEntry()
+	maxItemsEntry.SetText(fmt.Sprintf("%d", settings.Ui.GetMaxItemsPerRow()))
+
+	updateMaxItemsEnabled := func(isHorizontal bool) {
+		if isHorizontal {
+			maxItemsEntry.Enable()
+		} else {
+			maxItemsEntry.Disable()
+		}
+	}
+	updateMaxItemsEnabled(currentLayout == linkquisition.PickerLayoutHorizontal)
+
+	layoutSelect := widget.NewSelect(layoutOptions, func(selected string) {
+		s := c.settingsService.GetSettings()
+		if selected == layoutOptions[1] {
+			s.Ui.PickerLayout = linkquisition.PickerLayoutHorizontal
+			updateMaxItemsEnabled(true)
+		} else {
+			s.Ui.PickerLayout = linkquisition.PickerLayoutVertical
+			updateMaxItemsEnabled(false)
+		}
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving picker layout setting", "error", err)
+		}
+	})
+	layoutSelect.Selected = selectedLayout
+
+	maxItemsEntry.OnChanged = func(value string) {
+		var n int
+		if _, err := fmt.Sscanf(value, "%d", &n); err != nil || n < 1 {
+			return
+		}
+		s := c.settingsService.GetSettings()
+		s.Ui.MaxItemsPerRow = n
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving max items per row setting", "error", err)
+		}
+	}
+
+	return container.NewVBox(
+		hideGuideCheck,
+		widget.NewSeparator(),
+		container.NewBorder(
+			nil, nil,
+			widget.NewLabel(i18n.T("config.picker_layout_label")), nil,
+			layoutSelect,
+		),
+		container.NewBorder(
+			nil, nil,
+			widget.NewLabel(i18n.T("config.picker_max_per_row_label")), nil,
+			maxItemsEntry,
+		),
+	)
 }
 
 func (c *Configurator) getAboutTab() fyne.CanvasObject {

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -227,36 +227,18 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 	}
 
 	// Max items per row entry (only relevant for horizontal layout)
-	maxItemsEntry := widget.NewEntry()
-	maxItemsEntry.SetText(fmt.Sprintf("%d", settings.Ui.GetMaxItemsPerRow()))
-
-	updateMaxItemsEnabled := func(isHorizontal bool) {
-		if isHorizontal {
-			maxItemsEntry.Enable()
-		} else {
-			maxItemsEntry.Disable()
-		}
+	maxItemsOptions := []string{"3", "4", "5", "6"}
+	currentMaxItems := fmt.Sprintf("%d", settings.Ui.GetMaxItemsPerRow())
+	// Clamp to valid range for display
+	if settings.Ui.GetMaxItemsPerRow() < 3 { //nolint:mnd
+		currentMaxItems = "3"
+	} else if settings.Ui.GetMaxItemsPerRow() > 6 { //nolint:mnd
+		currentMaxItems = "6"
 	}
-	updateMaxItemsEnabled(currentLayout == linkquisition.PickerLayoutHorizontal)
 
-	layoutSelect := widget.NewSelect(layoutOptions, func(selected string) {
-		s := c.settingsService.GetSettings()
-		if selected == layoutOptions[1] {
-			s.Ui.PickerLayout = linkquisition.PickerLayoutHorizontal
-			updateMaxItemsEnabled(true)
-		} else {
-			s.Ui.PickerLayout = linkquisition.PickerLayoutVertical
-			updateMaxItemsEnabled(false)
-		}
-		if err := c.settingsService.WriteSettings(s); err != nil {
-			c.logger.Error("Error saving picker layout setting", "error", err)
-		}
-	})
-	layoutSelect.Selected = selectedLayout
-
-	maxItemsEntry.OnChanged = func(value string) {
+	maxItemsSelect := widget.NewSelect(maxItemsOptions, func(value string) {
 		var n int
-		if _, err := fmt.Sscanf(value, "%d", &n); err != nil || n < 1 {
+		if _, err := fmt.Sscanf(value, "%d", &n); err != nil {
 			return
 		}
 		s := c.settingsService.GetSettings()
@@ -264,7 +246,38 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 		if err := c.settingsService.WriteSettings(s); err != nil {
 			c.logger.Error("Error saving max items per row setting", "error", err)
 		}
+	})
+	maxItemsSelect.Selected = currentMaxItems
+
+	maxItemsRow := container.NewBorder(
+		nil, nil,
+		widget.NewLabel(i18n.T("config.picker_max_per_row_label")), nil,
+		maxItemsSelect,
+	)
+
+	updateMaxItemsVisible := func(isHorizontal bool) {
+		if isHorizontal {
+			maxItemsRow.Show()
+		} else {
+			maxItemsRow.Hide()
+		}
 	}
+	updateMaxItemsVisible(currentLayout == linkquisition.PickerLayoutHorizontal)
+
+	layoutSelect := widget.NewSelect(layoutOptions, func(selected string) {
+		s := c.settingsService.GetSettings()
+		if selected == layoutOptions[1] {
+			s.Ui.PickerLayout = linkquisition.PickerLayoutHorizontal
+			updateMaxItemsVisible(true)
+		} else {
+			s.Ui.PickerLayout = linkquisition.PickerLayoutVertical
+			updateMaxItemsVisible(false)
+		}
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving picker layout setting", "error", err)
+		}
+	})
+	layoutSelect.Selected = selectedLayout
 
 	return container.NewVBox(
 		hideGuideCheck,
@@ -274,11 +287,7 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 			widget.NewLabel(i18n.T("config.picker_layout_label")), nil,
 			layoutSelect,
 		),
-		container.NewBorder(
-			nil, nil,
-			widget.NewLabel(i18n.T("config.picker_max_per_row_label")), nil,
-			maxItemsEntry,
-		),
+		maxItemsRow,
 	)
 }
 

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -17,7 +17,21 @@ import (
 func (c *Configurator) getBrowsersTab() fyne.CanvasObject {
 	content := container.NewVBox()
 	c.rebuildBrowsersList(content)
-	return container.NewVScroll(content)
+
+	scrollArea := container.NewVScroll(content)
+
+	scanBtn := widget.NewButton(i18n.T("config.rescan_browsers"), nil)
+	scanBtn.OnTapped = func() {
+		c.scanBrowsersAndRebuild(content, scanBtn)
+	}
+
+	addBtn := widget.NewButton(i18n.T("config.browsers_add"), func() {
+		c.showAddBrowserDialog(content)
+	})
+
+	bottomBar := container.NewHBox(scanBtn, addBtn)
+
+	return container.NewBorder(nil, bottomBar, nil, nil, scrollArea)
 }
 
 func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
@@ -49,19 +63,6 @@ func (c *Configurator) rebuildBrowsersList(content *fyne.Container) {
 		content.Add(c.buildBrowserCard(settings, idx, content))
 	}
 
-	// Action buttons at the bottom
-	content.Add(layout.NewSpacer())
-
-	scanBtn := widget.NewButton(i18n.T("config.rescan_browsers"), nil)
-	scanBtn.OnTapped = func() {
-		c.scanBrowsersAndRebuild(content, scanBtn)
-	}
-
-	addBtn := widget.NewButton(i18n.T("config.browsers_add"), func() {
-		c.showAddBrowserDialog(content)
-	})
-
-	content.Add(container.NewHBox(scanBtn, addBtn))
 	content.Refresh()
 }
 

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -89,6 +89,14 @@ and *rule* subcommands).
 *hideKeyboardGuideLabel* (boolean, optional)
 	If _true_, hides the keyboard shortcut guide at the bottom of the picker.
 
+*pickerLayout* (string, optional)
+	Layout style for the browser picker window. One of: _vertical_ (default,
+	list of buttons) or _horizontal_ (grid of square icon buttons).
+
+*maxItemsPerRow* (integer, optional)
+	Maximum number of browser buttons per row in _horizontal_ layout.
+	Default: _5_. Browsers exceeding this number wrap to additional rows.
+
 # EXAMPLE
 
 ```
@@ -114,7 +122,11 @@ and *rule* subcommands).
       "path": "unwrap",
       "isDisabled": false
     }
-  ]
+  ],
+  "ui": {
+    "pickerLayout": "horizontal",
+    "maxItemsPerRow": 5
+  }
 }
 ```
 

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -241,5 +241,17 @@
   },
   "config.macos_picker_note": {
     "other": "Note: The browser picker window is not available while this settings screen is open. Links clicked while settings are open will be opened in the first matching browser automatically."
+  },
+  "config.picker_layout_label": {
+    "other": "Picker layout:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertical (list)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (buttons)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Max items per row:"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -241,5 +241,17 @@
   },
   "config.macos_picker_note": {
     "other": "Nota: La ventana de selección de navegador no está disponible mientras esta pantalla de ajustes está abierta. Los enlaces se abrirán automáticamente en el primer navegador coincidente."
+  },
+  "config.picker_layout_label": {
+    "other": "Diseño del selector:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertical (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (botones)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Máximo por fila:"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -241,5 +241,17 @@
   },
   "config.macos_picker_note": {
     "other": "Huom: Selainvalitsinikkuna ei ole käytettävissä kun asetusikkuna on auki. Linkit avataan automaattisesti ensimmäisellä vastaavalla selaimella."
+  },
+  "config.picker_layout_label": {
+    "other": "Valitsimen asettelu:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Pystysuora (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Vaakasuora (painikkeet)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Enimmäismäärä per rivi:"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -241,5 +241,17 @@
   },
   "config.macos_picker_note": {
     "other": "Obs: Webbläsarväljaren är inte tillgänglig medan detta inställningsfönster är öppet. Länkar öppnas automatiskt i den första matchande webbläsaren."
+  },
+  "config.picker_layout_label": {
+    "other": "Väljarens layout:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertikal (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horisontell (knappar)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Max per rad:"
   }
 }

--- a/settings.go
+++ b/settings.go
@@ -21,6 +21,11 @@ const (
 	LogLevelInfo  = "info"
 	LogLevelWarn  = "warn"
 	LogLevelError = "error"
+
+	PickerLayoutVertical   = "vertical"
+	PickerLayoutHorizontal = "horizontal"
+
+	DefaultMaxItemsPerRow = 5
 )
 
 type BrowserMatch struct {
@@ -105,7 +110,25 @@ type PluginSettings struct {
 }
 
 type UiSettings struct {
-	HideKeyboardGuideLabel bool `json:"hideKeyboardGuideLabel,omitempty"`
+	HideKeyboardGuideLabel bool   `json:"hideKeyboardGuideLabel,omitempty"`
+	PickerLayout           string `json:"pickerLayout,omitempty"`
+	MaxItemsPerRow         int    `json:"maxItemsPerRow,omitempty"`
+}
+
+// GetPickerLayout returns the effective picker layout, defaulting to vertical.
+func (u *UiSettings) GetPickerLayout() string {
+	if u.PickerLayout == PickerLayoutHorizontal {
+		return PickerLayoutHorizontal
+	}
+	return PickerLayoutVertical
+}
+
+// GetMaxItemsPerRow returns the effective max items per row, defaulting to DefaultMaxItemsPerRow.
+func (u *UiSettings) GetMaxItemsPerRow() int {
+	if u.MaxItemsPerRow > 0 {
+		return u.MaxItemsPerRow
+	}
+	return DefaultMaxItemsPerRow
 }
 
 type Settings struct {

--- a/settings_test.go
+++ b/settings_test.go
@@ -937,3 +937,68 @@ func TestBrowserSettings_MatchesUrl_FallbackCompilesRegexOnDemand(t *testing.T) 
 	assert.True(t, browser.MatchesUrl("https://internal.corp.example.com/app"))
 	assert.False(t, browser.MatchesUrl("https://external.example.com"))
 }
+
+func TestUiSettings_GetPickerLayout(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		ui       UiSettings
+		expected string
+	}{
+		{
+			name:     "defaults to vertical when empty",
+			ui:       UiSettings{},
+			expected: PickerLayoutVertical,
+		},
+		{
+			name:     "returns vertical when explicitly set",
+			ui:       UiSettings{PickerLayout: PickerLayoutVertical},
+			expected: PickerLayoutVertical,
+		},
+		{
+			name:     "returns horizontal when set",
+			ui:       UiSettings{PickerLayout: PickerLayoutHorizontal},
+			expected: PickerLayoutHorizontal,
+		},
+		{
+			name:     "defaults to vertical for unknown value",
+			ui:       UiSettings{PickerLayout: "unknown"},
+			expected: PickerLayoutVertical,
+		},
+	} {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.ui.GetPickerLayout())
+			},
+		)
+	}
+}
+
+func TestUiSettings_GetMaxItemsPerRow(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		ui       UiSettings
+		expected int
+	}{
+		{
+			name:     "defaults to DefaultMaxItemsPerRow when zero",
+			ui:       UiSettings{},
+			expected: DefaultMaxItemsPerRow,
+		},
+		{
+			name:     "returns configured value when positive",
+			ui:       UiSettings{MaxItemsPerRow: 3},
+			expected: 3,
+		},
+		{
+			name:     "defaults when negative",
+			ui:       UiSettings{MaxItemsPerRow: -1},
+			expected: DefaultMaxItemsPerRow,
+		},
+	} {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.ui.GetMaxItemsPerRow())
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional "horizontal" (button grid) layout for the browser picker window, configurable via the settings screen or `config.json`.

## Changes

- **Config model**: New `pickerLayout` (`"vertical"` | `"horizontal"`) and `maxItemsPerRow` (3–6, default 5) fields in the `ui` section
- **Browser picker**: When horizontal layout is active, browsers are shown as square buttons with a 96×96 icon centered and the browser name below. Buttons highlight on hover. The grid wraps at `maxItemsPerRow` columns. Missing icons show a letter placeholder.
- **Configurator**: The General tab now has a layout dropdown and a "max items per row" selector (hidden when vertical is selected). Also moves the scan/add buttons in the Browsers tab below the scroll area.
- **Documentation**: Updated `linkquisition.5.scd` man page with new UI settings
- **Tests**: Unit tests for `GetPickerLayout()` and `GetMaxItemsPerRow()` helpers
- **Translations**: All 4 locales (en, fi, es, sv) updated

## Config example

```json
{
  "ui": {
    "pickerLayout": "horizontal",
    "maxItemsPerRow": 5
  }
}
```

## Keyboard shortcuts

All shortcuts (1–9 to select, Enter for first, Escape to quit, Ctrl+C/⌘+C to copy) work identically in both layouts.