### PR TITLE
feat: add shenanigans plugin with visual effects for the browser picker

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,6 +91,24 @@ builds:
       - -X main.commitSHA={{.FullCommit}}
       - -X main.buildDate={{.Date}}
 
+  - id: "shenanigans-plugin"
+    binary: "plugins/shenanigans.so"
+    buildmode: plugin
+    no_main_check: true
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./plugins/shenanigans/
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commitSHA={{.FullCommit}}
+      - -X main.buildDate={{.Date}}
+
 nfpms:
   - package_name: linkquisition
     homepage: https://github.com/Strobotti/linkquisition
@@ -113,6 +131,8 @@ nfpms:
         dst: /usr/lib/linkquisition/plugins/sanitize.so
       - src: ./dist/defang-plugin_{{ .Os }}_{{ .Arch }}_v1/plugins/defang.so
         dst: /usr/lib/linkquisition/plugins/defang.so
+      - src: ./dist/shenanigans-plugin_{{ .Os }}_{{ .Arch }}_v1/plugins/shenanigans.so
+        dst: /usr/lib/linkquisition/plugins/shenanigans.so
       - src: package/linux
         dst: /
         type: tree

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -71,11 +71,11 @@ tasks:
   build-plugins:
     internal: true
     vars:
-      PLUGINS: "unwrap terminus sanitize defang"
+      PLUGINS: "unwrap terminus sanitize defang shenanigans"
     cmds:
       - mkdir -p {{.OUTPUT_DIR}}
       - for: { var: PLUGINS }
-        cmd: go build -buildmode=plugin -o {{.OUTPUT_DIR}}/{{.ITEM}}.so ./plugins/{{.ITEM}}/{{.ITEM}}.go
+        cmd: go build -tags release -buildmode=plugin -o {{.OUTPUT_DIR}}/{{.ITEM}}.so ./plugins/{{.ITEM}}/{{.ITEM}}.go
 
   clean:
     cmds:

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -7,7 +7,7 @@ vars:
 tasks:
   clean:
     cmds:
-      - rm -rfv dist package
+      - rm -rfv dist package/linux
 
   manpages:
     description: "Builds man pages from scdoc sources"
@@ -54,6 +54,26 @@ tasks:
     description: "Builds the .app bundle and installs it to /Applications"
     cmds:
       - task package:app
+      - cp -r dist/Linkquisition.app /Applications/
+      - /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -R -f /Applications/Linkquisition.app
+      - echo "Installed to /Applications/Linkquisition.app and registered with Launch Services"
+
+  app:dev:
+    description: "Builds a macOS .app bundle with a native single-arch binary (required for plugins to load)"
+    cmds:
+      - rm -rf dist/Linkquisition.app
+      - mkdir -p dist/Linkquisition.app/Contents/MacOS
+      - mkdir -p dist/Linkquisition.app/Contents/Resources
+      - go build -tags release -ldflags '-s -w -X main.version={{.VERSION}}' -o dist/Linkquisition.app/Contents/MacOS/linkquisition ./cmd/
+      - task build:plugins-darwin
+      - sed 's/${VERSION}/{{.VERSION}}/g' package/darwin/Info.plist > dist/Linkquisition.app/Contents/Info.plist
+      - sips -s format icns Icon.png --out dist/Linkquisition.app/Contents/Resources/Icon.icns 2>/dev/null || cp Icon.png dist/Linkquisition.app/Contents/Resources/Icon.icns
+      - echo "dist/Linkquisition.app created successfully (single-arch, plugin-compatible)"
+
+  app:install-dev:
+    description: "Builds a single-arch .app bundle and installs to /Applications (plugins work correctly)"
+    cmds:
+      - task package:app:dev
       - cp -r dist/Linkquisition.app /Applications/
       - /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -R -f /Applications/Linkquisition.app
       - echo "Installed to /Applications/Linkquisition.app and registered with Launch Services"

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -374,7 +374,7 @@ func (a *Application) openWithBrowserOrPicker(urlToOpen string) error {
 		a.Logger.Warn("browsers not configured, falling back to system settings")
 	}
 
-	bp := NewBrowserPicker(a.Fapp, a.BrowserService, browsers, a.SettingsService, a.Logger)
+	bp := NewBrowserPicker(a.Fapp, a.BrowserService, browsers, a.SettingsService, a.Logger, a.collectUIHooks())
 	return bp.Run(context.Background(), urlToOpen)
 }
 
@@ -395,6 +395,17 @@ func (a *Application) shutdownPlugins() {
 		}(plug)
 	}
 	wg.Wait()
+}
+
+// collectUIHooks returns all loaded plugins that implement the PluginUIHook interface.
+func (a *Application) collectUIHooks() []linkquisition.PluginUIHook {
+	var hooks []linkquisition.PluginUIHook
+	for _, plug := range a.plugins {
+		if hook, ok := plug.(linkquisition.PluginUIHook); ok {
+			hooks = append(hooks, hook)
+		}
+	}
+	return hooks
 }
 
 func (a *Application) openInFirstBrowser(urlToOpen string) error {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -35,6 +35,7 @@ type BrowserPicker struct {
 	browsers        []linkquisition.Browser
 	settingsService linkquisition.SettingsService
 	logger          *slog.Logger
+	uiHooks         []linkquisition.PluginUIHook
 }
 
 func NewBrowserPicker(
@@ -43,6 +44,7 @@ func NewBrowserPicker(
 	browsers []linkquisition.Browser,
 	settingsService linkquisition.SettingsService,
 	logger *slog.Logger,
+	uiHooks []linkquisition.PluginUIHook,
 ) *BrowserPicker {
 	return &BrowserPicker{
 		fapp:            fapp,
@@ -50,6 +52,7 @@ func NewBrowserPicker(
 		browsers:        browsers,
 		settingsService: settingsService,
 		logger:          logger,
+		uiHooks:         uiHooks,
 	}
 }
 
@@ -124,7 +127,10 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	}
 
 	w.SetFixedSize(true)
-	w.SetContent(container.NewVBox(widgets...))
+
+	mainContent := container.NewVBox(widgets...)
+	w.SetContent(buildPickerContent(mainContent, w, picker.uiHooks))
+
 	w.CenterOnScreen()
 
 	w.ShowAndRun()

--- a/cmd/picker_canvas.go
+++ b/cmd/picker_canvas.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"image"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+
+	"github.com/strobotti/linkquisition"
+)
+
+// Compile-time check that fynePickerCanvas implements PickerCanvas.
+var _ linkquisition.PickerCanvas = (*fynePickerCanvas)(nil)
+
+// fynePickerCanvas adapts a fyne.Window to the PickerCanvas interface,
+// allowing plugins to draw effects without importing fyne directly.
+// Effects are rendered as background layers beneath the main content,
+// so they do not intercept mouse/touch input.
+type fynePickerCanvas struct {
+	window  fyne.Window
+	rasters []*canvas.Raster
+}
+
+func newFynePickerCanvas(window fyne.Window) *fynePickerCanvas {
+	return &fynePickerCanvas{window: window}
+}
+
+func (c *fynePickerCanvas) AddRasterOverlay(translucency float64, draw func(w, h int) []uint8) {
+	raster := canvas.NewRaster(func(w, h int) image.Image {
+		if draw == nil || w == 0 || h == 0 {
+			return image.NewRGBA(image.Rect(0, 0, 1, 1))
+		}
+
+		pixels := draw(w, h)
+		img := image.NewRGBA(image.Rect(0, 0, w, h))
+
+		expectedLen := w * h * 4 //nolint:mnd
+		if len(pixels) >= expectedLen {
+			copy(img.Pix, pixels[:expectedLen])
+		} else {
+			copy(img.Pix, pixels)
+		}
+
+		return img
+	})
+	raster.Translucency = translucency
+	c.rasters = append(c.rasters, raster)
+}
+
+func (c *fynePickerCanvas) ScheduleRefresh() {
+	fyne.Do(func() {
+		for _, r := range c.rasters {
+			canvas.Refresh(r)
+		}
+	})
+}
+
+func (c *fynePickerCanvas) Width() int {
+	return int(c.window.Canvas().Size().Width)
+}
+
+func (c *fynePickerCanvas) Height() int {
+	return int(c.window.Canvas().Size().Height)
+}
+
+// buildPickerContent wraps the main content with any plugin effect layers underneath.
+// Effects are rendered as background layers in a Stack container, so they don't block input.
+// The content (buttons, labels) sits on top and receives all mouse/keyboard events normally.
+func buildPickerContent(
+	content fyne.CanvasObject, window fyne.Window, hooks []linkquisition.PluginUIHook,
+) fyne.CanvasObject {
+	if len(hooks) == 0 {
+		return content
+	}
+
+	var layers []fyne.CanvasObject
+
+	// Let each hook add its raster layers
+	for _, hook := range hooks {
+		pc := newFynePickerCanvas(window)
+		hook.OnPickerShown(pc)
+
+		for _, r := range pc.rasters {
+			layers = append(layers, r)
+		}
+	}
+
+	if len(layers) == 0 {
+		return content
+	}
+
+	// Stack: effects at the bottom, content on top
+	layers = append(layers, content)
+
+	return container.NewStack(layers...)
+}

--- a/cmd/picker_canvas.go
+++ b/cmd/picker_canvas.go
@@ -35,7 +35,7 @@ func (c *fynePickerCanvas) AddRasterOverlay(translucency float64, draw func(w, h
 		pixels := draw(w, h)
 		img := image.NewRGBA(image.Rect(0, 0, w, h))
 
-		expectedLen := w * h * 4 //nolint:mnd
+		expectedLen := w * h * 4
 		if len(pixels) >= expectedLen {
 			copy(img.Pix, pixels[:expectedLen])
 		} else {

--- a/plugin_ui_hook.go
+++ b/plugin_ui_hook.go
@@ -1,0 +1,44 @@
+package linkquisition
+
+// PluginUIHook is an optional interface that plugins can implement to receive
+// a callback when the browser picker window is shown. This allows plugins to
+// add visual effects, overlays, or animations to the picker UI.
+//
+// The host application checks each loaded plugin for this interface using a type
+// assertion. Plugins that do not implement it are simply skipped.
+//
+// The PickerCanvas abstraction is used instead of fyne.Window directly, so that
+// plugins do not need to import fyne.io/fyne/v2 (which causes build-flag
+// mismatches when the host binary is compiled with different ldflags or tags).
+type PluginUIHook interface {
+	// OnPickerShown is called after the browser picker window content is set
+	// and before it is displayed. The plugin receives a PickerCanvas that
+	// provides methods to add visual overlays.
+	//
+	// Implementations must not block — start goroutines for ongoing animations.
+	// The window may be closed at any time; plugins should not panic if refresh
+	// calls fail after the window is gone.
+	OnPickerShown(canvas PickerCanvas)
+}
+
+// PickerCanvas provides a limited interface for plugins to draw overlays on
+// the browser picker window. This abstraction avoids requiring plugins to
+// import fyne.io/fyne/v2 directly.
+type PickerCanvas interface {
+	// AddRasterOverlay adds a pixel-based overlay to the picker window.
+	// The draw function is called each time the overlay needs to be rendered.
+	// It receives the width and height of the canvas and must return RGBA pixel
+	// data (4 bytes per pixel: R, G, B, A) in row-major order.
+	// Translucency is a value from 0.0 (opaque) to 1.0 (fully transparent).
+	AddRasterOverlay(translucency float64, draw func(w, h int) []uint8)
+
+	// ScheduleRefresh requests that the overlay be redrawn. Call this from a
+	// goroutine after updating animation state. Safe to call from any goroutine.
+	ScheduleRefresh()
+
+	// Width returns the current canvas width in pixels.
+	Width() int
+
+	// Height returns the current canvas height in pixels.
+	Height() int
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -195,9 +195,17 @@ when it appears.
 
 ### Available effects
 
-- `matrix` — Green "Matrix rain" characters falling over the picker content
-- `fire` — Flames licking up from the bottom half of the window
-- `random` — Randomly picks one of the above effects each time
+- `random` — Randomly picks one of the effects below (default)
+- `aurora` — Northern lights with flowing green/purple/blue bands
+- `fire` — Realistic flames rising from the bottom of the window
+- `fireworks` — Rockets launching and exploding into colorful particle bursts
+- `football` — Top-down football/soccer pitch with animated spotlight sweep
+- `glitch` — Cyberpunk-style RGB channel splitting with periodic static bursts
+- `matrix` — Green Matrix-style falling characters
+- `plasma` — Classic demoscene swirling color blobs
+- `pride` — Animated rainbow pride flag waving in the wind
+- `snow` — Gentle snowfall with varying sizes and wobble
+- `starfield` — 3D warp-speed stars flying toward the viewer
 
 ### Configuration
 
@@ -219,9 +227,9 @@ when it appears.
 
 ### Settings
 
-| Setting  | Type   | Default    | Description                                             |
-|----------|--------|------------|---------------------------------------------------------|
-| `effect` | choice | `"random"` | Which visual effect to show: `matrix`, `fire`, `random` |
+| Setting  | Type   | Default    | Description                                      |
+|----------|--------|------------|--------------------------------------------------|
+| `effect` | choice | `"random"` | Which visual effect to show on the picker window |
 
 ## Developing plugins
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -184,6 +184,45 @@ whatever is cached and updates lazily.
 - `warn` — shows a native dialog with an "Open anyway" option, letting the user choose to proceed
 - `log` — logs the blocked domain but still opens the URL normally (useful for monitoring without disruption)
 
+## [Shenanigans](./shenanigans/shenanigans.go) -plugin
+
+This plugin adds completely useless but entertaining visual effects to the browser picker window.
+It demonstrates the `PluginUIHook` interface — an optional extension that allows plugins to interact
+with the picker GUI.
+
+The plugin does not modify URLs in any way. It simply overlays animated effects on the picker window
+when it appears.
+
+### Available effects
+
+- `matrix` — Green "Matrix rain" characters falling over the picker content
+- `fire` — Flames licking up from the bottom half of the window
+- `random` — Randomly picks one of the above effects each time
+
+### Configuration
+
+```json
+{
+  "browsers": [
+    ...
+  ],
+  "plugins": [
+    {
+      "path": "shenanigans.so",
+      "settings": {
+        "effect": "random"
+      }
+    }
+  ]
+}
+```
+
+### Settings
+
+| Setting  | Type   | Default    | Description                                             |
+|----------|--------|------------|---------------------------------------------------------|
+| `effect` | choice | `"random"` | Which visual effect to show: `matrix`, `fire`, `random` |
+
 ## Developing plugins
 
 The plugin is a shared object file (`.so`) that is loaded by the main application. The plugin must implement the
@@ -202,3 +241,14 @@ The plugin is a shared object file (`.so`) that is loaded by the main applicatio
     - `ActionOpenDirect` — bypass browser matching and open in the first available browser
 - `Shutdown(ctx context.Context)` — called when the application is about to exit. Plugins with background work (e.g.
   downloads) should use this to finish gracefully before the context deadline expires.
+
+### Optional: PluginUIHook interface
+
+Plugins can optionally implement the [`PluginUIHook`](../plugin_ui_hook.go) interface to receive a callback when the
+browser picker window is shown:
+
+- `OnPickerShown(window fyne.Window)` — called after the picker window content is set and before it is displayed.
+  The plugin can add canvas overlays, start animations, or modify the window appearance.
+
+The host application detects this interface via a type assertion — plugins that don't implement it are simply skipped.
+See the [Shenanigans](./shenanigans/shenanigans.go) plugin for an example.

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -15,6 +15,7 @@ const (
 	effectSnow        = "snow"
 	effectPlasma      = "plasma"
 	effectStarfield   = "starfield"
+	effectAurora      = "aurora"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -45,10 +46,13 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, or random",
+				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, aurora, or random",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
-				Options:     []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield, effectRandom},
+				Options: []string{
+					effectMatrix, effectFire, effectSnow, effectPlasma,
+					effectStarfield, effectAurora, effectRandom,
+				},
 			},
 		},
 	}
@@ -83,7 +87,7 @@ func (p *shenanigans) Shutdown(_ context.Context) {
 func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	effect := p.effect
 	if effect == effectRandom {
-		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield}
+		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield, effectAurora}
 		effect = effects[rand.IntN(len(effects))]
 	}
 
@@ -100,6 +104,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startPlasma(canvas)
 	case effectStarfield:
 		p.startStarfield(canvas)
+	case effectAurora:
+		p.startAurora(canvas)
 	}
 }
 
