### PR TITLE
feat: Add copy button and improve URL readability in browser picker

### DIFF
--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -75,6 +75,8 @@ tasks:
     cmds:
       - task package:app:dev
       - cp -r dist/Linkquisition.app /Applications/
+      - codesign --force --deep --sign - /Applications/Linkquisition.app
+      - xattr -cr /Applications/Linkquisition.app
       - /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -R -f /Applications/Linkquisition.app
       - echo "Installed to /Applications/Linkquisition.app and registered with Launch Services"
 

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -14,6 +14,7 @@ import (
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
@@ -107,7 +108,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 		widgets = append(widgets, buttons...)
 	}
 
-	widgets = append(widgets, picker.buildURLDisplay(urlToOpen)...)
+	widgets = append(widgets, picker.buildURLDisplay(urlToOpen, w)...)
 	widgets = append(widgets, picker.buildRememberCheck(urlToOpen, remember)...)
 
 	if !settings.Ui.HideKeyboardGuideLabel {
@@ -192,18 +193,26 @@ func (picker *BrowserPicker) buildHorizontalGrid(buttons []fyne.CanvasObject, ma
 	return container.NewGridWithColumns(cols, buttons...)
 }
 
-func (picker *BrowserPicker) buildURLDisplay(urlToOpen string) []fyne.CanvasObject {
+func (picker *BrowserPicker) buildURLDisplay(urlToOpen string, w fyne.Window) []fyne.CanvasObject {
 	text := urlToOpen
 	if len(urlToOpen) > 75 { //nolint:mnd
 		text = urlToOpen[:75] + "..."
 	}
 
-	input := widget.NewEntry()
-	input.SetText(text)
-	input.Disable()
+	urlLabel := widget.NewLabel(text)
+	urlLabel.TextStyle = fyne.TextStyle{Monospace: true}
+
+	copyButton := widget.NewButtonWithIcon(i18n.T("picker.copy_button"), theme.ContentCopyIcon(), func() {
+		w.Clipboard().SetContent(urlToOpen)
+	})
+	copyButton.Importance = widget.LowImportance
 
 	return []fyne.CanvasObject{
-		container.NewBorder(nil, nil, widget.NewLabel(i18n.T("picker.open_label")), nil, input),
+		container.NewHBox(
+			copyButton,
+			widget.NewLabel(i18n.T("picker.open_label")),
+			urlLabel,
+		),
 	}
 }
 

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -59,6 +59,9 @@
   "picker.open_label": {
     "other": "Open:"
   },
+  "picker.copy_button": {
+    "other": "Copy"
+  },
   "picker.remember_choice": {
     "other": "Remember this choice with {{.Site}}"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -59,6 +59,9 @@
   "picker.open_label": {
     "other": "Abrir:"
   },
+  "picker.copy_button": {
+    "other": "Copiar"
+  },
   "picker.remember_choice": {
     "other": "Recordar esta elección para {{.Site}}"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -59,6 +59,9 @@
   "picker.open_label": {
     "other": "Avaa:"
   },
+  "picker.copy_button": {
+    "other": "Kopioi"
+  },
   "picker.remember_choice": {
     "other": "Muista tämä valinta sivustolle {{.Site}}"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -59,6 +59,9 @@
   "picker.open_label": {
     "other": "Öppna:"
   },
+  "picker.copy_button": {
+    "other": "Kopiera"
+  },
   "picker.remember_choice": {
     "other": "Kom ihåg detta val för {{.Site}}"
   },


### PR DESCRIPTION
## Summary

- Add a "Copy" button with clipboard icon to the browser picker URL display for one-click URL copying
- Replace the disabled Entry widget with a monospace Label for better text contrast (especially in dark mode)
- Fix macOS `install-dev` task to ad-hoc codesign the app after copying to `/Applications`