@@ -813,6 +819,149 @@ func (s *starfieldState) render() []uint8 {
 	}
 
 	return pixels
+}
+
+// --- Aurora Effect ---
+
+const auroraLayers = 4
+
+type auroraState struct {
+	time float64
+}
+
+func (p *shenanigans) startAurora(pc linkquisition.PickerCanvas) {
+	state := &auroraState{}
+
+	pc.AddRasterOverlay(0.4, func(w, h int) []uint8 {
+		return state.render(w, h)
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.time += 0.03 //nolint:mnd
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *auroraState) render(w, h int) []uint8 {
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+	t := s.time
+
+	// Aurora occupies the top 2/3 of the window
+	auroraEndY := h * 2 / 3
+
+	for py := 0; py < auroraEndY; py++ {
+		// Vertical position normalized (0 at top, 1 at aurora bottom)
+		fy := float64(py) / float64(auroraEndY)
+
+		for px := 0; px < w; px++ {
+			fx := float64(px) / float64(w)
+
+			// Combine multiple curtain layers
+			var intensity float64
+			for layer := range auroraLayers {
+				fl := float64(layer)
+				// Each layer has different frequency, speed, and phase
+				wave := sinApprox((fx*(3+fl) + t*(0.4+fl*0.15) + fl*1.7) * 3.14159)     //nolint:mnd
+				wave2 := sinApprox((fx*(2+fl*0.7) - t*(0.3+fl*0.1) + fl*2.3) * 3.14159) //nolint:mnd
+
+				// Curtain shape: thin band that undulates
+				curtainCenter := 0.2 + 0.15*fl + 0.1*(wave*0.5+0.5) //nolint:mnd
+				curtainWidth := 0.08 + 0.04*wave2                   //nolint:mnd
+
+				// Gaussian-like falloff from the curtain center
+				dist := (fy - curtainCenter) / curtainWidth
+				layerIntensity := fastExp(-dist * dist * 0.5) //nolint:mnd
+
+				intensity += layerIntensity * (0.6 + 0.4/(fl+1)) //nolint:mnd
+			}
+
+			if intensity < 0.01 { //nolint:mnd
+				continue
+			}
+			if intensity > 1.0 {
+				intensity = 1.0
+			}
+
+			// Aurora color: shift from green to purple/blue based on position and time
+			colorPhase := fx*0.5 + fy*0.3 + t*0.1 //nolint:mnd
+			r, g, b := auroraColor(colorPhase, intensity)
+
+			alpha := uint8(intensity * 180) //nolint:mnd,gosec
+
+			offset := (py*w + px) * rgbaChannels
+			pixels[offset] = r
+			pixels[offset+1] = g
+			pixels[offset+2] = b
+			pixels[offset+3] = alpha
+		}
+	}
+
+	return pixels
+}
+
+// auroraColor maps a phase and intensity to northern lights colors.
+// Shifts between green, teal, blue, and purple.
+func auroraColor(phase, intensity float64) (r, g, b uint8) {
+	// Cycle through aurora palette
+	p := sinApprox(phase * 3.14159 * 2) //nolint:mnd
+	p = (p + 1.0) / 2.0                 // normalize to 0-1
+
+	// Blend between green-dominant and purple-dominant
+	var rf, gf, bf float64
+	switch {
+	case p < 0.33: //nolint:mnd
+		// Green to teal
+		t := p / 0.33 //nolint:mnd
+		rf = 0.1 * t
+		gf = 0.8 + 0.2*t //nolint:mnd
+		bf = 0.2 + 0.5*t //nolint:mnd
+	case p < 0.66: //nolint:mnd
+		// Teal to purple
+		t := (p - 0.33) / 0.33 //nolint:mnd
+		rf = 0.1 + 0.5*t       //nolint:mnd
+		gf = 1.0 - 0.6*t       //nolint:mnd
+		bf = 0.7 + 0.3*t       //nolint:mnd
+	default:
+		// Purple back to green
+		t := (p - 0.66) / 0.34 //nolint:mnd
+		rf = 0.6 - 0.5*t       //nolint:mnd
+		gf = 0.4 + 0.4*t       //nolint:mnd
+		bf = 1.0 - 0.8*t       //nolint:mnd
+	}
+
+	r = uint8(rf * intensity * 255) //nolint:mnd,gosec
+	g = uint8(gf * intensity * 255) //nolint:mnd,gosec
+	b = uint8(bf * intensity * 255) //nolint:mnd,gosec
+	return r, g, b
+}
+
+// fastExp approximates e^x for negative x values (used for Gaussian falloff).
+func fastExp(x float64) float64 {
+	if x < -6 { //nolint:mnd
+		return 0
+	}
+	// Padé approximation: (1 + x/n)^n for small |x|
+	// Using n=8 for reasonable accuracy
+	t := 1.0 + x/8.0 //nolint:mnd
+	t *= t           // ^2
+	t *= t           // ^4
+	t *= t           // ^8
+	if t < 0 {
+		return 0
+	}
+	return t
 }
 
 // sinNorm returns sinApprox mapped to 0.0-1.0 range.

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -17,6 +17,7 @@ const (
 	effectStarfield   = "starfield"
 	effectAurora      = "aurora"
 	effectGlitch      = "glitch"
+	effectPride       = "pride"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -47,12 +48,13 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, aurora, glitch, or random",
+				Description: "Which visual effect to show on the picker window",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
 				Options: []string{
 					effectMatrix, effectFire, effectSnow, effectPlasma,
-					effectStarfield, effectAurora, effectGlitch, effectRandom,
+					effectStarfield, effectAurora, effectGlitch, effectPride,
+					effectRandom,
 				},
 			},
 		},
@@ -90,7 +92,7 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	if effect == effectRandom {
 		effects := []string{
 			effectMatrix, effectFire, effectSnow, effectPlasma,
-			effectStarfield, effectAurora, effectGlitch,
+			effectStarfield, effectAurora, effectGlitch, effectPride,
 		}
 		effect = effects[rand.IntN(len(effects))]
 	}
@@ -112,6 +114,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startAurora(canvas)
 	case effectGlitch:
 		p.startGlitch(canvas)
+	case effectPride:
+		p.startPride(canvas)
 	}
 }
 
@@ -1103,6 +1107,109 @@ func (s *glitchState) render(w, h int) []uint8 {
 			pixels[offset+1] = v
 			pixels[offset+2] = v
 			pixels[offset+3] = uint8(rand.IntN(100)) //nolint:mnd,gosec
+		}
+	}
+
+	return pixels
+}
+
+// --- Pride Effect ---
+
+type prideState struct {
+	time float64
+}
+
+// Pride flag colors (6-stripe rainbow)
+var prideColors = [][3]uint8{
+	{228, 3, 3},   // Red
+	{255, 140, 0}, // Orange
+	{255, 237, 0}, // Yellow
+	{0, 128, 38},  // Green
+	{0, 77, 255},  // Blue
+	{117, 7, 135}, // Purple
+}
+
+func (p *shenanigans) startPride(pc linkquisition.PickerCanvas) {
+	state := &prideState{}
+
+	pc.AddRasterOverlay(0.45, func(w, h int) []uint8 {
+		return state.render(w, h)
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.time += 0.04 //nolint:mnd
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *prideState) render(w, h int) []uint8 {
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+	t := s.time
+	stripeCount := float64(len(prideColors))
+
+	for py := 0; py < h; py++ {
+		for px := 0; px < w; px++ {
+			fx := float64(px) / float64(w)
+			fy := float64(py) / float64(h)
+
+			// Flag wave: pinned on the left edge, wave amplitude increases to the right
+			// This simulates fabric attached to a pole on the left side
+			amplitude := fx * fx * 0.05 //nolint:mnd
+			wave := sinApprox((fx*2.0-t*1.5)*3.14159) * amplitude
+			wave2 := sinApprox((fx*3.0-t*2.0)*3.14159) * amplitude * 0.4 //nolint:mnd
+
+			// Determine which stripe this pixel belongs to (with wave offset)
+			stripePos := (fy + wave + wave2) * stripeCount
+			stripeIdx := int(stripePos)
+
+			if stripeIdx < 0 {
+				stripeIdx = 0
+			}
+			if stripeIdx >= len(prideColors) {
+				stripeIdx = len(prideColors) - 1
+			}
+
+			// Smooth blending between stripes
+			blend := stripePos - float64(stripeIdx)
+			nextIdx := stripeIdx + 1
+			if nextIdx >= len(prideColors) {
+				nextIdx = len(prideColors) - 1
+			}
+
+			c1 := prideColors[stripeIdx]
+			c2 := prideColors[nextIdx]
+
+			// Smooth interpolation (smoothstep-like)
+			blend = blend * blend * (3 - 2*blend) //nolint:mnd
+
+			r := uint8(float64(c1[0])*(1-blend) + float64(c2[0])*blend) //nolint:gosec
+			g := uint8(float64(c1[1])*(1-blend) + float64(c2[1])*blend) //nolint:gosec
+			b := uint8(float64(c1[2])*(1-blend) + float64(c2[2])*blend) //nolint:gosec
+
+			// Subtle shading to simulate fabric folds (stronger toward free edge)
+			foldDepth := fx * 0.15                                               //nolint:mnd
+			shade := 1.0 - foldDepth + foldDepth*sinApprox((fx*3-t*1.5)*3.14159) //nolint:mnd
+			r = uint8(float64(r) * shade)                                        //nolint:gosec
+			g = uint8(float64(g) * shade)                                        //nolint:gosec
+			b = uint8(float64(b) * shade)                                        //nolint:gosec
+
+			offset := (py*w + px) * rgbaChannels
+			pixels[offset] = r
+			pixels[offset+1] = g
+			pixels[offset+2] = b
+			pixels[offset+3] = 200 //nolint:mnd
 		}
 	}
 

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -19,6 +19,7 @@ const (
 	effectGlitch      = "glitch"
 	effectPride       = "pride"
 	effectFootball    = "football"
+	effectFireworks   = "fireworks"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -55,7 +56,7 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 				Options: []string{
 					effectMatrix, effectFire, effectSnow, effectPlasma,
 					effectStarfield, effectAurora, effectGlitch, effectPride,
-					effectFootball, effectRandom,
+					effectFootball, effectFireworks, effectRandom,
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		effects := []string{
 			effectMatrix, effectFire, effectSnow, effectPlasma,
 			effectStarfield, effectAurora, effectGlitch, effectPride,
-			effectFootball,
+			effectFootball, effectFireworks,
 		}
 		effect = effects[rand.IntN(len(effects))]
 	}
@@ -120,6 +121,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startPride(canvas)
 	case effectFootball:
 		p.startFootball(canvas)
+	case effectFireworks:
+		p.startFireworks(canvas)
 	}
 }
 
@@ -1346,6 +1349,201 @@ func (s *footballState) render() []uint8 {
 	}
 
 	return pixels
+}
+
+// --- Fireworks Effect ---
+
+const (
+	fireworksMaxRockets   = 5
+	fireworksParticles    = 60
+	fireworksLaunchChance = 8 // percent chance per frame to launch a new rocket
+)
+
+type fireworksParticle struct {
+	x, y    float64
+	vx, vy  float64
+	life    float64
+	r, g, b uint8
+}
+
+type fireworksRocket struct {
+	particles []fireworksParticle
+	exploded  bool
+	// Pre-explosion rocket position
+	x, y    float64
+	vy      float64
+	targetY float64
+	color   [3]uint8
+}
+
+type fireworksState struct {
+	rockets []fireworksRocket
+	width   int
+	height  int
+}
+
+var fireworksColors = [][3]uint8{
+	{255, 200, 50},  // Gold
+	{255, 80, 80},   // Red
+	{80, 150, 255},  // Blue
+	{80, 255, 80},   // Green
+	{200, 100, 255}, // Purple
+	{255, 150, 200}, // Pink
+	{255, 255, 255}, // White
+}
+
+func (p *shenanigans) startFireworks(pc linkquisition.PickerCanvas) {
+	state := &fireworksState{}
+
+	pc.AddRasterOverlay(0.2, func(w, h int) []uint8 {
+		state.width = w
+		state.height = h
+		return state.render()
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *fireworksState) update() {
+	if s.width == 0 || s.height == 0 {
+		return
+	}
+
+	// Chance to launch a new rocket
+	if len(s.rockets) < fireworksMaxRockets && rand.IntN(100) < fireworksLaunchChance { //nolint:mnd
+		color := fireworksColors[rand.IntN(len(fireworksColors))]
+		s.rockets = append(s.rockets, fireworksRocket{
+			x:       0.2 + rand.Float64()*0.6, //nolint:mnd
+			y:       1.0,
+			vy:      -0.025 - rand.Float64()*0.015, //nolint:mnd
+			targetY: 0.15 + rand.Float64()*0.35,    //nolint:mnd
+			color:   color,
+		})
+	}
+
+	// Update rockets
+	alive := s.rockets[:0]
+	for i := range s.rockets {
+		r := &s.rockets[i]
+
+		if !r.exploded {
+			r.y += r.vy
+			// Explode when reaching target height
+			if r.y <= r.targetY {
+				r.exploded = true
+				r.particles = make([]fireworksParticle, fireworksParticles)
+				for j := range r.particles {
+					angle := rand.Float64() * 6.283       //nolint:mnd
+					speed := 0.005 + rand.Float64()*0.015 //nolint:mnd
+					r.particles[j] = fireworksParticle{
+						x:    r.x,
+						y:    r.y,
+						vx:   sinApprox(angle) * speed,
+						vy:   sinApprox(angle+1.5708) * speed, //nolint:mnd
+						life: 1.0,
+						r:    r.color[0],
+						g:    r.color[1],
+						b:    r.color[2],
+					}
+				}
+			}
+		} else {
+			// Update particles
+			allDead := true
+			for j := range r.particles {
+				p := &r.particles[j]
+				if p.life <= 0 {
+					continue
+				}
+				p.x += p.vx
+				p.y += p.vy
+				p.vy += 0.0004  // gravity //nolint:mnd
+				p.vx *= 0.98    // drag    //nolint:mnd
+				p.vy *= 0.98    //nolint:mnd
+				p.life -= 0.015 //nolint:mnd
+				if p.life > 0 {
+					allDead = false
+				}
+			}
+			if allDead {
+				continue // don't keep this rocket
+			}
+		}
+		alive = append(alive, *r)
+	}
+	s.rockets = alive
+}
+
+func (s *fireworksState) render() []uint8 {
+	w, h := s.width, s.height
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+
+	for _, rocket := range s.rockets {
+		if !rocket.exploded {
+			// Draw rising rocket as a small bright dot with trail
+			px := int(rocket.x * float64(w))
+			py := int(rocket.y * float64(h))
+			s.drawDot(pixels, px, py, 2, 255, 220, 150, 255) //nolint:mnd
+			// Trail
+			s.drawDot(pixels, px, py+3, 1, 255, 150, 50, 150) //nolint:mnd
+			s.drawDot(pixels, px, py+6, 1, 255, 100, 30, 80)  //nolint:mnd
+		} else {
+			// Draw particles
+			for _, p := range rocket.particles {
+				if p.life <= 0 {
+					continue
+				}
+				px := int(p.x * float64(w))
+				py := int(p.y * float64(h))
+				alpha := uint8(p.life * 255) //nolint:mnd,gosec
+				size := 1
+				if p.life > 0.7 { //nolint:mnd
+					size = 2
+				}
+				s.drawDot(pixels, px, py, size, p.r, p.g, p.b, alpha)
+			}
+		}
+	}
+
+	return pixels
+}
+
+func (s *fireworksState) drawDot(pixels []uint8, cx, cy, radius int, r, g, b, a uint8) {
+	w, h := s.width, s.height
+	for dy := -radius; dy <= radius; dy++ {
+		for dx := -radius; dx <= radius; dx++ {
+			px := cx + dx
+			py := cy + dy
+			if px < 0 || px >= w || py < 0 || py >= h {
+				continue
+			}
+			if dx*dx+dy*dy > radius*radius {
+				continue
+			}
+			offset := (py*w + px) * rgbaChannels
+			if a > pixels[offset+3] {
+				pixels[offset] = r
+				pixels[offset+1] = g
+				pixels[offset+2] = b
+				pixels[offset+3] = a
+			}
+		}
+	}
 }
 
 // absF returns the absolute value of a float64.

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -12,6 +12,7 @@ import (
 const (
 	effectMatrix      = "matrix"
 	effectFire        = "fire"
+	effectSnow        = "snow"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -42,10 +43,10 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, or random",
+				Description: "Which visual effect to show: matrix, fire, snow, or random",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
-				Options:     []string{effectMatrix, effectFire, effectRandom},
+				Options:     []string{effectMatrix, effectFire, effectSnow, effectRandom},
 			},
 		},
 	}
@@ -80,7 +81,7 @@ func (p *shenanigans) Shutdown(_ context.Context) {
 func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	effect := p.effect
 	if effect == effectRandom {
-		effects := []string{effectMatrix, effectFire}
+		effects := []string{effectMatrix, effectFire, effectSnow}
 		effect = effects[rand.IntN(len(effects))]
 	}
 
@@ -91,6 +92,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startMatrixRain(canvas)
 	case effectFire:
 		p.startFire(canvas)
+	case effectSnow:
+		p.startSnow(canvas)
 	}
 }
 
@@ -416,6 +419,194 @@ func fireColor(val uint8) (r, g, b, a uint8) {
 		a = uint8(255 - p*80) //nolint:mnd,gosec
 		return r, g, b, a
 	}
+}
+
+// --- Snow Effect ---
+
+const (
+	snowFlakeCount = 150
+	snowMaxSize    = 4
+)
+
+type snowflake struct {
+	x, y   float64
+	size   float64
+	speed  float64
+	drift  float64
+	wobble float64
+	phase  float64
+}
+
+type snowState struct {
+	flakes      []snowflake
+	width       int
+	height      int
+	initialized bool
+}
+
+func (p *shenanigans) startSnow(pc linkquisition.PickerCanvas) {
+	state := &snowState{
+		width:  pc.Width(),
+		height: pc.Height(),
+	}
+	if state.width == 0 {
+		state.width = 600
+	}
+	if state.height == 0 {
+		state.height = 400
+	}
+
+	pc.AddRasterOverlay(0.3, func(w, h int) []uint8 {
+		if !state.initialized || w != state.width || h != state.height {
+			state.width = w
+			state.height = h
+			state.init()
+			state.initialized = true
+		}
+		return state.render()
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *snowState) init() {
+	s.flakes = make([]snowflake, snowFlakeCount)
+	for i := range s.flakes {
+		// Start most flakes above the window so they drift in gradually.
+		// A few start on-screen so it's not completely empty at first.
+		onScreen := i < snowFlakeCount/5 //nolint:mnd
+		s.flakes[i] = s.newFlake(onScreen)
+	}
+}
+
+func (s *snowState) newFlake(onScreen bool) snowflake {
+	// Default: spawn above the viewport at varying distances
+	y := -(rand.Float64() * float64(s.height))
+	if onScreen {
+		y = rand.Float64() * float64(s.height)
+	}
+
+	return snowflake{
+		x:      rand.Float64() * float64(s.width),
+		y:      y,
+		size:   1 + rand.Float64()*float64(snowMaxSize-1),
+		speed:  0.5 + rand.Float64()*2.0,
+		drift:  (rand.Float64() - 0.5) * 0.3, //nolint:mnd
+		wobble: 0.3 + rand.Float64()*0.7,     //nolint:mnd
+		phase:  rand.Float64() * 6.28,        //nolint:mnd
+	}
+}
+
+func (s *snowState) update() {
+	for i := range s.flakes {
+		f := &s.flakes[i]
+		f.y += f.speed
+		f.phase += 0.05 //nolint:mnd
+
+		// Gentle sine-wave wobble for horizontal drift
+		f.x += f.drift + f.wobble*sinApprox(f.phase)*0.3 //nolint:mnd
+
+		// Respawn at top if fallen below window
+		if f.y > float64(s.height)+10 { //nolint:mnd
+			*f = s.newFlake(false)
+		}
+
+		// Wrap horizontally
+		if f.x < 0 {
+			f.x += float64(s.width)
+		} else if f.x >= float64(s.width) {
+			f.x -= float64(s.width)
+		}
+	}
+}
+
+func (s *snowState) render() []uint8 {
+	w, h := s.width, s.height
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+
+	for _, f := range s.flakes {
+		s.drawFlake(pixels, f)
+	}
+
+	return pixels
+}
+
+func (s *snowState) drawFlake(pixels []uint8, f snowflake) {
+	w, h := s.width, s.height
+	cx, cy := int(f.x), int(f.y)
+	radius := int(f.size)
+
+	// Draw a soft circle with alpha falloff
+	for dy := -radius; dy <= radius; dy++ {
+		for dx := -radius; dx <= radius; dx++ {
+			px := cx + dx
+			py := cy + dy
+
+			if px < 0 || px >= w || py < 0 || py >= h {
+				continue
+			}
+
+			// Distance from center (0.0 to 1.0+)
+			dist := float64(dx*dx+dy*dy) / float64(radius*radius+1)
+			if dist > 1.0 {
+				continue
+			}
+
+			// Soft edge: alpha falls off near the border
+			alpha := uint8((1.0 - dist*dist) * 220) //nolint:mnd,gosec
+
+			offset := (py*w + px) * rgbaChannels
+			// Blend: white snowflake with alpha
+			existing := pixels[offset+3]
+			if alpha > existing {
+				pixels[offset] = 255   // R
+				pixels[offset+1] = 255 // G
+				pixels[offset+2] = 255 // B
+				pixels[offset+3] = alpha
+			}
+		}
+	}
+}
+
+// sinApprox is a fast sine approximation (Bhaskara I's formula) avoiding math import.
+func sinApprox(x float64) float64 {
+	// Normalize to [0, 2π)
+	const twoPi = 6.283185307
+	const pi = 3.141592654
+
+	for x < 0 {
+		x += twoPi
+	}
+	for x >= twoPi {
+		x -= twoPi
+	}
+
+	// Map to [0, π] with sign
+	sign := 1.0
+	if x > pi {
+		x -= pi
+		sign = -1.0
+	}
+
+	// Bhaskara I's approximation: sin(x) ≈ 16x(π-x) / (5π²-4x(π-x))
+	num := 16 * x * (pi - x)    //nolint:mnd
+	den := 5*pi*pi - 4*x*(pi-x) //nolint:mnd
+	return sign * num / den
 }
 
 // NewForTesting creates a fresh shenanigans instance for use in tests,

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -16,6 +16,7 @@ const (
 	effectPlasma      = "plasma"
 	effectStarfield   = "starfield"
 	effectAurora      = "aurora"
+	effectGlitch      = "glitch"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -46,12 +47,12 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, aurora, or random",
+				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, aurora, glitch, or random",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
 				Options: []string{
 					effectMatrix, effectFire, effectSnow, effectPlasma,
-					effectStarfield, effectAurora, effectRandom,
+					effectStarfield, effectAurora, effectGlitch, effectRandom,
 				},
 			},
 		},
@@ -87,7 +88,10 @@ func (p *shenanigans) Shutdown(_ context.Context) {
 func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	effect := p.effect
 	if effect == effectRandom {
-		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield, effectAurora}
+		effects := []string{
+			effectMatrix, effectFire, effectSnow, effectPlasma,
+			effectStarfield, effectAurora, effectGlitch,
+		}
 		effect = effects[rand.IntN(len(effects))]
 	}
 
@@ -106,6 +110,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startStarfield(canvas)
 	case effectAurora:
 		p.startAurora(canvas)
+	case effectGlitch:
+		p.startGlitch(canvas)
 	}
 }
 
@@ -962,6 +968,145 @@ func fastExp(x float64) float64 {
 		return 0
 	}
 	return t
+}
+
+// --- Glitch Effect ---
+
+type glitchState struct {
+	frame      int
+	slices     []glitchSlice
+	burstTimer int
+	isBursting bool
+}
+
+type glitchSlice struct {
+	y, height int
+	offsetX   int
+	channel   int // 0=R shift, 1=G shift, 2=B shift
+	alpha     uint8
+}
+
+func (p *shenanigans) startGlitch(pc linkquisition.PickerCanvas) {
+	state := &glitchState{}
+
+	pc.AddRasterOverlay(0.0, func(w, h int) []uint8 {
+		return state.render(w, h)
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *glitchState) update() {
+	s.frame++
+	s.burstTimer--
+
+	// Trigger glitch bursts periodically
+	if s.burstTimer <= 0 {
+		if s.isBursting {
+			// End burst
+			s.isBursting = false
+			s.slices = nil
+			s.burstTimer = 20 + rand.IntN(40) //nolint:mnd
+		} else {
+			// Start burst
+			s.isBursting = true
+			s.burstTimer = 3 + rand.IntN(8) //nolint:mnd
+			s.generateSlices()
+		}
+	} else if s.isBursting && s.frame%2 == 0 {
+		// Regenerate slices during burst for flicker
+		s.generateSlices()
+	}
+}
+
+func (s *glitchState) generateSlices() {
+	count := 3 + rand.IntN(8) //nolint:mnd
+	s.slices = make([]glitchSlice, count)
+
+	for i := range s.slices {
+		s.slices[i] = glitchSlice{
+			y:       rand.IntN(400),             //nolint:mnd
+			height:  2 + rand.IntN(20),          //nolint:mnd
+			offsetX: -30 + rand.IntN(60),        //nolint:mnd
+			channel: rand.IntN(3),               //nolint:mnd
+			alpha:   uint8(80 + rand.IntN(176)), //nolint:mnd,gosec
+		}
+	}
+}
+
+func (s *glitchState) render(w, h int) []uint8 {
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+
+	if !s.isBursting {
+		return pixels
+	}
+
+	// Draw glitch slices
+	for _, slice := range s.slices {
+		sy := slice.y * h / 400      //nolint:mnd
+		sh := slice.height * h / 400 //nolint:mnd
+
+		for py := sy; py < sy+sh && py < h; py++ {
+			if py < 0 {
+				continue
+			}
+			for px := 0; px < w; px++ {
+				offset := (py*w + px) * rgbaChannels
+
+				// RGB channel separation effect
+				switch slice.channel {
+				case 0: // Red shift
+					srcX := px - slice.offsetX
+					if srcX >= 0 && srcX < w {
+						pixels[offset] = slice.alpha
+						pixels[offset+3] = slice.alpha / 2
+					}
+				case 1: // Green shift
+					srcX := px + slice.offsetX
+					if srcX >= 0 && srcX < w {
+						pixels[offset+1] = slice.alpha
+						pixels[offset+3] = slice.alpha / 2
+					}
+				case 2: // Blue/cyan shift
+					pixels[offset+2] = slice.alpha
+					pixels[offset+1] = slice.alpha / 3
+					pixels[offset+3] = slice.alpha / 2
+				}
+			}
+		}
+	}
+
+	// Add random static noise during bursts
+	if s.isBursting {
+		noiseCount := w * h / 40 //nolint:mnd
+		for range noiseCount {
+			px := rand.IntN(w)
+			py := rand.IntN(h)
+			offset := (py*w + px) * rgbaChannels
+			v := uint8(rand.IntN(256)) //nolint:mnd,gosec
+			pixels[offset] = v
+			pixels[offset+1] = v
+			pixels[offset+2] = v
+			pixels[offset+3] = uint8(rand.IntN(100)) //nolint:mnd,gosec
+		}
+	}
+
+	return pixels
 }
 
 // sinNorm returns sinApprox mapped to 0.0-1.0 range.

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -1321,6 +1321,12 @@ func (s *footballState) render() []uint8 {
 
 // isPitchLine determines if a normalized coordinate is on a white pitch marking.
 func isPitchLine(fx, fy float64) bool {
+	return isPitchCenterMarkings(fx, fy) ||
+		isPitchBoundary(fx, fy) ||
+		isPitchPenaltyArea(fx, fy)
+}
+
+func isPitchCenterMarkings(fx, fy float64) bool {
 	// Center line (vertical)
 	if absF(fx-0.5) < 0.004 {
 		return true
@@ -1334,18 +1340,19 @@ func isPitchLine(fx, fy float64) bool {
 	}
 
 	// Center dot
-	if dist < 0.002 {
-		return true
-	}
+	return dist < 0.002
+}
 
-	// Outer boundary
+func isPitchBoundary(fx, fy float64) bool {
 	if fx < 0.02 || fx > 0.98 || fy < 0.03 || fy > 0.97 {
 		if fx > 0.015 && fx < 0.985 && fy > 0.025 && fy < 0.975 {
 			return true
 		}
 	}
+	return false
+}
 
-	// Penalty areas (left and right)
+func isPitchPenaltyArea(fx, fy float64) bool {
 	penaltyW := 0.15
 	penaltyH := 0.35
 	penaltyTop := 0.5 - penaltyH

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -13,6 +13,7 @@ const (
 	effectMatrix      = "matrix"
 	effectFire        = "fire"
 	effectSnow        = "snow"
+	effectPlasma      = "plasma"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -43,10 +44,10 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, snow, or random",
+				Description: "Which visual effect to show: matrix, fire, snow, plasma, or random",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
-				Options:     []string{effectMatrix, effectFire, effectSnow, effectRandom},
+				Options:     []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectRandom},
 			},
 		},
 	}
@@ -81,7 +82,7 @@ func (p *shenanigans) Shutdown(_ context.Context) {
 func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	effect := p.effect
 	if effect == effectRandom {
-		effects := []string{effectMatrix, effectFire, effectSnow}
+		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma}
 		effect = effects[rand.IntN(len(effects))]
 	}
 
@@ -94,6 +95,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startFire(canvas)
 	case effectSnow:
 		p.startSnow(canvas)
+	case effectPlasma:
+		p.startPlasma(canvas)
 	}
 }
 
@@ -607,6 +610,78 @@ func sinApprox(x float64) float64 {
 	num := 16 * x * (pi - x)    //nolint:mnd
 	den := 5*pi*pi - 4*x*(pi-x) //nolint:mnd
 	return sign * num / den
+}
+
+// --- Plasma Effect ---
+
+type plasmaState struct {
+	time float64
+}
+
+func (p *shenanigans) startPlasma(pc linkquisition.PickerCanvas) {
+	state := &plasmaState{}
+
+	pc.AddRasterOverlay(0.5, func(w, h int) []uint8 {
+		return state.render(w, h)
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.time += 0.06 //nolint:mnd
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *plasmaState) render(w, h int) []uint8 {
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+	t := s.time
+
+	for py := 0; py < h; py++ {
+		fy := float64(py) / float64(h)
+		for px := 0; px < w; px++ {
+			fx := float64(px) / float64(w)
+
+			// Overlapping sine waves at different frequencies and phases
+			v1 := sinApprox((fx*4 + t) * 3.14159)                //nolint:mnd
+			v2 := sinApprox((fy*4 + t*0.7) * 3.14159)            //nolint:mnd
+			v3 := sinApprox(((fx+fy)*3 + t*1.3) * 3.14159)       //nolint:mnd
+			v4 := sinApprox(((fx-fy)*2 + t*0.5) * 3.14159)       //nolint:mnd
+			v5 := sinApprox(((fx*fx+fy*fy)*4 - t*0.9) * 3.14159) //nolint:mnd
+
+			// Combine waves (result in -1 to 1 range, normalize to 0-1)
+			val := (v1 + v2 + v3 + v4 + v5) / 5.0 //nolint:mnd
+			val = (val + 1.0) / 2.0
+
+			// Map to color using three phase-shifted sine waves for RGB
+			r := uint8(sinNorm(val*3.14159*2+t*0.3) * 255)      //nolint:mnd,gosec
+			g := uint8(sinNorm(val*3.14159*2+t*0.3+2.09) * 255) //nolint:mnd,gosec
+			b := uint8(sinNorm(val*3.14159*2+t*0.3+4.19) * 255) //nolint:mnd,gosec
+
+			offset := (py*w + px) * rgbaChannels
+			pixels[offset] = r
+			pixels[offset+1] = g
+			pixels[offset+2] = b
+			pixels[offset+3] = 200 //nolint:mnd
+		}
+	}
+
+	return pixels
+}
+
+// sinNorm returns sinApprox mapped to 0.0-1.0 range.
+func sinNorm(x float64) float64 {
+	return (sinApprox(x) + 1.0) / 2.0
 }
 
 // NewForTesting creates a fresh shenanigans instance for use in tests,

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -14,6 +14,7 @@ const (
 	effectFire        = "fire"
 	effectSnow        = "snow"
 	effectPlasma      = "plasma"
+	effectStarfield   = "starfield"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -44,10 +45,10 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "effect",
 				Label:       "Effect",
-				Description: "Which visual effect to show: matrix, fire, snow, plasma, or random",
+				Description: "Which visual effect to show: matrix, fire, snow, plasma, starfield, or random",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
-				Options:     []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectRandom},
+				Options:     []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield, effectRandom},
 			},
 		},
 	}
@@ -82,7 +83,7 @@ func (p *shenanigans) Shutdown(_ context.Context) {
 func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 	effect := p.effect
 	if effect == effectRandom {
-		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma}
+		effects := []string{effectMatrix, effectFire, effectSnow, effectPlasma, effectStarfield}
 		effect = effects[rand.IntN(len(effects))]
 	}
 
@@ -97,6 +98,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startSnow(canvas)
 	case effectPlasma:
 		p.startPlasma(canvas)
+	case effectStarfield:
+		p.startStarfield(canvas)
 	}
 }
 
@@ -673,6 +676,139 @@ func (s *plasmaState) render(w, h int) []uint8 {
 			pixels[offset+1] = g
 			pixels[offset+2] = b
 			pixels[offset+3] = 200 //nolint:mnd
+		}
+	}
+
+	return pixels
+}
+
+// --- Starfield Effect ---
+
+const starCount = 200
+
+type star struct {
+	x, y, z float64
+}
+
+type starfieldState struct {
+	stars  []star
+	width  int
+	height int
+}
+
+func (p *shenanigans) startStarfield(pc linkquisition.PickerCanvas) {
+	state := &starfieldState{}
+
+	pc.AddRasterOverlay(0.2, func(w, h int) []uint8 {
+		if !state.isInitialized() || w != state.width || h != state.height {
+			state.width = w
+			state.height = h
+			state.init()
+		}
+		return state.render()
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *starfieldState) isInitialized() bool {
+	return len(s.stars) > 0
+}
+
+func (s *starfieldState) init() {
+	s.stars = make([]star, starCount)
+	for i := range s.stars {
+		s.stars[i] = s.newStar(true)
+	}
+}
+
+func (s *starfieldState) newStar(randomDepth bool) star {
+	z := 0.01 + rand.Float64()*0.99
+	if randomDepth {
+		z = 0.1 + rand.Float64()*0.9 //nolint:mnd
+	}
+
+	return star{
+		x: (rand.Float64() - 0.5) * 2.0,
+		y: (rand.Float64() - 0.5) * 2.0,
+		z: z,
+	}
+}
+
+func (s *starfieldState) update() {
+	for i := range s.stars {
+		s.stars[i].z -= 0.015 //nolint:mnd
+
+		// Respawn stars that have passed the viewer
+		if s.stars[i].z <= 0.001 { //nolint:mnd
+			s.stars[i] = s.newStar(false)
+			s.stars[i].z = 0.9 + rand.Float64()*0.1 //nolint:mnd
+		}
+	}
+}
+
+func (s *starfieldState) render() []uint8 {
+	w, h := s.width, s.height
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+	cx := float64(w) / 2.0
+	cy := float64(h) / 2.0
+
+	for _, st := range s.stars {
+		// Perspective projection
+		screenX := int(cx + (st.x/st.z)*cx)
+		screenY := int(cy + (st.y/st.z)*cy)
+
+		if screenX < 0 || screenX >= w || screenY < 0 || screenY >= h {
+			continue
+		}
+
+		// Size and brightness increase as stars get closer (z → 0)
+		brightness := uint8(min(int((1.0-st.z)*255), 255)) //nolint:mnd,gosec
+		size := int(1 + (1.0-st.z)*3)                      //nolint:mnd
+
+		// Draw star with glow
+		for dy := -size; dy <= size; dy++ {
+			for dx := -size; dx <= size; dx++ {
+				px := screenX + dx
+				py := screenY + dy
+
+				if px < 0 || px >= w || py < 0 || py >= h {
+					continue
+				}
+
+				dist := dx*dx + dy*dy
+				maxDist := size * size
+				if dist > maxDist {
+					continue
+				}
+
+				// Alpha falls off with distance from center
+				falloff := 1.0 - float64(dist)/float64(maxDist+1)
+				alpha := uint8(float64(brightness) * falloff) //nolint:gosec
+
+				offset := (py*w + px) * rgbaChannels
+				if alpha > pixels[offset+3] {
+					pixels[offset] = brightness
+					pixels[offset+1] = brightness
+					pixels[offset+2] = 255 // slight blue tint
+					pixels[offset+3] = alpha
+				}
+			}
 		}
 	}
 

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -18,6 +18,7 @@ const (
 	effectAurora      = "aurora"
 	effectGlitch      = "glitch"
 	effectPride       = "pride"
+	effectFootball    = "football"
 	effectRandom      = "random"
 	frameInterval     = 30 * time.Millisecond
 	fireFrameInterval = 25 * time.Millisecond
@@ -54,7 +55,7 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 				Options: []string{
 					effectMatrix, effectFire, effectSnow, effectPlasma,
 					effectStarfield, effectAurora, effectGlitch, effectPride,
-					effectRandom,
+					effectFootball, effectRandom,
 				},
 			},
 		},
@@ -93,6 +94,7 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		effects := []string{
 			effectMatrix, effectFire, effectSnow, effectPlasma,
 			effectStarfield, effectAurora, effectGlitch, effectPride,
+			effectFootball,
 		}
 		effect = effects[rand.IntN(len(effects))]
 	}
@@ -116,6 +118,8 @@ func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
 		p.startGlitch(canvas)
 	case effectPride:
 		p.startPride(canvas)
+	case effectFootball:
+		p.startFootball(canvas)
 	}
 }
 
@@ -1214,6 +1218,142 @@ func (s *prideState) render(w, h int) []uint8 {
 	}
 
 	return pixels
+}
+
+// --- Football Effect ---
+
+type footballState struct {
+	time   float64
+	width  int
+	height int
+}
+
+func (p *shenanigans) startFootball(pc linkquisition.PickerCanvas) {
+	state := &footballState{}
+
+	pc.AddRasterOverlay(0.4, func(w, h int) []uint8 {
+		state.width = w
+		state.height = h
+		return state.render()
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.time += 0.03 //nolint:mnd
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *footballState) render() []uint8 {
+	w, h := s.width, s.height
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+	t := s.time
+
+	for py := 0; py < h; py++ {
+		fy := float64(py) / float64(h)
+		for px := 0; px < w; px++ {
+			fx := float64(px) / float64(w)
+
+			// Green pitch base with subtle stripe pattern (mowed grass look)
+			stripeWidth := 0.08 //nolint:mnd
+			stripe := int(fx/stripeWidth) % 2
+			var gr, gg, gb uint8
+			if stripe == 0 {
+				gr, gg, gb = 34, 139, 34 //nolint:mnd
+			} else {
+				gr, gg, gb = 30, 124, 30 //nolint:mnd
+			}
+
+			// Draw white pitch lines
+			isLine := false
+
+			// Center line (vertical)
+			if absF(fx-0.5) < 0.004 { //nolint:mnd
+				isLine = true
+			}
+
+			// Center circle
+			cx, cy := 0.5, 0.5
+			dist := (fx-cx)*(fx-cx)*1.5 + (fy-cy)*(fy-cy) //nolint:mnd
+			if absF(dist-0.04) < 0.003 {                  //nolint:mnd
+				isLine = true
+			}
+
+			// Center dot
+			if dist < 0.002 { //nolint:mnd
+				isLine = true
+			}
+
+			// Outer boundary
+			if fx < 0.02 || fx > 0.98 || fy < 0.03 || fy > 0.97 { //nolint:mnd
+				if fx > 0.015 && fx < 0.985 && fy > 0.025 && fy < 0.975 { //nolint:mnd
+					isLine = true
+				}
+			}
+
+			// Penalty areas (left and right)
+			penaltyW := 0.15 //nolint:mnd
+			penaltyH := 0.35 //nolint:mnd
+			penaltyTop := 0.5 - penaltyH
+			penaltyBot := 0.5 + penaltyH
+
+			// Left penalty area
+			if fx < penaltyW && fy > penaltyTop && fy < penaltyBot {
+				if absF(fx-penaltyW) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 { //nolint:mnd
+					isLine = true
+				}
+			}
+
+			// Right penalty area
+			if fx > (1-penaltyW) && fy > penaltyTop && fy < penaltyBot {
+				if absF(fx-(1-penaltyW)) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 { //nolint:mnd
+					isLine = true
+				}
+			}
+
+			// Animated element: a "spotlight" sweeping across the pitch
+			spotX := 0.5 + 0.4*sinApprox(t*1.5)     //nolint:mnd
+			spotY := 0.5 + 0.3*sinApprox(t*1.1+1.0) //nolint:mnd
+			spotDist := (fx-spotX)*(fx-spotX) + (fy-spotY)*(fy-spotY)
+			spotLight := fastExp(-spotDist*15) * 0.3 //nolint:mnd
+
+			var r, g, b uint8
+			if isLine {
+				r, g, b = 255, 255, 255
+			} else {
+				r = uint8(min(int(float64(gr)*(1+spotLight)), 255)) //nolint:gosec
+				g = uint8(min(int(float64(gg)*(1+spotLight)), 255)) //nolint:gosec
+				b = uint8(min(int(float64(gb)*(1+spotLight)), 255)) //nolint:gosec
+			}
+
+			offset := (py*w + px) * rgbaChannels
+			pixels[offset] = r
+			pixels[offset+1] = g
+			pixels[offset+2] = b
+			pixels[offset+3] = 180 //nolint:mnd
+		}
+	}
+
+	return pixels
+}
+
+// absF returns the absolute value of a float64.
+func absF(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // sinNorm returns sinApprox mapped to 0.0-1.0 range.

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -53,10 +53,12 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 				Description: "Which visual effect to show on the picker window",
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
+				// Options: "random" stays on top as the default; the rest are alphabetical.
 				Options: []string{
-					effectRandom, effectMatrix, effectFire, effectSnow, effectPlasma,
-					effectStarfield, effectAurora, effectGlitch, effectPride,
-					effectFootball, effectFireworks,
+					effectRandom,
+					effectAurora, effectFire, effectFireworks, effectFootball,
+					effectGlitch, effectMatrix, effectPlasma, effectPride,
+					effectSnow, effectStarfield,
 				},
 			},
 		},

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -54,9 +54,9 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 				Type:        linkquisition.SettingTypeChoice,
 				Default:     effectRandom,
 				Options: []string{
-					effectMatrix, effectFire, effectSnow, effectPlasma,
+					effectRandom, effectMatrix, effectFire, effectSnow, effectPlasma,
 					effectStarfield, effectAurora, effectGlitch, effectPride,
-					effectFootball, effectFireworks, effectRandom,
+					effectFootball, effectFireworks,
 				},
 			},
 		},

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -1,3 +1,4 @@
+//nolint:mnd,gosec // Visual effects plugin: magic numbers (colors, speeds, sizes) and weak random are by design.
 package main
 
 import (
@@ -27,6 +28,8 @@ const (
 	fireHeight        = 100
 	matrixColumns     = 40
 	rgbaChannels      = 4
+
+	settingKeyEffect = "effect"
 )
 
 // Compile-time interface checks.
@@ -48,7 +51,7 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{
 			{
-				Key:         "effect",
+				Key:         settingKeyEffect,
 				Label:       "Effect",
 				Description: "Which visual effect to show on the picker window",
 				Type:        linkquisition.SettingTypeChoice,
@@ -70,7 +73,7 @@ func (p *shenanigans) Setup(
 ) error {
 	p.serviceProvider = serviceProvider
 
-	if effectVal, ok := config["effect"]; ok {
+	if effectVal, ok := config[settingKeyEffect]; ok {
 		if s, isStr := effectVal.(string); isStr {
 			p.effect = s
 		}
@@ -185,7 +188,7 @@ func (s *matrixState) initColumns() {
 		s.columns[i] = matrixColumn{
 			y:     -rand.Float64() * float64(s.height),
 			speed: 2 + rand.Float64()*6,
-			chars: generateMatrixChars(20 + rand.IntN(15)), //nolint:mnd
+			chars: generateMatrixChars(20 + rand.IntN(15)),
 		}
 	}
 }
@@ -201,7 +204,7 @@ func (s *matrixState) update() {
 		if s.columns[i].y > h+float64(len(s.columns[i].chars)*16) {
 			s.columns[i].y = -float64(len(s.columns[i].chars) * 16)
 			s.columns[i].speed = 2 + rand.Float64()*6
-			s.columns[i].chars = generateMatrixChars(20 + rand.IntN(15)) //nolint:mnd
+			s.columns[i].chars = generateMatrixChars(20 + rand.IntN(15))
 		}
 	}
 }
@@ -230,7 +233,7 @@ func (s *matrixState) render() []uint8 {
 			}
 
 			// Fade out older characters
-			brightness := uint8(255 - min(j*12, 230)) //nolint:mnd
+			brightness := uint8(255 - min(j*12, 230))
 
 			// Draw a simple block for each character
 			for dx := 2; dx < min(colWidth-2, 10); dx++ {
@@ -305,8 +308,8 @@ func (s *fireState) init() {
 func (s *fireState) update() {
 	// Set the bottom two rows to random hot values (wider fuel source)
 	for x := range s.width {
-		s.grid[s.height-1][x] = uint8(180 + rand.IntN(76))  //nolint:mnd
-		s.grid[s.height-2][x] = uint8(150 + rand.IntN(106)) //nolint:mnd
+		s.grid[s.height-1][x] = uint8(180 + rand.IntN(76))
+		s.grid[s.height-2][x] = uint8(150 + rand.IntN(106))
 	}
 
 	// Propagate fire upward with averaging and cooling
@@ -326,17 +329,17 @@ func (s *fireState) update() {
 				int(s.grid[y+2][x])*2 +
 				int(s.grid[y+2][r2])
 
-			avg := sum / 9 //nolint:mnd
+			avg := sum / 9
 
 			// Cooling increases toward the top for natural fadeout
-			coolBase := 2 + (s.height-y)/15 //nolint:mnd
+			coolBase := 2 + (s.height-y)/15
 			cooling := rand.IntN(coolBase + 1)
 			val := avg - cooling
 
 			if val < 0 {
 				val = 0
 			}
-			s.grid[y][x] = uint8(val) //nolint:gosec
+			s.grid[y][x] = uint8(val)
 		}
 	}
 }
@@ -397,57 +400,57 @@ func (s *fireState) sampleBilinear(fx, fy float64) uint8 {
 	bottom := v01*(1-xFrac) + v11*xFrac
 	val := top*(1-yFrac) + bottom*yFrac
 
-	return uint8(min(max(int(val), 0), 255)) //nolint:gosec
+	return uint8(min(max(int(val), 0), 255))
 }
 
 // fireColor maps a heat value (0-255) to a realistic fire palette.
 // Gradient: transparent → dark red/brown → red → orange → gold → pale yellow
 func fireColor(val uint8) (r, g, b, a uint8) {
-	if val < 24 { //nolint:mnd
+	if val < 24 {
 		return 0, 0, 0, 0
 	}
 
 	// Normalize to 0.0-1.0 range (24-255 → 0.0-1.0)
-	t := float64(val-24) / 231.0 //nolint:mnd
+	t := float64(val-24) / 231.0
 
 	// Piecewise palette for realistic fire
 	switch {
-	case t < 0.2: //nolint:mnd
+	case t < 0.2:
 		// Black → dark maroon/brown
-		p := t / 0.2       //nolint:mnd
-		r = uint8(p * 80)  //nolint:mnd,gosec
-		g = uint8(p * 10)  //nolint:mnd,gosec
-		a = uint8(p * 180) //nolint:mnd,gosec
+		p := t / 0.2
+		r = uint8(p * 80)
+		g = uint8(p * 10)
+		a = uint8(p * 180)
 		return r, g, 0, a
-	case t < 0.45: //nolint:mnd
+	case t < 0.45:
 		// Dark maroon → bright red
-		p := (t - 0.2) / 0.25 //nolint:mnd
-		r = uint8(80 + p*175) //nolint:mnd,gosec
-		g = uint8(10 + p*20)  //nolint:mnd,gosec
-		a = uint8(180 + p*75) //nolint:mnd,gosec
+		p := (t - 0.2) / 0.25
+		r = uint8(80 + p*175)
+		g = uint8(10 + p*20)
+		a = uint8(180 + p*75)
 		return r, g, 0, a
-	case t < 0.7: //nolint:mnd
+	case t < 0.7:
 		// Red → orange
-		p := (t - 0.45) / 0.25 //nolint:mnd
-		r = 255                //nolint:mnd
-		g = uint8(30 + p*170)  //nolint:mnd,gosec
-		a = 255                //nolint:mnd
+		p := (t - 0.45) / 0.25
+		r = 255
+		g = uint8(30 + p*170)
+		a = 255
 		return r, g, 0, a
-	case t < 0.9: //nolint:mnd
+	case t < 0.9:
 		// Orange → golden yellow
-		p := (t - 0.7) / 0.2  //nolint:mnd
-		r = 255               //nolint:mnd
-		g = uint8(200 + p*55) //nolint:mnd,gosec
-		b = uint8(p * 30)     //nolint:mnd,gosec
-		a = 255               //nolint:mnd
+		p := (t - 0.7) / 0.2
+		r = 255
+		g = uint8(200 + p*55)
+		b = uint8(p * 30)
+		a = 255
 		return r, g, b, a
 	default:
 		// Golden yellow → pale yellow/white tips
-		p := (t - 0.9) / 0.1  //nolint:mnd
-		r = 255               //nolint:mnd
-		g = 255               //nolint:mnd
-		b = uint8(30 + p*120) //nolint:mnd,gosec
-		a = uint8(255 - p*80) //nolint:mnd,gosec
+		p := (t - 0.9) / 0.1
+		r = 255
+		g = 255
+		b = uint8(30 + p*120)
+		a = uint8(255 - p*80)
 		return r, g, b, a
 	}
 }
@@ -516,7 +519,7 @@ func (s *snowState) init() {
 	for i := range s.flakes {
 		// Start most flakes above the window so they drift in gradually.
 		// A few start on-screen so it's not completely empty at first.
-		onScreen := i < snowFlakeCount/5 //nolint:mnd
+		onScreen := i < snowFlakeCount/5
 		s.flakes[i] = s.newFlake(onScreen)
 	}
 }
@@ -533,9 +536,9 @@ func (s *snowState) newFlake(onScreen bool) snowflake {
 		y:      y,
 		size:   1 + rand.Float64()*float64(snowMaxSize-1),
 		speed:  0.5 + rand.Float64()*2.0,
-		drift:  (rand.Float64() - 0.5) * 0.3, //nolint:mnd
-		wobble: 0.3 + rand.Float64()*0.7,     //nolint:mnd
-		phase:  rand.Float64() * 6.28,        //nolint:mnd
+		drift:  (rand.Float64() - 0.5) * 0.3,
+		wobble: 0.3 + rand.Float64()*0.7,
+		phase:  rand.Float64() * 6.28,
 	}
 }
 
@@ -543,13 +546,13 @@ func (s *snowState) update() {
 	for i := range s.flakes {
 		f := &s.flakes[i]
 		f.y += f.speed
-		f.phase += 0.05 //nolint:mnd
+		f.phase += 0.05
 
 		// Gentle sine-wave wobble for horizontal drift
-		f.x += f.drift + f.wobble*sinApprox(f.phase)*0.3 //nolint:mnd
+		f.x += f.drift + f.wobble*sinApprox(f.phase)*0.3
 
 		// Respawn at top if fallen below window
-		if f.y > float64(s.height)+10 { //nolint:mnd
+		if f.y > float64(s.height)+10 {
 			*f = s.newFlake(false)
 		}
 
@@ -599,7 +602,7 @@ func (s *snowState) drawFlake(pixels []uint8, f snowflake) {
 			}
 
 			// Soft edge: alpha falls off near the border
-			alpha := uint8((1.0 - dist*dist) * 220) //nolint:mnd,gosec
+			alpha := uint8((1.0 - dist*dist) * 220)
 
 			offset := (py*w + px) * rgbaChannels
 			// Blend: white snowflake with alpha
@@ -635,8 +638,8 @@ func sinApprox(x float64) float64 {
 	}
 
 	// Bhaskara I's approximation: sin(x) ≈ 16x(π-x) / (5π²-4x(π-x))
-	num := 16 * x * (pi - x)    //nolint:mnd
-	den := 5*pi*pi - 4*x*(pi-x) //nolint:mnd
+	num := 16 * x * (pi - x)
+	den := 5*pi*pi - 4*x*(pi-x)
 	return sign * num / den
 }
 
@@ -661,7 +664,7 @@ func (p *shenanigans) startPlasma(pc linkquisition.PickerCanvas) {
 			if p.stopped.Load() {
 				return
 			}
-			state.time += 0.06 //nolint:mnd
+			state.time += 0.06
 			pc.ScheduleRefresh()
 		}
 	}()
@@ -681,26 +684,26 @@ func (s *plasmaState) render(w, h int) []uint8 {
 			fx := float64(px) / float64(w)
 
 			// Overlapping sine waves at different frequencies and phases
-			v1 := sinApprox((fx*4 + t) * 3.14159)                //nolint:mnd
-			v2 := sinApprox((fy*4 + t*0.7) * 3.14159)            //nolint:mnd
-			v3 := sinApprox(((fx+fy)*3 + t*1.3) * 3.14159)       //nolint:mnd
-			v4 := sinApprox(((fx-fy)*2 + t*0.5) * 3.14159)       //nolint:mnd
-			v5 := sinApprox(((fx*fx+fy*fy)*4 - t*0.9) * 3.14159) //nolint:mnd
+			v1 := sinApprox((fx*4 + t) * 3.14159)
+			v2 := sinApprox((fy*4 + t*0.7) * 3.14159)
+			v3 := sinApprox(((fx+fy)*3 + t*1.3) * 3.14159)
+			v4 := sinApprox(((fx-fy)*2 + t*0.5) * 3.14159)
+			v5 := sinApprox(((fx*fx+fy*fy)*4 - t*0.9) * 3.14159)
 
 			// Combine waves (result in -1 to 1 range, normalize to 0-1)
-			val := (v1 + v2 + v3 + v4 + v5) / 5.0 //nolint:mnd
+			val := (v1 + v2 + v3 + v4 + v5) / 5.0
 			val = (val + 1.0) / 2.0
 
 			// Map to color using three phase-shifted sine waves for RGB
-			r := uint8(sinNorm(val*3.14159*2+t*0.3) * 255)      //nolint:mnd,gosec
-			g := uint8(sinNorm(val*3.14159*2+t*0.3+2.09) * 255) //nolint:mnd,gosec
-			b := uint8(sinNorm(val*3.14159*2+t*0.3+4.19) * 255) //nolint:mnd,gosec
+			r := uint8(sinNorm(val*3.14159*2+t*0.3) * 255)
+			g := uint8(sinNorm(val*3.14159*2+t*0.3+2.09) * 255)
+			b := uint8(sinNorm(val*3.14159*2+t*0.3+4.19) * 255)
 
 			offset := (py*w + px) * rgbaChannels
 			pixels[offset] = r
 			pixels[offset+1] = g
 			pixels[offset+2] = b
-			pixels[offset+3] = 200 //nolint:mnd
+			pixels[offset+3] = 200
 		}
 	}
 
@@ -761,7 +764,7 @@ func (s *starfieldState) init() {
 func (s *starfieldState) newStar(randomDepth bool) star {
 	z := 0.01 + rand.Float64()*0.99
 	if randomDepth {
-		z = 0.1 + rand.Float64()*0.9 //nolint:mnd
+		z = 0.1 + rand.Float64()*0.9
 	}
 
 	return star{
@@ -773,12 +776,12 @@ func (s *starfieldState) newStar(randomDepth bool) star {
 
 func (s *starfieldState) update() {
 	for i := range s.stars {
-		s.stars[i].z -= 0.015 //nolint:mnd
+		s.stars[i].z -= 0.015
 
 		// Respawn stars that have passed the viewer
-		if s.stars[i].z <= 0.001 { //nolint:mnd
+		if s.stars[i].z <= 0.001 {
 			s.stars[i] = s.newStar(false)
-			s.stars[i].z = 0.9 + rand.Float64()*0.1 //nolint:mnd
+			s.stars[i].z = 0.9 + rand.Float64()*0.1
 		}
 	}
 }
@@ -803,41 +806,45 @@ func (s *starfieldState) render() []uint8 {
 		}
 
 		// Size and brightness increase as stars get closer (z → 0)
-		brightness := uint8(min(int((1.0-st.z)*255), 255)) //nolint:mnd,gosec
-		size := int(1 + (1.0-st.z)*3)                      //nolint:mnd
+		brightness := uint8(min(int((1.0-st.z)*255), 255))
+		size := int(1 + (1.0-st.z)*3)
 
-		// Draw star with glow
-		for dy := -size; dy <= size; dy++ {
-			for dx := -size; dx <= size; dx++ {
-				px := screenX + dx
-				py := screenY + dy
-
-				if px < 0 || px >= w || py < 0 || py >= h {
-					continue
-				}
-
-				dist := dx*dx + dy*dy
-				maxDist := size * size
-				if dist > maxDist {
-					continue
-				}
-
-				// Alpha falls off with distance from center
-				falloff := 1.0 - float64(dist)/float64(maxDist+1)
-				alpha := uint8(float64(brightness) * falloff) //nolint:gosec
-
-				offset := (py*w + px) * rgbaChannels
-				if alpha > pixels[offset+3] {
-					pixels[offset] = brightness
-					pixels[offset+1] = brightness
-					pixels[offset+2] = 255 // slight blue tint
-					pixels[offset+3] = alpha
-				}
-			}
-		}
+		s.drawStar(pixels, screenX, screenY, size, brightness)
 	}
 
 	return pixels
+}
+
+func (s *starfieldState) drawStar(pixels []uint8, screenX, screenY, size int, brightness uint8) {
+	w, h := s.width, s.height
+	for dy := -size; dy <= size; dy++ {
+		for dx := -size; dx <= size; dx++ {
+			px := screenX + dx
+			py := screenY + dy
+
+			if px < 0 || px >= w || py < 0 || py >= h {
+				continue
+			}
+
+			dist := dx*dx + dy*dy
+			maxDist := size * size
+			if dist > maxDist {
+				continue
+			}
+
+			// Alpha falls off with distance from center
+			falloff := 1.0 - float64(dist)/float64(maxDist+1)
+			alpha := uint8(float64(brightness) * falloff)
+
+			offset := (py*w + px) * rgbaChannels
+			if alpha > pixels[offset+3] {
+				pixels[offset] = brightness
+				pixels[offset+1] = brightness
+				pixels[offset+2] = 255 // slight blue tint
+				pixels[offset+3] = alpha
+			}
+		}
+	}
 }
 
 // --- Aurora Effect ---
@@ -863,7 +870,7 @@ func (p *shenanigans) startAurora(pc linkquisition.PickerCanvas) {
 			if p.stopped.Load() {
 				return
 			}
-			state.time += 0.03 //nolint:mnd
+			state.time += 0.03
 			pc.ScheduleRefresh()
 		}
 	}()
@@ -892,21 +899,21 @@ func (s *auroraState) render(w, h int) []uint8 {
 			for layer := range auroraLayers {
 				fl := float64(layer)
 				// Each layer has different frequency, speed, and phase
-				wave := sinApprox((fx*(3+fl) + t*(0.4+fl*0.15) + fl*1.7) * 3.14159)     //nolint:mnd
-				wave2 := sinApprox((fx*(2+fl*0.7) - t*(0.3+fl*0.1) + fl*2.3) * 3.14159) //nolint:mnd
+				wave := sinApprox((fx*(3+fl) + t*(0.4+fl*0.15) + fl*1.7) * 3.14159)
+				wave2 := sinApprox((fx*(2+fl*0.7) - t*(0.3+fl*0.1) + fl*2.3) * 3.14159)
 
 				// Curtain shape: thin band that undulates
-				curtainCenter := 0.2 + 0.15*fl + 0.1*(wave*0.5+0.5) //nolint:mnd
-				curtainWidth := 0.08 + 0.04*wave2                   //nolint:mnd
+				curtainCenter := 0.2 + 0.15*fl + 0.1*(wave*0.5+0.5)
+				curtainWidth := 0.08 + 0.04*wave2
 
 				// Gaussian-like falloff from the curtain center
 				dist := (fy - curtainCenter) / curtainWidth
-				layerIntensity := fastExp(-dist * dist * 0.5) //nolint:mnd
+				layerIntensity := fastExp(-dist * dist * 0.5)
 
-				intensity += layerIntensity * (0.6 + 0.4/(fl+1)) //nolint:mnd
+				intensity += layerIntensity * (0.6 + 0.4/(fl+1))
 			}
 
-			if intensity < 0.01 { //nolint:mnd
+			if intensity < 0.01 {
 				continue
 			}
 			if intensity > 1.0 {
@@ -914,10 +921,10 @@ func (s *auroraState) render(w, h int) []uint8 {
 			}
 
 			// Aurora color: shift from green to purple/blue based on position and time
-			colorPhase := fx*0.5 + fy*0.3 + t*0.1 //nolint:mnd
+			colorPhase := fx*0.5 + fy*0.3 + t*0.1
 			r, g, b := auroraColor(colorPhase, intensity)
 
-			alpha := uint8(intensity * 180) //nolint:mnd,gosec
+			alpha := uint8(intensity * 180)
 
 			offset := (py*w + px) * rgbaChannels
 			pixels[offset] = r
@@ -934,49 +941,49 @@ func (s *auroraState) render(w, h int) []uint8 {
 // Shifts between green, teal, blue, and purple.
 func auroraColor(phase, intensity float64) (r, g, b uint8) {
 	// Cycle through aurora palette
-	p := sinApprox(phase * 3.14159 * 2) //nolint:mnd
-	p = (p + 1.0) / 2.0                 // normalize to 0-1
+	p := sinApprox(phase * 3.14159 * 2)
+	p = (p + 1.0) / 2.0 // normalize to 0-1
 
 	// Blend between green-dominant and purple-dominant
 	var rf, gf, bf float64
 	switch {
-	case p < 0.33: //nolint:mnd
+	case p < 0.33:
 		// Green to teal
-		t := p / 0.33 //nolint:mnd
+		t := p / 0.33
 		rf = 0.1 * t
-		gf = 0.8 + 0.2*t //nolint:mnd
-		bf = 0.2 + 0.5*t //nolint:mnd
-	case p < 0.66: //nolint:mnd
+		gf = 0.8 + 0.2*t
+		bf = 0.2 + 0.5*t
+	case p < 0.66:
 		// Teal to purple
-		t := (p - 0.33) / 0.33 //nolint:mnd
-		rf = 0.1 + 0.5*t       //nolint:mnd
-		gf = 1.0 - 0.6*t       //nolint:mnd
-		bf = 0.7 + 0.3*t       //nolint:mnd
+		t := (p - 0.33) / 0.33
+		rf = 0.1 + 0.5*t
+		gf = 1.0 - 0.6*t
+		bf = 0.7 + 0.3*t
 	default:
 		// Purple back to green
-		t := (p - 0.66) / 0.34 //nolint:mnd
-		rf = 0.6 - 0.5*t       //nolint:mnd
-		gf = 0.4 + 0.4*t       //nolint:mnd
-		bf = 1.0 - 0.8*t       //nolint:mnd
+		t := (p - 0.66) / 0.34
+		rf = 0.6 - 0.5*t
+		gf = 0.4 + 0.4*t
+		bf = 1.0 - 0.8*t
 	}
 
-	r = uint8(rf * intensity * 255) //nolint:mnd,gosec
-	g = uint8(gf * intensity * 255) //nolint:mnd,gosec
-	b = uint8(bf * intensity * 255) //nolint:mnd,gosec
+	r = uint8(rf * intensity * 255)
+	g = uint8(gf * intensity * 255)
+	b = uint8(bf * intensity * 255)
 	return r, g, b
 }
 
 // fastExp approximates e^x for negative x values (used for Gaussian falloff).
 func fastExp(x float64) float64 {
-	if x < -6 { //nolint:mnd
+	if x < -6 {
 		return 0
 	}
 	// Padé approximation: (1 + x/n)^n for small |x|
 	// Using n=8 for reasonable accuracy
-	t := 1.0 + x/8.0 //nolint:mnd
-	t *= t           // ^2
-	t *= t           // ^4
-	t *= t           // ^8
+	t := 1.0 + x/8.0
+	t *= t // ^2
+	t *= t // ^4
+	t *= t // ^8
 	if t < 0 {
 		return 0
 	}
@@ -1030,11 +1037,11 @@ func (s *glitchState) update() {
 			// End burst
 			s.isBursting = false
 			s.slices = nil
-			s.burstTimer = 20 + rand.IntN(40) //nolint:mnd
+			s.burstTimer = 20 + rand.IntN(40)
 		} else {
 			// Start burst
 			s.isBursting = true
-			s.burstTimer = 3 + rand.IntN(8) //nolint:mnd
+			s.burstTimer = 3 + rand.IntN(8)
 			s.generateSlices()
 		}
 	} else if s.isBursting && s.frame%2 == 0 {
@@ -1044,16 +1051,16 @@ func (s *glitchState) update() {
 }
 
 func (s *glitchState) generateSlices() {
-	count := 3 + rand.IntN(8) //nolint:mnd
+	count := 3 + rand.IntN(8)
 	s.slices = make([]glitchSlice, count)
 
 	for i := range s.slices {
 		s.slices[i] = glitchSlice{
-			y:       rand.IntN(400),             //nolint:mnd
-			height:  2 + rand.IntN(20),          //nolint:mnd
-			offsetX: -30 + rand.IntN(60),        //nolint:mnd
-			channel: rand.IntN(3),               //nolint:mnd
-			alpha:   uint8(80 + rand.IntN(176)), //nolint:mnd,gosec
+			y:       rand.IntN(400),
+			height:  2 + rand.IntN(20),
+			offsetX: -30 + rand.IntN(60),
+			channel: rand.IntN(3),
+			alpha:   uint8(80 + rand.IntN(176)),
 		}
 	}
 }
@@ -1071,55 +1078,61 @@ func (s *glitchState) render(w, h int) []uint8 {
 
 	// Draw glitch slices
 	for _, slice := range s.slices {
-		sy := slice.y * h / 400      //nolint:mnd
-		sh := slice.height * h / 400 //nolint:mnd
-
-		for py := sy; py < sy+sh && py < h; py++ {
-			if py < 0 {
-				continue
-			}
-			for px := 0; px < w; px++ {
-				offset := (py*w + px) * rgbaChannels
-
-				// RGB channel separation effect
-				switch slice.channel {
-				case 0: // Red shift
-					srcX := px - slice.offsetX
-					if srcX >= 0 && srcX < w {
-						pixels[offset] = slice.alpha
-						pixels[offset+3] = slice.alpha / 2
-					}
-				case 1: // Green shift
-					srcX := px + slice.offsetX
-					if srcX >= 0 && srcX < w {
-						pixels[offset+1] = slice.alpha
-						pixels[offset+3] = slice.alpha / 2
-					}
-				case 2: // Blue/cyan shift
-					pixels[offset+2] = slice.alpha
-					pixels[offset+1] = slice.alpha / 3
-					pixels[offset+3] = slice.alpha / 2
-				}
-			}
-		}
+		s.drawSlice(pixels, slice, w, h)
 	}
 
 	// Add random static noise during bursts
-	if s.isBursting {
-		noiseCount := w * h / 40 //nolint:mnd
-		for range noiseCount {
-			px := rand.IntN(w)
-			py := rand.IntN(h)
-			offset := (py*w + px) * rgbaChannels
-			v := uint8(rand.IntN(256)) //nolint:mnd,gosec
-			pixels[offset] = v
-			pixels[offset+1] = v
-			pixels[offset+2] = v
-			pixels[offset+3] = uint8(rand.IntN(100)) //nolint:mnd,gosec
-		}
-	}
+	s.addNoise(pixels, w, h)
 
 	return pixels
+}
+
+func (s *glitchState) drawSlice(pixels []uint8, slice glitchSlice, w, h int) {
+	sy := slice.y * h / 400
+	sh := slice.height * h / 400
+
+	for py := sy; py < sy+sh && py < h; py++ {
+		if py < 0 {
+			continue
+		}
+		for px := 0; px < w; px++ {
+			offset := (py*w + px) * rgbaChannels
+
+			// RGB channel separation effect
+			switch slice.channel {
+			case 0: // Red shift
+				srcX := px - slice.offsetX
+				if srcX >= 0 && srcX < w {
+					pixels[offset] = slice.alpha
+					pixels[offset+3] = slice.alpha / 2
+				}
+			case 1: // Green shift
+				srcX := px + slice.offsetX
+				if srcX >= 0 && srcX < w {
+					pixels[offset+1] = slice.alpha
+					pixels[offset+3] = slice.alpha / 2
+				}
+			default: // Blue/cyan shift
+				pixels[offset+2] = slice.alpha
+				pixels[offset+1] = slice.alpha / 3
+				pixels[offset+3] = slice.alpha / 2
+			}
+		}
+	}
+}
+
+func (s *glitchState) addNoise(pixels []uint8, w, h int) {
+	noiseCount := w * h / 40
+	for range noiseCount {
+		px := rand.IntN(w)
+		py := rand.IntN(h)
+		offset := (py*w + px) * rgbaChannels
+		v := uint8(rand.IntN(256))
+		pixels[offset] = v
+		pixels[offset+1] = v
+		pixels[offset+2] = v
+		pixels[offset+3] = uint8(rand.IntN(100))
+	}
 }
 
 // --- Pride Effect ---
@@ -1153,7 +1166,7 @@ func (p *shenanigans) startPride(pc linkquisition.PickerCanvas) {
 			if p.stopped.Load() {
 				return
 			}
-			state.time += 0.04 //nolint:mnd
+			state.time += 0.04
 			pc.ScheduleRefresh()
 		}
 	}()
@@ -1175,9 +1188,9 @@ func (s *prideState) render(w, h int) []uint8 {
 
 			// Flag wave: pinned on the left edge, wave amplitude increases to the right
 			// This simulates fabric attached to a pole on the left side
-			amplitude := fx * fx * 0.05 //nolint:mnd
+			amplitude := fx * fx * 0.05
 			wave := sinApprox((fx*2.0-t*1.5)*3.14159) * amplitude
-			wave2 := sinApprox((fx*3.0-t*2.0)*3.14159) * amplitude * 0.4 //nolint:mnd
+			wave2 := sinApprox((fx*3.0-t*2.0)*3.14159) * amplitude * 0.4
 
 			// Determine which stripe this pixel belongs to (with wave offset)
 			stripePos := (fy + wave + wave2) * stripeCount
@@ -1201,24 +1214,24 @@ func (s *prideState) render(w, h int) []uint8 {
 			c2 := prideColors[nextIdx]
 
 			// Smooth interpolation (smoothstep-like)
-			blend = blend * blend * (3 - 2*blend) //nolint:mnd
+			blend = blend * blend * (3 - 2*blend)
 
-			r := uint8(float64(c1[0])*(1-blend) + float64(c2[0])*blend) //nolint:gosec
-			g := uint8(float64(c1[1])*(1-blend) + float64(c2[1])*blend) //nolint:gosec
-			b := uint8(float64(c1[2])*(1-blend) + float64(c2[2])*blend) //nolint:gosec
+			r := uint8(float64(c1[0])*(1-blend) + float64(c2[0])*blend)
+			g := uint8(float64(c1[1])*(1-blend) + float64(c2[1])*blend)
+			b := uint8(float64(c1[2])*(1-blend) + float64(c2[2])*blend)
 
 			// Subtle shading to simulate fabric folds (stronger toward free edge)
-			foldDepth := fx * 0.15                                               //nolint:mnd
-			shade := 1.0 - foldDepth + foldDepth*sinApprox((fx*3-t*1.5)*3.14159) //nolint:mnd
-			r = uint8(float64(r) * shade)                                        //nolint:gosec
-			g = uint8(float64(g) * shade)                                        //nolint:gosec
-			b = uint8(float64(b) * shade)                                        //nolint:gosec
+			foldDepth := fx * 0.15
+			shade := 1.0 - foldDepth + foldDepth*sinApprox((fx*3-t*1.5)*3.14159)
+			r = uint8(float64(r) * shade)
+			g = uint8(float64(g) * shade)
+			b = uint8(float64(b) * shade)
 
 			offset := (py*w + px) * rgbaChannels
 			pixels[offset] = r
 			pixels[offset+1] = g
 			pixels[offset+2] = b
-			pixels[offset+3] = 200 //nolint:mnd
+			pixels[offset+3] = 200
 		}
 	}
 
@@ -1250,7 +1263,7 @@ func (p *shenanigans) startFootball(pc linkquisition.PickerCanvas) {
 			if p.stopped.Load() {
 				return
 			}
-			state.time += 0.03 //nolint:mnd
+			state.time += 0.03
 			pc.ScheduleRefresh()
 		}
 	}()
@@ -1271,86 +1284,88 @@ func (s *footballState) render() []uint8 {
 			fx := float64(px) / float64(w)
 
 			// Green pitch base with subtle stripe pattern (mowed grass look)
-			stripeWidth := 0.08 //nolint:mnd
+			stripeWidth := 0.08
 			stripe := int(fx/stripeWidth) % 2
 			var gr, gg, gb uint8
 			if stripe == 0 {
-				gr, gg, gb = 34, 139, 34 //nolint:mnd
+				gr, gg, gb = 34, 139, 34
 			} else {
-				gr, gg, gb = 30, 124, 30 //nolint:mnd
-			}
-
-			// Draw white pitch lines
-			isLine := false
-
-			// Center line (vertical)
-			if absF(fx-0.5) < 0.004 { //nolint:mnd
-				isLine = true
-			}
-
-			// Center circle
-			cx, cy := 0.5, 0.5
-			dist := (fx-cx)*(fx-cx)*1.5 + (fy-cy)*(fy-cy) //nolint:mnd
-			if absF(dist-0.04) < 0.003 {                  //nolint:mnd
-				isLine = true
-			}
-
-			// Center dot
-			if dist < 0.002 { //nolint:mnd
-				isLine = true
-			}
-
-			// Outer boundary
-			if fx < 0.02 || fx > 0.98 || fy < 0.03 || fy > 0.97 { //nolint:mnd
-				if fx > 0.015 && fx < 0.985 && fy > 0.025 && fy < 0.975 { //nolint:mnd
-					isLine = true
-				}
-			}
-
-			// Penalty areas (left and right)
-			penaltyW := 0.15 //nolint:mnd
-			penaltyH := 0.35 //nolint:mnd
-			penaltyTop := 0.5 - penaltyH
-			penaltyBot := 0.5 + penaltyH
-
-			// Left penalty area
-			if fx < penaltyW && fy > penaltyTop && fy < penaltyBot {
-				if absF(fx-penaltyW) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 { //nolint:mnd
-					isLine = true
-				}
-			}
-
-			// Right penalty area
-			if fx > (1-penaltyW) && fy > penaltyTop && fy < penaltyBot {
-				if absF(fx-(1-penaltyW)) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 { //nolint:mnd
-					isLine = true
-				}
+				gr, gg, gb = 30, 124, 30
 			}
 
 			// Animated element: a "spotlight" sweeping across the pitch
-			spotX := 0.5 + 0.4*sinApprox(t*1.5)     //nolint:mnd
-			spotY := 0.5 + 0.3*sinApprox(t*1.1+1.0) //nolint:mnd
+			spotX := 0.5 + 0.4*sinApprox(t*1.5)
+			spotY := 0.5 + 0.3*sinApprox(t*1.1+1.0)
 			spotDist := (fx-spotX)*(fx-spotX) + (fy-spotY)*(fy-spotY)
-			spotLight := fastExp(-spotDist*15) * 0.3 //nolint:mnd
+			spotLight := fastExp(-spotDist*15) * 0.3
 
 			var r, g, b uint8
-			if isLine {
+			if isPitchLine(fx, fy) {
 				r, g, b = 255, 255, 255
 			} else {
-				r = uint8(min(int(float64(gr)*(1+spotLight)), 255)) //nolint:gosec
-				g = uint8(min(int(float64(gg)*(1+spotLight)), 255)) //nolint:gosec
-				b = uint8(min(int(float64(gb)*(1+spotLight)), 255)) //nolint:gosec
+				r = uint8(min(int(float64(gr)*(1+spotLight)), 255))
+				g = uint8(min(int(float64(gg)*(1+spotLight)), 255))
+				b = uint8(min(int(float64(gb)*(1+spotLight)), 255))
 			}
 
 			offset := (py*w + px) * rgbaChannels
 			pixels[offset] = r
 			pixels[offset+1] = g
 			pixels[offset+2] = b
-			pixels[offset+3] = 180 //nolint:mnd
+			pixels[offset+3] = 180
 		}
 	}
 
 	return pixels
+}
+
+// isPitchLine determines if a normalized coordinate is on a white pitch marking.
+func isPitchLine(fx, fy float64) bool {
+	// Center line (vertical)
+	if absF(fx-0.5) < 0.004 {
+		return true
+	}
+
+	// Center circle
+	cx, cy := 0.5, 0.5
+	dist := (fx-cx)*(fx-cx)*1.5 + (fy-cy)*(fy-cy)
+	if absF(dist-0.04) < 0.003 {
+		return true
+	}
+
+	// Center dot
+	if dist < 0.002 {
+		return true
+	}
+
+	// Outer boundary
+	if fx < 0.02 || fx > 0.98 || fy < 0.03 || fy > 0.97 {
+		if fx > 0.015 && fx < 0.985 && fy > 0.025 && fy < 0.975 {
+			return true
+		}
+	}
+
+	// Penalty areas (left and right)
+	penaltyW := 0.15
+	penaltyH := 0.35
+	penaltyTop := 0.5 - penaltyH
+	penaltyBot := 0.5 + penaltyH
+
+	// Left penalty area
+	if fx < penaltyW && fy > penaltyTop && fy < penaltyBot {
+		if absF(fx-penaltyW) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 {
+			return true
+		}
+	}
+
+	// Right penalty area
+	if fx > (1-penaltyW) && fy > penaltyTop && fy < penaltyBot {
+		if absF(fx-(1-penaltyW)) < 0.004 || absF(fy-penaltyTop) < 0.005 || absF(fy-penaltyBot) < 0.005 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // --- Fireworks Effect ---
@@ -1423,13 +1438,13 @@ func (s *fireworksState) update() {
 	}
 
 	// Chance to launch a new rocket
-	if len(s.rockets) < fireworksMaxRockets && rand.IntN(100) < fireworksLaunchChance { //nolint:mnd
+	if len(s.rockets) < fireworksMaxRockets && rand.IntN(100) < fireworksLaunchChance {
 		color := fireworksColors[rand.IntN(len(fireworksColors))]
 		s.rockets = append(s.rockets, fireworksRocket{
-			x:       0.2 + rand.Float64()*0.6, //nolint:mnd
+			x:       0.2 + rand.Float64()*0.6,
 			y:       1.0,
-			vy:      -0.025 - rand.Float64()*0.015, //nolint:mnd
-			targetY: 0.15 + rand.Float64()*0.35,    //nolint:mnd
+			vy:      -0.025 - rand.Float64()*0.015,
+			targetY: 0.15 + rand.Float64()*0.35,
 			color:   color,
 		})
 	}
@@ -1446,13 +1461,13 @@ func (s *fireworksState) update() {
 				r.exploded = true
 				r.particles = make([]fireworksParticle, fireworksParticles)
 				for j := range r.particles {
-					angle := rand.Float64() * 6.283       //nolint:mnd
-					speed := 0.005 + rand.Float64()*0.015 //nolint:mnd
+					angle := rand.Float64() * 6.283
+					speed := 0.005 + rand.Float64()*0.015
 					r.particles[j] = fireworksParticle{
 						x:    r.x,
 						y:    r.y,
 						vx:   sinApprox(angle) * speed,
-						vy:   sinApprox(angle+1.5708) * speed, //nolint:mnd
+						vy:   sinApprox(angle+1.5708) * speed,
 						life: 1.0,
 						r:    r.color[0],
 						g:    r.color[1],
@@ -1470,10 +1485,10 @@ func (s *fireworksState) update() {
 				}
 				p.x += p.vx
 				p.y += p.vy
-				p.vy += 0.0004  // gravity //nolint:mnd
-				p.vx *= 0.98    // drag    //nolint:mnd
-				p.vy *= 0.98    //nolint:mnd
-				p.life -= 0.015 //nolint:mnd
+				p.vy += 0.0004 // gravity
+				p.vx *= 0.98   // drag
+				p.vy *= 0.98
+				p.life -= 0.015
 				if p.life > 0 {
 					allDead = false
 				}
@@ -1500,10 +1515,10 @@ func (s *fireworksState) render() []uint8 {
 			// Draw rising rocket as a small bright dot with trail
 			px := int(rocket.x * float64(w))
 			py := int(rocket.y * float64(h))
-			s.drawDot(pixels, px, py, 2, 255, 220, 150, 255) //nolint:mnd
+			s.drawDot(pixels, px, py, 2, 255, 220, 150, 255)
 			// Trail
-			s.drawDot(pixels, px, py+3, 1, 255, 150, 50, 150) //nolint:mnd
-			s.drawDot(pixels, px, py+6, 1, 255, 100, 30, 80)  //nolint:mnd
+			s.drawDot(pixels, px, py+3, 1, 255, 150, 50, 150)
+			s.drawDot(pixels, px, py+6, 1, 255, 100, 30, 80)
 		} else {
 			// Draw particles
 			for _, p := range rocket.particles {
@@ -1512,9 +1527,9 @@ func (s *fireworksState) render() []uint8 {
 				}
 				px := int(p.x * float64(w))
 				py := int(p.y * float64(h))
-				alpha := uint8(p.life * 255) //nolint:mnd,gosec
+				alpha := uint8(p.life * 255)
 				size := 1
-				if p.life > 0.7 { //nolint:mnd
+				if p.life > 0.7 {
 					size = 2
 				}
 				s.drawDot(pixels, px, py, size, p.r, p.g, p.b, alpha)

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -1,0 +1,427 @@
+package main
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/strobotti/linkquisition"
+)
+
+const (
+	effectMatrix      = "matrix"
+	effectFire        = "fire"
+	effectRandom      = "random"
+	frameInterval     = 30 * time.Millisecond
+	fireFrameInterval = 25 * time.Millisecond
+	fireWidth         = 200
+	fireHeight        = 100
+	matrixColumns     = 40
+	rgbaChannels      = 4
+)
+
+// Compile-time interface checks.
+var _ linkquisition.Plugin = (*shenanigans)(nil)
+var _ linkquisition.PluginUIHook = (*shenanigans)(nil)
+
+type shenanigans struct {
+	serviceProvider linkquisition.PluginServiceProvider
+	effect          string
+	stopped         atomic.Bool
+}
+
+func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
+	return linkquisition.PluginMetadata{
+		Name:        "Shenanigans",
+		Description: "Adds completely useless but entertaining visual effects to the browser picker window",
+		Author:      "Strobotti",
+		Version:     "1.0.0",
+		URL:         "https://github.com/Strobotti/linkquisition",
+		Settings: []linkquisition.PluginSettingDescriptor{
+			{
+				Key:         "effect",
+				Label:       "Effect",
+				Description: "Which visual effect to show: matrix, fire, or random",
+				Type:        linkquisition.SettingTypeChoice,
+				Default:     effectRandom,
+				Options:     []string{effectMatrix, effectFire, effectRandom},
+			},
+		},
+	}
+}
+
+func (p *shenanigans) Setup(
+	serviceProvider linkquisition.PluginServiceProvider, config map[string]interface{},
+) error {
+	p.serviceProvider = serviceProvider
+
+	if effectVal, ok := config["effect"]; ok {
+		if s, isStr := effectVal.(string); isStr {
+			p.effect = s
+		}
+	}
+
+	if p.effect == "" {
+		p.effect = effectRandom
+	}
+
+	return nil
+}
+
+func (p *shenanigans) ProcessURL(_ context.Context, url string) linkquisition.PluginResult {
+	return linkquisition.PluginResult{URL: url, Action: linkquisition.ActionContinue, ContinueChain: true}
+}
+
+func (p *shenanigans) Shutdown(_ context.Context) {
+	p.stopped.Store(true)
+}
+
+func (p *shenanigans) OnPickerShown(canvas linkquisition.PickerCanvas) {
+	effect := p.effect
+	if effect == effectRandom {
+		effects := []string{effectMatrix, effectFire}
+		effect = effects[rand.IntN(len(effects))]
+	}
+
+	p.serviceProvider.GetLogger().Debug("Shenanigans activating", "effect", effect)
+
+	switch effect {
+	case effectMatrix:
+		p.startMatrixRain(canvas)
+	case effectFire:
+		p.startFire(canvas)
+	}
+}
+
+// --- Matrix Rain Effect ---
+
+type matrixState struct {
+	columns []matrixColumn
+	width   int
+	height  int
+}
+
+type matrixColumn struct {
+	y     float64
+	speed float64
+	chars []rune
+}
+
+func (p *shenanigans) startMatrixRain(pc linkquisition.PickerCanvas) {
+	state := &matrixState{}
+	state.width = pc.Width()
+	state.height = pc.Height()
+	state.initColumns()
+
+	pc.AddRasterOverlay(0.6, func(w, h int) []uint8 {
+		if w != state.width || h != state.height {
+			state.width = w
+			state.height = h
+			state.initColumns()
+		}
+		return state.render()
+	})
+
+	go func() {
+		ticker := time.NewTicker(frameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *matrixState) initColumns() {
+	colCount := matrixColumns
+	if s.width > 0 {
+		colCount = s.width / 14
+		if colCount < 1 {
+			colCount = 1
+		}
+	}
+
+	s.columns = make([]matrixColumn, colCount)
+	for i := range s.columns {
+		s.columns[i] = matrixColumn{
+			y:     -rand.Float64() * float64(s.height),
+			speed: 2 + rand.Float64()*6,
+			chars: generateMatrixChars(20 + rand.IntN(15)), //nolint:mnd
+		}
+	}
+}
+
+func (s *matrixState) update() {
+	h := float64(s.height)
+	if h == 0 {
+		h = 400
+	}
+
+	for i := range s.columns {
+		s.columns[i].y += s.columns[i].speed
+		if s.columns[i].y > h+float64(len(s.columns[i].chars)*16) {
+			s.columns[i].y = -float64(len(s.columns[i].chars) * 16)
+			s.columns[i].speed = 2 + rand.Float64()*6
+			s.columns[i].chars = generateMatrixChars(20 + rand.IntN(15)) //nolint:mnd
+		}
+	}
+}
+
+func (s *matrixState) render() []uint8 {
+	w, h := s.width, s.height
+	if w == 0 || h == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, w*h*rgbaChannels)
+
+	colWidth := w / len(s.columns)
+	if colWidth < 1 {
+		colWidth = 1
+	}
+
+	for i, col := range s.columns {
+		x := i * colWidth
+		charHeight := 16
+
+		for j := range col.chars {
+			cy := int(col.y) - j*charHeight
+			if cy < 0 || cy >= h {
+				continue
+			}
+
+			// Fade out older characters
+			brightness := uint8(255 - min(j*12, 230)) //nolint:mnd
+
+			// Draw a simple block for each character
+			for dx := 2; dx < min(colWidth-2, 10); dx++ {
+				for dy := 2; dy < charHeight-2; dy++ {
+					px := x + dx
+					py := cy + dy
+					if px < w && py < h {
+						offset := (py*w + px) * rgbaChannels
+						pixels[offset] = 0                // R
+						pixels[offset+1] = brightness     // G
+						pixels[offset+2] = brightness / 4 // B
+						pixels[offset+3] = brightness     // A
+					}
+				}
+			}
+		}
+	}
+
+	return pixels
+}
+
+func generateMatrixChars(length int) []rune {
+	chars := []rune("アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモ0123456789")
+	result := make([]rune, length)
+	for i := range result {
+		result[i] = chars[rand.IntN(len(chars))]
+	}
+	return result
+}
+
+// --- Fire Effect ---
+
+type fireState struct {
+	grid   [][]uint8
+	width  int
+	height int
+}
+
+func (p *shenanigans) startFire(pc linkquisition.PickerCanvas) {
+	state := &fireState{
+		width:  fireWidth,
+		height: fireHeight,
+	}
+	state.init()
+
+	pc.AddRasterOverlay(0.4, func(w, h int) []uint8 {
+		return state.render(w, h)
+	})
+
+	go func() {
+		ticker := time.NewTicker(fireFrameInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			if p.stopped.Load() {
+				return
+			}
+			state.update()
+			state.update() // double-step for faster movement
+			pc.ScheduleRefresh()
+		}
+	}()
+}
+
+func (s *fireState) init() {
+	s.grid = make([][]uint8, s.height)
+	for i := range s.grid {
+		s.grid[i] = make([]uint8, s.width)
+	}
+}
+
+func (s *fireState) update() {
+	// Set the bottom two rows to random hot values (wider fuel source)
+	for x := range s.width {
+		s.grid[s.height-1][x] = uint8(180 + rand.IntN(76))  //nolint:mnd
+		s.grid[s.height-2][x] = uint8(150 + rand.IntN(106)) //nolint:mnd
+	}
+
+	// Propagate fire upward with averaging and cooling
+	for y := range s.height - 2 {
+		for x := range s.width {
+			// Sample a wider neighborhood for smoother spread
+			l2 := max(x-2, 0)
+			l1 := max(x-1, 0)
+			r1 := min(x+1, s.width-1)
+			r2 := min(x+2, s.width-1)
+
+			// Weighted average: center-heavy for more vertical flames
+			sum := int(s.grid[y+1][l1]) +
+				int(s.grid[y+1][x])*3 +
+				int(s.grid[y+1][r1]) +
+				int(s.grid[y+2][l2]) +
+				int(s.grid[y+2][x])*2 +
+				int(s.grid[y+2][r2])
+
+			avg := sum / 9 //nolint:mnd
+
+			// Cooling increases toward the top for natural fadeout
+			coolBase := 2 + (s.height-y)/15 //nolint:mnd
+			cooling := rand.IntN(coolBase + 1)
+			val := avg - cooling
+
+			if val < 0 {
+				val = 0
+			}
+			s.grid[y][x] = uint8(val) //nolint:gosec
+		}
+	}
+}
+
+func (s *fireState) render(targetW, targetH int) []uint8 {
+	if targetW == 0 || targetH == 0 {
+		return make([]uint8, rgbaChannels)
+	}
+
+	pixels := make([]uint8, targetW*targetH*rgbaChannels)
+
+	// Fire occupies the bottom 2/3 of the window
+	fireStartY := targetH / 3
+
+	fireH := targetH - fireStartY
+	if fireH <= 0 {
+		return pixels
+	}
+
+	for py := fireStartY; py < targetH; py++ {
+		for px := 0; px < targetW; px++ {
+			// Map to fire grid with bilinear interpolation
+			fy := float64(py-fireStartY) * float64(s.height-1) / float64(fireH-1)
+			fx := float64(px) * float64(s.width-1) / float64(targetW-1)
+
+			val := s.sampleBilinear(fx, fy)
+
+			r, g, b, a := fireColor(val)
+			offset := (py*targetW + px) * rgbaChannels
+			pixels[offset] = r
+			pixels[offset+1] = g
+			pixels[offset+2] = b
+			pixels[offset+3] = a
+		}
+	}
+
+	return pixels
+}
+
+// sampleBilinear performs bilinear interpolation on the fire grid for smooth scaling.
+func (s *fireState) sampleBilinear(fx, fy float64) uint8 {
+	x0 := int(fx)
+	y0 := int(fy)
+	x1 := min(x0+1, s.width-1)
+	y1 := min(y0+1, s.height-1)
+
+	xFrac := fx - float64(x0)
+	yFrac := fy - float64(y0)
+
+	// Four corners
+	v00 := float64(s.grid[y0][x0])
+	v10 := float64(s.grid[y0][x1])
+	v01 := float64(s.grid[y1][x0])
+	v11 := float64(s.grid[y1][x1])
+
+	// Interpolate
+	top := v00*(1-xFrac) + v10*xFrac
+	bottom := v01*(1-xFrac) + v11*xFrac
+	val := top*(1-yFrac) + bottom*yFrac
+
+	return uint8(min(max(int(val), 0), 255)) //nolint:gosec
+}
+
+// fireColor maps a heat value (0-255) to a realistic fire palette.
+// Gradient: transparent → dark red/brown → red → orange → gold → pale yellow
+func fireColor(val uint8) (r, g, b, a uint8) {
+	if val < 24 { //nolint:mnd
+		return 0, 0, 0, 0
+	}
+
+	// Normalize to 0.0-1.0 range (24-255 → 0.0-1.0)
+	t := float64(val-24) / 231.0 //nolint:mnd
+
+	// Piecewise palette for realistic fire
+	switch {
+	case t < 0.2: //nolint:mnd
+		// Black → dark maroon/brown
+		p := t / 0.2       //nolint:mnd
+		r = uint8(p * 80)  //nolint:mnd,gosec
+		g = uint8(p * 10)  //nolint:mnd,gosec
+		a = uint8(p * 180) //nolint:mnd,gosec
+		return r, g, 0, a
+	case t < 0.45: //nolint:mnd
+		// Dark maroon → bright red
+		p := (t - 0.2) / 0.25 //nolint:mnd
+		r = uint8(80 + p*175) //nolint:mnd,gosec
+		g = uint8(10 + p*20)  //nolint:mnd,gosec
+		a = uint8(180 + p*75) //nolint:mnd,gosec
+		return r, g, 0, a
+	case t < 0.7: //nolint:mnd
+		// Red → orange
+		p := (t - 0.45) / 0.25 //nolint:mnd
+		r = 255                //nolint:mnd
+		g = uint8(30 + p*170)  //nolint:mnd,gosec
+		a = 255                //nolint:mnd
+		return r, g, 0, a
+	case t < 0.9: //nolint:mnd
+		// Orange → golden yellow
+		p := (t - 0.7) / 0.2  //nolint:mnd
+		r = 255               //nolint:mnd
+		g = uint8(200 + p*55) //nolint:mnd,gosec
+		b = uint8(p * 30)     //nolint:mnd,gosec
+		a = 255               //nolint:mnd
+		return r, g, b, a
+	default:
+		// Golden yellow → pale yellow/white tips
+		p := (t - 0.9) / 0.1  //nolint:mnd
+		r = 255               //nolint:mnd
+		g = 255               //nolint:mnd
+		b = uint8(30 + p*120) //nolint:mnd,gosec
+		a = uint8(255 - p*80) //nolint:mnd,gosec
+		return r, g, b, a
+	}
+}
+
+// NewForTesting creates a fresh shenanigans instance for use in tests,
+// avoiding copying the package-level Plugin variable (which may contain a mutex).
+func NewForTesting() *shenanigans {
+	return &shenanigans{}
+}
+
+var Plugin shenanigans

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -48,7 +48,10 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
 	assert.Equal(t, []string{
-		"random", "matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "fireworks",
+		"random",
+		"aurora", "fire", "fireworks", "football",
+		"glitch", "matrix", "plasma", "pride",
+		"snow", "starfield",
 	}, meta.Settings[0].Options)
 }
 

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/strobotti/linkquisition"
+)
+
+func newTestServiceProvider() linkquisition.PluginServiceProvider {
+	return linkquisition.NewPluginServiceProvider(
+		slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		&linkquisition.Settings{},
+		"",
+	)
+}
+
+// mockPickerCanvas implements PickerCanvas for testing.
+type mockPickerCanvas struct {
+	drawFn       func(w, h int) []uint8
+	refreshes    int
+	overlayAdded bool
+}
+
+func (m *mockPickerCanvas) AddRasterOverlay(_ float64, draw func(w, h int) []uint8) {
+	m.drawFn = draw
+	m.overlayAdded = true
+}
+
+func (m *mockPickerCanvas) ScheduleRefresh() {
+	m.refreshes++
+}
+
+func (m *mockPickerCanvas) Width() int  { return 600 }
+func (m *mockPickerCanvas) Height() int { return 400 }
+
+func TestShenanigans_Metadata(t *testing.T) {
+	p := NewForTesting()
+	meta := p.Metadata()
+
+	assert.Equal(t, "Shenanigans", meta.Name)
+	assert.NotEmpty(t, meta.Description)
+	assert.Len(t, meta.Settings, 1)
+	assert.Equal(t, "effect", meta.Settings[0].Key)
+	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
+	assert.Equal(t, []string{"matrix", "fire", "random"}, meta.Settings[0].Options)
+}
+
+func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
+	p := NewForTesting()
+	err := p.Setup(newTestServiceProvider(), map[string]interface{}{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, effectRandom, p.effect)
+}
+
+func TestShenanigans_Setup_SpecificEffect(t *testing.T) {
+	p := NewForTesting()
+	err := p.Setup(newTestServiceProvider(), map[string]interface{}{
+		"effect": "fire",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, effectFire, p.effect)
+}
+
+func TestShenanigans_ProcessURL_PassThrough(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{})
+
+	testURL := "https://example.com/page?query=test"
+	result := p.ProcessURL(context.Background(), testURL)
+
+	assert.Equal(t, testURL, result.URL)
+	assert.Equal(t, linkquisition.ActionContinue, result.Action)
+	assert.True(t, result.ContinueChain)
+	assert.Empty(t, result.Message)
+}
+
+func TestShenanigans_ImplementsPluginUIHook(t *testing.T) {
+	p := NewForTesting()
+
+	var _ linkquisition.PluginUIHook = p
+}
+
+func TestShenanigans_OnPickerShown_Matrix(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "matrix"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	// Call the draw function to ensure it doesn't panic
+	pixels := mc.drawFn(200, 100)
+	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestShenanigans_OnPickerShown_Fire(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "fire"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	// Call the draw function to ensure it doesn't panic
+	pixels := mc.drawFn(200, 100)
+	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestShenanigans_Shutdown(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{})
+
+	p.Shutdown(context.Background())
+	assert.True(t, p.stopped.Load())
+}
+
+func TestFireState_Update(t *testing.T) {
+	state := &fireState{width: fireWidth, height: fireHeight}
+	state.init()
+
+	// Should not panic
+	state.update()
+
+	// Bottom row should have hot values (180+)
+	for x := range state.width {
+		assert.Greater(t, state.grid[state.height-1][x], uint8(179))
+	}
+}
+
+func TestFireState_Render(t *testing.T) {
+	state := &fireState{width: fireWidth, height: fireHeight}
+	state.init()
+	state.update()
+
+	pixels := state.render(200, 100)
+	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestMatrixState_InitAndUpdate(t *testing.T) {
+	state := &matrixState{width: 200, height: 400}
+	state.initColumns()
+
+	assert.NotEmpty(t, state.columns)
+
+	// Should not panic
+	state.update()
+}
+
+func TestMatrixState_Render(t *testing.T) {
+	state := &matrixState{width: 200, height: 400}
+	state.initColumns()
+	state.update()
+
+	pixels := state.render()
+	assert.Len(t, pixels, 200*400*4)
+}
+
+func TestFireColor(t *testing.T) {
+	// Low values should be transparent
+	_, _, _, a := fireColor(0)
+	assert.Equal(t, uint8(0), a)
+
+	// High values should have full red
+	r, _, _, _ := fireColor(200)
+	assert.Equal(t, uint8(255), r)
+}

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -1,4 +1,3 @@
-//nolint:mnd,gosec // Test file for visual effects plugin — magic numbers expected.
 package main
 
 import (
@@ -383,6 +382,9 @@ func TestFireColor(t *testing.T) {
 	assert.Equal(t, uint8(0), b)
 
 	// High values should have full red
-	r, _, _, _ = fireColor(200)
+	r, g, b, a = fireColor(200)
 	assert.Equal(t, uint8(255), r)
+	assert.Greater(t, g, uint8(0))
+	assert.Greater(t, a, uint8(0))
+	_ = b // blue varies by palette position
 }

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "aurora", "random"}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -209,6 +209,20 @@ func TestStarfieldState_Update(t *testing.T) {
 	initialZ := state.stars[0].z
 	state.update()
 	assert.Less(t, state.stars[0].z, initialZ)
+}
+
+func TestShenanigans_OnPickerShown_Aurora(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "aurora"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "snow", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "random"}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -146,6 +146,38 @@ func TestSnowState_Update(t *testing.T) {
 		assert.GreaterOrEqual(t, f.x, 0.0)
 		assert.Less(t, f.x, float64(state.width))
 	}
+}
+
+func TestShenanigans_OnPickerShown_Plasma(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "plasma"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	// Call the draw function to ensure it doesn't panic
+	pixels := mc.drawFn(200, 100)
+	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestPlasmaState_Render(t *testing.T) {
+	state := &plasmaState{time: 1.5}
+	pixels := state.render(100, 50)
+
+	assert.Len(t, pixels, 100*50*4)
+
+	// Should have some non-zero color values
+	hasColor := false
+	for i := 0; i < len(pixels); i += 4 {
+		if pixels[i] > 0 || pixels[i+1] > 0 || pixels[i+2] > 0 {
+			hasColor = true
+			break
+		}
+	}
+	assert.True(t, hasColor)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{"matrix", "fire", "snow", "random"}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -115,6 +115,37 @@ func TestShenanigans_OnPickerShown_Fire(t *testing.T) {
 	// Call the draw function to ensure it doesn't panic
 	pixels := mc.drawFn(200, 100)
 	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestShenanigans_OnPickerShown_Snow(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "snow"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	// Call the draw function to ensure it doesn't panic
+	pixels := mc.drawFn(600, 400)
+	assert.Len(t, pixels, 600*400*4)
+}
+
+func TestSnowState_Update(t *testing.T) {
+	state := &snowState{width: 600, height: 400}
+	state.init()
+
+	assert.Len(t, state.flakes, snowFlakeCount)
+
+	// Should not panic
+	state.update()
+
+	// All flakes should still be within bounds (with wrapping)
+	for _, f := range state.flakes {
+		assert.GreaterOrEqual(t, f.x, 0.0)
+		assert.Less(t, f.x, float64(state.width))
+	}
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -48,7 +48,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
 	assert.Equal(t, []string{
-		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "random",
+		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "fireworks", "random",
 	}, meta.Settings[0].Options)
 }
 
@@ -303,6 +303,20 @@ func TestShenanigans_OnPickerShown_Football(t *testing.T) {
 		}
 	}
 	assert.True(t, hasGreen)
+}
+
+func TestShenanigans_OnPickerShown_Fireworks(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "fireworks"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -48,7 +48,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
 	assert.Equal(t, []string{
-		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "random",
+		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "random",
 	}, meta.Settings[0].Options)
 }
 
@@ -279,6 +279,30 @@ func TestShenanigans_OnPickerShown_Pride(t *testing.T) {
 		}
 	}
 	assert.True(t, hasColor)
+}
+
+func TestShenanigans_OnPickerShown_Football(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "football"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
+
+	// Should have green pixels (pitch)
+	hasGreen := false
+	for i := 0; i < len(pixels); i += 4 {
+		if pixels[i+1] > pixels[i] && pixels[i+1] > pixels[i+2] {
+			hasGreen = true
+			break
+		}
+	}
+	assert.True(t, hasGreen)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -1,3 +1,4 @@
+//nolint:mnd,gosec // Test file for visual effects plugin — magic numbers expected.
 package main
 
 import (
@@ -89,7 +90,9 @@ func TestShenanigans_ProcessURL_PassThrough(t *testing.T) {
 func TestShenanigans_ImplementsPluginUIHook(t *testing.T) {
 	p := NewForTesting()
 
-	var _ linkquisition.PluginUIHook = p
+	// Verify the plugin satisfies the PluginUIHook interface at compile time
+	var hook linkquisition.PluginUIHook = p
+	assert.NotNil(t, hook)
 }
 
 func TestShenanigans_OnPickerShown_Matrix(t *testing.T) {
@@ -373,10 +376,13 @@ func TestMatrixState_Render(t *testing.T) {
 
 func TestFireColor(t *testing.T) {
 	// Low values should be transparent
-	_, _, _, a := fireColor(0)
+	r, g, b, a := fireColor(0)
 	assert.Equal(t, uint8(0), a)
+	assert.Equal(t, uint8(0), r)
+	assert.Equal(t, uint8(0), g)
+	assert.Equal(t, uint8(0), b)
 
 	// High values should have full red
-	r, _, _, _ := fireColor(200)
+	r, _, _, _ = fireColor(200)
 	assert.Equal(t, uint8(255), r)
 }

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "random"}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -178,6 +178,37 @@ func TestPlasmaState_Render(t *testing.T) {
 		}
 	}
 	assert.True(t, hasColor)
+}
+
+func TestShenanigans_OnPickerShown_Starfield(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "starfield"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
+}
+
+func TestStarfieldState_Update(t *testing.T) {
+	state := &starfieldState{width: 400, height: 300}
+	state.init()
+
+	assert.Len(t, state.stars, starCount)
+
+	// All z values should be positive after init
+	for _, s := range state.stars {
+		assert.Greater(t, s.z, 0.0)
+	}
+
+	// After update, stars should have moved closer
+	initialZ := state.stars[0].z
+	state.update()
+	assert.Less(t, state.stars[0].z, initialZ)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "aurora", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "random"}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -223,6 +223,36 @@ func TestShenanigans_OnPickerShown_Aurora(t *testing.T) {
 
 	pixels := mc.drawFn(400, 300)
 	assert.Len(t, pixels, 400*300*4)
+}
+
+func TestShenanigans_OnPickerShown_Glitch(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "glitch"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	// Glitch starts in non-burst state, should return empty pixels
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
+}
+
+func TestGlitchState_BurstCycle(t *testing.T) {
+	state := &glitchState{}
+
+	// Run enough updates to trigger a burst
+	for range 100 {
+		state.update()
+	}
+
+	// At some point during 100 frames, a burst should have occurred
+	// (timer starts at 0, so first update triggers a burst)
+	// Just verify it doesn't panic
+	pixels := state.render(200, 100)
+	assert.Len(t, pixels, 200*100*4)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -48,7 +48,7 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
 	assert.Equal(t, []string{
-		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "fireworks", "random",
+		"random", "matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "football", "fireworks",
 	}, meta.Settings[0].Options)
 }
 

--- a/plugins/shenanigans/shenanigans_test.go
+++ b/plugins/shenanigans/shenanigans_test.go
@@ -47,7 +47,9 @@ func TestShenanigans_Metadata(t *testing.T) {
 	assert.Len(t, meta.Settings, 1)
 	assert.Equal(t, "effect", meta.Settings[0].Key)
 	assert.Equal(t, linkquisition.SettingTypeChoice, meta.Settings[0].Type)
-	assert.Equal(t, []string{"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "random"}, meta.Settings[0].Options)
+	assert.Equal(t, []string{
+		"matrix", "fire", "snow", "plasma", "starfield", "aurora", "glitch", "pride", "random",
+	}, meta.Settings[0].Options)
 }
 
 func TestShenanigans_Setup_DefaultEffect(t *testing.T) {
@@ -253,6 +255,30 @@ func TestGlitchState_BurstCycle(t *testing.T) {
 	// Just verify it doesn't panic
 	pixels := state.render(200, 100)
 	assert.Len(t, pixels, 200*100*4)
+}
+
+func TestShenanigans_OnPickerShown_Pride(t *testing.T) {
+	p := NewForTesting()
+	_ = p.Setup(newTestServiceProvider(), map[string]interface{}{"effect": "pride"})
+
+	mc := &mockPickerCanvas{}
+	p.OnPickerShown(mc)
+
+	assert.True(t, mc.overlayAdded)
+	assert.NotNil(t, mc.drawFn)
+
+	pixels := mc.drawFn(400, 300)
+	assert.Len(t, pixels, 400*300*4)
+
+	// Should have colorful pixels (not all black)
+	hasColor := false
+	for i := 0; i < len(pixels); i += 4 {
+		if pixels[i] > 0 || pixels[i+1] > 0 || pixels[i+2] > 0 {
+			hasColor = true
+			break
+		}
+	}
+	assert.True(t, hasColor)
 }
 
 func TestShenanigans_Shutdown(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new **shenanigans** plugin that draws completely useless but entertaining visual effects on the browser picker window. This also introduces the `PluginUIHook` interface — an optional extension that allows plugins to interact with the picker GUI without importing Fyne directly.

## New plugin interface: `PluginUIHook`

Plugins can optionally implement `PluginUIHook` to receive a callback when the picker window is shown. The `PickerCanvas` abstraction provides methods to add raster overlays without requiring plugins to import `fyne.io/fyne/v2` (which would cause build-flag mismatches).

## Effects (10 total)

- **random** — Randomly picks one of the effects below
- **aurora** — Northern lights with flowing green/purple/blue bands
- **fire** — Realistic flames rising from the bottom
- **fireworks** — Rockets launching and exploding into colorful particles
- **football** — Top-down football pitch with animated spotlight
- **glitch** — Cyberpunk RGB channel splitting with static bursts
- **matrix** — Green Matrix-style falling characters
- **plasma** — Classic demoscene swirling color blobs
- **pride** — Animated rainbow pride flag waving in the wind
- **snow** — Gentle snowfall with varying sizes and wobble
- **starfield** — 3D warp-speed stars flying toward the viewer

## Other changes

- Added `task package:app:dev` / `task package:app:install-dev` for macOS dev builds (single-arch, required for plugin loading)
- Fixed `task package:clean` to not delete tracked source files (`package/darwin/Info.plist`)
- Added `-tags release` to plugin builds in `Taskfile.build.yml` for consistency with the main binary
- Updated `.goreleaser.yaml` and `plugins/README.md` with shenanigans documentation
