### PR TITLE
feat: Add translations for 6 new languages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ The app has two UI modes, both in `cmd/`:
 ## Localization
 
 - Translation files live in `internal/i18n/translations/` (JSON, keyed by locale code)
-- Supported: `en`, `fi`, `es`, `sv`
+- Supported: `de`, `en`, `es`, `fi`, `fr`, `hu`, `pt`, `pt-BR`, `sv`, `uk`
 - The `locale` config key overrides system detection
 - Plugins do NOT currently have access to the i18n system
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,15 @@ Linkquisition supports localization. The UI language is determined in the follow
 Currently supported languages:
 
 - English (en) — default
+- Brazilian Portuguese (pt-BR)
 - Finnish (fi)
+- French (fr)
+- German (de)
+- Hungarian (hu)
+- Portuguese (pt)
 - Spanish (es)
 - Swedish (sv)
+- Ukrainian (uk)
 
 To contribute a new translation, add a JSON file to `internal/i18n/translations/` following the
 format of the existing files (e.g. `en.json`). The filename should be the locale code (e.g. `de.json` for German).

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
@@ -135,6 +136,11 @@ func (c *Configurator) buildMakeDefaultSection() fyne.CanvasObject {
 func (c *Configurator) buildLanguageSection() fyne.CanvasObject {
 	locales := i18n.AvailableLocales()
 	autoLabel := i18n.T("config.language_auto")
+
+	// Sort locales alphabetically by display name.
+	sort.Slice(locales, func(i, j int) bool {
+		return i18n.LocaleDisplayName(locales[i]) < i18n.LocaleDisplayName(locales[j])
+	})
 
 	options := []string{autoLabel}
 	for _, code := range locales {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -22,18 +22,30 @@ var localizer *i18n.Localizer
 
 // Locale code constants.
 const (
-	LocaleEnglish = "en"
-	LocaleSpanish = "es"
-	LocaleFinnish = "fi"
-	LocaleSwedish = "sv"
+	LocaleGerman              = "de"
+	LocaleEnglish             = "en"
+	LocaleSpanish             = "es"
+	LocaleFinnish             = "fi"
+	LocaleFrench              = "fr"
+	LocaleHungarian           = "hu"
+	LocalePortuguese          = "pt"
+	LocaleBrazilianPortuguese = "pt-BR"
+	LocaleSwedish             = "sv"
+	LocaleUkrainian           = "uk"
 )
 
 // localeNames maps locale codes to their display names (in their own language).
 var localeNames = map[string]string{
-	LocaleEnglish: "English",
-	LocaleSpanish: "Español",
-	LocaleFinnish: "Suomi",
-	LocaleSwedish: "Svenska",
+	LocaleGerman:              "Deutsch",
+	LocaleEnglish:             "English",
+	LocaleSpanish:             "Español",
+	LocaleFinnish:             "Suomi",
+	LocaleFrench:              "Français",
+	LocaleHungarian:           "Magyar",
+	LocalePortuguese:          "Português",
+	LocaleBrazilianPortuguese: "Português (Brasil)",
+	LocaleSwedish:             "Svenska",
+	LocaleUkrainian:           "Українська",
 }
 
 // AvailableLocales returns the locale codes of all embedded translation files,

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -123,12 +123,15 @@ func TestDetectLocale_EmptyOverrideFallsBack(t *testing.T) {
 func TestAvailableLocales(t *testing.T) {
 	locales := AvailableLocales()
 
-	// Should contain at least the four known locales
-	if len(locales) < 4 {
-		t.Errorf("AvailableLocales() returned %d locales, want at least 4", len(locales))
+	// Should contain at least the ten known locales
+	if len(locales) < 10 {
+		t.Errorf("AvailableLocales() returned %d locales, want at least 10", len(locales))
 	}
 
-	expected := map[string]bool{"en": false, "es": false, "fi": false, "sv": false}
+	expected := map[string]bool{
+		"de": false, "en": false, "es": false, "fi": false, "fr": false,
+		"hu": false, "pt": false, "pt-BR": false, "sv": false, "uk": false,
+	}
 	for _, loc := range locales {
 		if _, ok := expected[loc]; ok {
 			expected[loc] = true
@@ -147,10 +150,16 @@ func TestLocaleDisplayName(t *testing.T) {
 		code string
 		want string
 	}{
+		{LocaleGerman, "Deutsch"},
 		{LocaleEnglish, "English"},
-		{LocaleFinnish, "Suomi"},
 		{LocaleSpanish, "Español"},
+		{LocaleFinnish, "Suomi"},
+		{LocaleFrench, "Français"},
+		{LocaleHungarian, "Magyar"},
+		{LocalePortuguese, "Português"},
+		{LocaleBrazilianPortuguese, "Português (Brasil)"},
 		{LocaleSwedish, "Svenska"},
+		{LocaleUkrainian, "Українська"},
 		{"unknown", "unknown"}, // falls back to code itself
 		{"", ""},               // empty code returns empty
 	}

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Linkquisition Einstellungen"
+  },
+  "config.tab_general": {
+    "other": "Allgemein"
+  },
+  "config.tab_about": {
+    "other": "Über"
+  },
+  "config.tab_rules": {
+    "other": "Regeln"
+  },
+  "config.rules_description": {
+    "other": "Zuordnungsregeln bestimmen, welcher Browser eine URL automatisch öffnet.\n\nRegeln können nach Webseite (z.B. www.example.com), Domain (z.B. example.com) oder regulärem Ausdruck zuordnen.\n\nDerzeit werden Regeln durch direkte Bearbeitung der Konfigurationsdatei verwaltet. Ein visueller Editor wird in einer zukünftigen Version hinzugefügt."
+  },
+  "config.rules_edit_button": {
+    "other": "Konfigurationsdatei im Editor öffnen"
+  },
+  "config.make_default_label": {
+    "other": "Damit Linkquisition als Browser-Auswahl funktioniert,\nmuss es als Standardbrowser festgelegt werden:"
+  },
+  "config.make_default_done": {
+    "other": "Alles in Ordnung!"
+  },
+  "config.make_default_button": {
+    "other": "Als Standard festlegen"
+  },
+  "config.make_default_error": {
+    "other": "Fehler beim Festlegen als Standard!"
+  },
+  "config.make_default_checking": {
+    "other": "Prüfe"
+  },
+  "config.scan_browsers": {
+    "other": "Browser suchen"
+  },
+  "config.rescan_browsers": {
+    "other": "Browser erneut suchen"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "Suche\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Fertig"
+  },
+  "config.scan_now": {
+    "other": "Jetzt suchen"
+  },
+  "config.scan_error": {
+    "other": "Fehler bei der Browser-Suche!"
+  },
+  "config.scan_description": {
+    "other": "Die Browser sollten gescannt und in einer Konfigurationsdatei gespeichert werden,\num schnellere Startzeiten und einfachere Konfiguration zu ermöglichen.\n\nDer Scan kann jederzeit sicher ausgeführt werden: Nur neu erkannte\nBrowser werden hinzugefügt und nicht mehr vorhandene werden entfernt.\n\nBestehende Regeln, Reihenfolge oder Anpassungen bleiben unberührt."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Öffne:"
+  },
+  "picker.copy_button": {
+    "other": "Kopieren"
+  },
+  "picker.remember_choice": {
+    "other": "Auswahl für {{.Site}} merken"
+  },
+  "picker.keyboard_guide": {
+    "other": "Drücke 'ENTER' für den ersten, 'ESC' zum Beenden, '{{.CopyShortcut}}' um die URL zu kopieren"
+  },
+  "config.language_label": {
+    "other": "Sprache:"
+  },
+  "config.language_auto": {
+    "other": "Automatisch (Systemstandard)"
+  },
+  "config.language_restart_note": {
+    "other": "Sprachänderung wird beim nächsten Start wirksam."
+  },
+  "config.scan_in_progress": {
+    "other": "Suche..."
+  },
+  "config.scan_success": {
+    "other": "✓ Browser erfolgreich gescannt"
+  },
+  "config.scan_failed": {
+    "other": "✗ Scan fehlgeschlagen"
+  },
+  "config.log_level_label": {
+    "other": "Protokollebene:"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Tastenkürzel-Anleitung im Auswahlfenster ausblenden"
+  },
+  "about.description": {
+    "other": "Eine schnelle, konfigurierbare Browser-Auswahl für Linux und macOS."
+  },
+  "about.author_label": {
+    "other": "Autor:"
+  },
+  "about.license_label": {
+    "other": "Lizenz:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
+  },
+  "plugin.blocked_title": {
+    "other": "Von Plugin blockiert"
+  },
+  "plugin.warning_title": {
+    "other": "Warnung"
+  },
+  "plugin.warn_cancel": {
+    "other": "Abbrechen"
+  },
+  "plugin.warn_proceed": {
+    "other": "Trotzdem öffnen"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Aktiviert"
+  },
+  "config.plugins_configure": {
+    "other": "Konfigurieren..."
+  },
+  "config.plugins_add": {
+    "other": "Hinzufügen"
+  },
+  "config.plugins_available": {
+    "other": "Verfügbar (nicht konfiguriert):"
+  },
+  "config.plugins_none_available": {
+    "other": "Keine weiteren Plugins verfügbar."
+  },
+  "config.plugins_settings_title": {
+    "other": "{{.Name}} Einstellungen"
+  },
+  "config.plugins_save": {
+    "other": "Speichern"
+  },
+  "config.plugins_cancel": {
+    "other": "Abbrechen"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Plugin-Änderungen werden beim nächsten URL-Öffnen wirksam."
+  },
+  "config.tab_browsers": {
+    "other": "Browser"
+  },
+  "config.browsers_empty": {
+    "other": "Noch keine Browser konfiguriert.\n\nKlicke den Button unten, um das System nach installierten Browsern zu durchsuchen. Dies ist erforderlich, damit Linkquisition als Browser-Auswahl funktioniert."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Im Auswahlfenster anzeigen"
+  },
+  "config.browsers_add": {
+    "other": "Browser hinzufügen..."
+  },
+  "config.browsers_add_title": {
+    "other": "Browser hinzufügen"
+  },
+  "config.browsers_edit": {
+    "other": "Bearbeiten..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Browser bearbeiten"
+  },
+  "config.browsers_delete": {
+    "other": "Löschen"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Möchtest du \"{{.Name}}\" wirklich löschen?"
+  },
+  "config.browsers_name": {
+    "other": "Name"
+  },
+  "config.browsers_command": {
+    "other": "Befehl"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "z.B. Firefox Privat"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "z.B. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Symbol"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/pfad/zum/symbol.png (optional)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(automatisch)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(manuell)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} Regel(n)"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Keine Browser konfiguriert. Gehe zum Browser-Tab, um installierte Browser zu suchen."
+  },
+  "config.rules_no_browsers": {
+    "other": "Keine Browser konfiguriert. Füge zuerst Browser im Browser-Tab hinzu."
+  },
+  "config.rules_empty": {
+    "other": "Noch keine Zuordnungsregeln konfiguriert.\n\nRegeln bestimmen, welcher Browser eine URL automatisch öffnet. Verwende den \"+ Regel hinzufügen\"-Button neben einem Browser-Namen, um eine Regel zu erstellen."
+  },
+  "config.rules_add": {
+    "other": "+ Regel hinzufügen"
+  },
+  "config.rules_add_title": {
+    "other": "Regel hinzufügen für {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Typ"
+  },
+  "config.rules_value": {
+    "other": "Wert"
+  },
+  "config.rules_value_placeholder": {
+    "other": "z.B. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Keine Regeln konfiguriert"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Ungültiger regulärer Ausdruck"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Regeln filtern..."
+  },
+  "config.rules_no_match": {
+    "other": "Keine Regeln entsprechen dem Filter."
+  },
+  "config.macos_picker_note": {
+    "other": "Hinweis: Das Browser-Auswahlfenster ist nicht verfügbar, solange die Einstellungen geöffnet sind. Links, die während der geöffneten Einstellungen angeklickt werden, werden automatisch im ersten passenden Browser geöffnet."
+  },
+  "config.picker_layout_label": {
+    "other": "Auswahl-Layout:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertikal (Liste)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (Buttons)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Maximale Elemente pro Zeile:"
+  }
+}

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Paramètres Linkquisition"
+  },
+  "config.tab_general": {
+    "other": "Général"
+  },
+  "config.tab_about": {
+    "other": "À propos"
+  },
+  "config.tab_rules": {
+    "other": "Règles"
+  },
+  "config.rules_description": {
+    "other": "Les règles de correspondance déterminent quel navigateur ouvre automatiquement une URL donnée.\n\nLes règles peuvent correspondre par site (ex. www.example.com), domaine (ex. example.com) ou expression régulière.\n\nPour l'instant, les règles sont gérées en modifiant directement le fichier de configuration. Un éditeur visuel sera ajouté dans une version future."
+  },
+  "config.rules_edit_button": {
+    "other": "Ouvrir le fichier de configuration dans l'éditeur"
+  },
+  "config.make_default_label": {
+    "other": "Pour que Linkquisition fonctionne comme sélecteur de navigateur,\nil doit être défini comme navigateur par défaut :"
+  },
+  "config.make_default_done": {
+    "other": "Tout est bon !"
+  },
+  "config.make_default_button": {
+    "other": "Définir par défaut"
+  },
+  "config.make_default_error": {
+    "other": "Erreur lors de la définition par défaut !"
+  },
+  "config.make_default_checking": {
+    "other": "vérification"
+  },
+  "config.scan_browsers": {
+    "other": "Rechercher les navigateurs"
+  },
+  "config.rescan_browsers": {
+    "other": "Rechercher à nouveau"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "Recherche\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Terminé"
+  },
+  "config.scan_now": {
+    "other": "Rechercher maintenant"
+  },
+  "config.scan_error": {
+    "other": "Erreur lors de la recherche des navigateurs !"
+  },
+  "config.scan_description": {
+    "other": "Les navigateurs doivent être détectés et enregistrés dans un fichier de configuration\npour un démarrage plus rapide et une configuration personnalisée.\n\nLa recherche peut être exécutée en toute sécurité à tout moment : seuls les\nnavigateurs nouvellement détectés sont ajoutés et ceux qui ne sont plus\nprésents sont supprimés.\n\nLes règles, l'ordre ou les personnalisations existantes ne sont pas affectés."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Ouvrir :"
+  },
+  "picker.copy_button": {
+    "other": "Copier"
+  },
+  "picker.remember_choice": {
+    "other": "Se souvenir de ce choix pour {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Appuyez sur 'ENTRÉE' pour le premier, 'ÉCHAP' pour quitter, '{{.CopyShortcut}}' pour copier l'URL"
+  },
+  "config.language_label": {
+    "other": "Langue :"
+  },
+  "config.language_auto": {
+    "other": "Automatique (par défaut du système)"
+  },
+  "config.language_restart_note": {
+    "other": "Le changement de langue prend effet au prochain lancement."
+  },
+  "config.scan_in_progress": {
+    "other": "Recherche..."
+  },
+  "config.scan_success": {
+    "other": "✓ Navigateurs détectés avec succès"
+  },
+  "config.scan_failed": {
+    "other": "✗ Échec de la recherche"
+  },
+  "config.log_level_label": {
+    "other": "Niveau de journalisation :"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Masquer le guide des raccourcis clavier dans le sélecteur"
+  },
+  "about.description": {
+    "other": "Un sélecteur de navigateur rapide et configurable pour Linux et macOS."
+  },
+  "about.author_label": {
+    "other": "Auteur :"
+  },
+  "about.license_label": {
+    "other": "Licence :"
+  },
+  "about.github_label": {
+    "other": "GitHub :"
+  },
+  "plugin.blocked_title": {
+    "other": "Bloqué par le plugin"
+  },
+  "plugin.warning_title": {
+    "other": "Avertissement"
+  },
+  "plugin.warn_cancel": {
+    "other": "Annuler"
+  },
+  "plugin.warn_proceed": {
+    "other": "Ouvrir quand même"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Activé"
+  },
+  "config.plugins_configure": {
+    "other": "Configurer..."
+  },
+  "config.plugins_add": {
+    "other": "Ajouter"
+  },
+  "config.plugins_available": {
+    "other": "Disponibles (non configurés) :"
+  },
+  "config.plugins_none_available": {
+    "other": "Aucun plugin supplémentaire disponible."
+  },
+  "config.plugins_settings_title": {
+    "other": "Paramètres de {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Enregistrer"
+  },
+  "config.plugins_cancel": {
+    "other": "Annuler"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Les modifications de plugins prennent effet à la prochaine ouverture d'URL."
+  },
+  "config.tab_browsers": {
+    "other": "Navigateurs"
+  },
+  "config.browsers_empty": {
+    "other": "Aucun navigateur configuré pour le moment.\n\nCliquez sur le bouton ci-dessous pour rechercher les navigateurs installés. Ceci est nécessaire pour que Linkquisition fonctionne comme sélecteur de navigateur."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Afficher dans le sélecteur"
+  },
+  "config.browsers_add": {
+    "other": "Ajouter un navigateur..."
+  },
+  "config.browsers_add_title": {
+    "other": "Ajouter un navigateur"
+  },
+  "config.browsers_edit": {
+    "other": "Modifier..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Modifier le navigateur"
+  },
+  "config.browsers_delete": {
+    "other": "Supprimer"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Êtes-vous sûr de vouloir supprimer \"{{.Name}}\" ?"
+  },
+  "config.browsers_name": {
+    "other": "Nom"
+  },
+  "config.browsers_command": {
+    "other": "Commande"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "ex. Firefox Privé"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "ex. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Icône"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/chemin/vers/icone.png (optionnel)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(automatique)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(manuel)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} règle(s)"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Aucun navigateur configuré. Allez dans l'onglet Navigateurs pour rechercher les navigateurs installés."
+  },
+  "config.rules_no_browsers": {
+    "other": "Aucun navigateur configuré. Ajoutez d'abord des navigateurs dans l'onglet Navigateurs."
+  },
+  "config.rules_empty": {
+    "other": "Aucune règle de correspondance configurée pour le moment.\n\nLes règles déterminent quel navigateur ouvre automatiquement une URL. Utilisez le bouton \"+ Ajouter une règle\" à côté du nom d'un navigateur pour en créer une."
+  },
+  "config.rules_add": {
+    "other": "+ Ajouter une règle"
+  },
+  "config.rules_add_title": {
+    "other": "Ajouter une règle à {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Type"
+  },
+  "config.rules_value": {
+    "other": "Valeur"
+  },
+  "config.rules_value_placeholder": {
+    "other": "ex. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Aucune règle configurée"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Expression régulière invalide"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Filtrer les règles..."
+  },
+  "config.rules_no_match": {
+    "other": "Aucune règle ne correspond au filtre."
+  },
+  "config.macos_picker_note": {
+    "other": "Note : La fenêtre de sélection de navigateur n'est pas disponible tant que cet écran de paramètres est ouvert. Les liens cliqués pendant que les paramètres sont ouverts seront ouverts automatiquement dans le premier navigateur correspondant."
+  },
+  "config.picker_layout_label": {
+    "other": "Disposition du sélecteur :"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertical (liste)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (boutons)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Éléments maximum par ligne :"
+  }
+}

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Linkquisition beállítások"
+  },
+  "config.tab_general": {
+    "other": "Általános"
+  },
+  "config.tab_about": {
+    "other": "Névjegy"
+  },
+  "config.tab_rules": {
+    "other": "Szabályok"
+  },
+  "config.rules_description": {
+    "other": "Az egyezési szabályok határozzák meg, melyik böngésző nyitja meg automatikusan az adott URL-t.\n\nA szabályok egyezhetnek webhely (pl. www.example.com), domain (pl. example.com) vagy reguláris kifejezés alapján.\n\nEgyelőre a szabályok a konfigurációs fájl közvetlen szerkesztésével kezelhetők. Vizuális szerkesztő egy jövőbeli verzióban lesz elérhető."
+  },
+  "config.rules_edit_button": {
+    "other": "Konfigurációs fájl megnyitása szerkesztőben"
+  },
+  "config.make_default_label": {
+    "other": "Ahhoz, hogy a Linkquisition böngészőválasztóként működjön,\nalapértelmezett böngészőként kell beállítani:"
+  },
+  "config.make_default_done": {
+    "other": "Minden rendben!"
+  },
+  "config.make_default_button": {
+    "other": "Beállítás alapértelmezettként"
+  },
+  "config.make_default_error": {
+    "other": "Hiba az alapértelmezett beállításakor!"
+  },
+  "config.make_default_checking": {
+    "other": "ellenőrzés"
+  },
+  "config.scan_browsers": {
+    "other": "Böngészők keresése"
+  },
+  "config.rescan_browsers": {
+    "other": "Böngészők újrakeresése"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "Keresés\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Kész"
+  },
+  "config.scan_now": {
+    "other": "Keresés most"
+  },
+  "config.scan_error": {
+    "other": "Hiba a böngészők keresésekor!"
+  },
+  "config.scan_description": {
+    "other": "A böngészőket be kell olvasni és el kell tárolni a konfigurációs fájlban\na gyorsabb indulás és az egyéni konfiguráció érdekében.\n\nA keresés bármikor biztonságosan végrehajtható: csak az újonnan\ntalált böngészők kerülnek hozzáadásra, a már nem jelenlevők pedig\ntörlődnek.\n\nA meglévő szabályok, sorrend vagy testreszabások nem érintettek."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Megnyitás:"
+  },
+  "picker.copy_button": {
+    "other": "Másolás"
+  },
+  "picker.remember_choice": {
+    "other": "Választás megjegyzése a(z) {{.Site}} webhelyhez"
+  },
+  "picker.keyboard_guide": {
+    "other": "Nyomj 'ENTER'-t az első kiválasztásához, 'ESC'-t a kilépéshez, '{{.CopyShortcut}}'-t az URL vágólapra másolásához"
+  },
+  "config.language_label": {
+    "other": "Nyelv:"
+  },
+  "config.language_auto": {
+    "other": "Automatikus (rendszer alapértelmezett)"
+  },
+  "config.language_restart_note": {
+    "other": "A nyelvváltozás a következő indításkor lép érvénybe."
+  },
+  "config.scan_in_progress": {
+    "other": "Keresés..."
+  },
+  "config.scan_success": {
+    "other": "✓ Böngészők sikeresen beolvasva"
+  },
+  "config.scan_failed": {
+    "other": "✗ A keresés sikertelen"
+  },
+  "config.log_level_label": {
+    "other": "Naplózási szint:"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Billentyűparancs-útmutató elrejtése a választóban"
+  },
+  "about.description": {
+    "other": "Gyors, konfigurálható böngészőválasztó Linuxhoz és macOS-hez."
+  },
+  "about.author_label": {
+    "other": "Szerző:"
+  },
+  "about.license_label": {
+    "other": "Licenc:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
+  },
+  "plugin.blocked_title": {
+    "other": "Bővítmény által blokkolva"
+  },
+  "plugin.warning_title": {
+    "other": "Figyelmeztetés"
+  },
+  "plugin.warn_cancel": {
+    "other": "Mégse"
+  },
+  "plugin.warn_proceed": {
+    "other": "Megnyitás mindenképp"
+  },
+  "config.tab_plugins": {
+    "other": "Bővítmények"
+  },
+  "config.plugins_enabled": {
+    "other": "Engedélyezve"
+  },
+  "config.plugins_configure": {
+    "other": "Beállítás..."
+  },
+  "config.plugins_add": {
+    "other": "Hozzáadás"
+  },
+  "config.plugins_available": {
+    "other": "Elérhető (nincs konfigurálva):"
+  },
+  "config.plugins_none_available": {
+    "other": "Nincs további elérhető bővítmény."
+  },
+  "config.plugins_settings_title": {
+    "other": "{{.Name}} beállítások"
+  },
+  "config.plugins_save": {
+    "other": "Mentés"
+  },
+  "config.plugins_cancel": {
+    "other": "Mégse"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "A bővítmény-módosítások a következő URL megnyitásakor lépnek érvénybe."
+  },
+  "config.tab_browsers": {
+    "other": "Böngészők"
+  },
+  "config.browsers_empty": {
+    "other": "Még nincsenek böngészők konfigurálva.\n\nKattints az alábbi gombra a telepített böngészők kereséséhez. Ez szükséges a Linkquisition böngészőválasztóként való működéséhez."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Megjelenítés a választóban"
+  },
+  "config.browsers_add": {
+    "other": "Böngésző hozzáadása..."
+  },
+  "config.browsers_add_title": {
+    "other": "Böngésző hozzáadása"
+  },
+  "config.browsers_edit": {
+    "other": "Szerkesztés..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Böngésző szerkesztése"
+  },
+  "config.browsers_delete": {
+    "other": "Törlés"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Biztosan törölni szeretnéd a(z) \"{{.Name}}\" böngészőt?"
+  },
+  "config.browsers_name": {
+    "other": "Név"
+  },
+  "config.browsers_command": {
+    "other": "Parancs"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "pl. Firefox Privát"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "pl. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Ikon"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/útvonal/ikon.png (opcionális)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(automatikus)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(kézi)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} szabály"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Nincsenek böngészők konfigurálva. Menj a Böngészők fülre a telepített böngészők kereséséhez."
+  },
+  "config.rules_no_browsers": {
+    "other": "Nincsenek böngészők konfigurálva. Először adj hozzá böngészőket a Böngészők fülön."
+  },
+  "config.rules_empty": {
+    "other": "Még nincsenek egyezési szabályok konfigurálva.\n\nA szabályok határozzák meg, melyik böngésző nyit meg automatikusan egy URL-t. Használd a \"+ Szabály hozzáadása\" gombot a böngésző neve mellett egy szabály létrehozásához."
+  },
+  "config.rules_add": {
+    "other": "+ Szabály hozzáadása"
+  },
+  "config.rules_add_title": {
+    "other": "Szabály hozzáadása: {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Típus"
+  },
+  "config.rules_value": {
+    "other": "Érték"
+  },
+  "config.rules_value_placeholder": {
+    "other": "pl. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Nincsenek konfigurált szabályok"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Érvénytelen reguláris kifejezés"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Szabályok szűrése..."
+  },
+  "config.rules_no_match": {
+    "other": "Nincs a szűrőnek megfelelő szabály."
+  },
+  "config.macos_picker_note": {
+    "other": "Megjegyzés: A böngészőválasztó ablak nem érhető el, amíg ez a beállítások képernyő nyitva van. A beállítások megnyitása közben kattintott linkek automatikusan az első egyező böngészőben nyílnak meg."
+  },
+  "config.picker_layout_label": {
+    "other": "Választó elrendezése:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Függőleges (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Vízszintes (gombok)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Maximum elemek soronként:"
+  }
+}

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Configurações do Linkquisition"
+  },
+  "config.tab_general": {
+    "other": "Geral"
+  },
+  "config.tab_about": {
+    "other": "Sobre"
+  },
+  "config.tab_rules": {
+    "other": "Regras"
+  },
+  "config.rules_description": {
+    "other": "As regras de correspondência determinam qual navegador abre automaticamente uma URL.\n\nAs regras podem corresponder por site (ex. www.example.com), domínio (ex. example.com) ou expressão regular.\n\nPor enquanto, as regras são gerenciadas editando diretamente o arquivo de configuração. Um editor visual será adicionado em uma versão futura."
+  },
+  "config.rules_edit_button": {
+    "other": "Abrir arquivo de configuração no editor"
+  },
+  "config.make_default_label": {
+    "other": "Para que o Linkquisition funcione como seletor de navegador,\nele deve ser definido como navegador padrão:"
+  },
+  "config.make_default_done": {
+    "other": "Tudo certo!"
+  },
+  "config.make_default_button": {
+    "other": "Definir como padrão"
+  },
+  "config.make_default_error": {
+    "other": "Erro ao definir como padrão!"
+  },
+  "config.make_default_checking": {
+    "other": "verificando"
+  },
+  "config.scan_browsers": {
+    "other": "Buscar navegadores"
+  },
+  "config.rescan_browsers": {
+    "other": "Buscar navegadores novamente"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "Buscando\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Concluído"
+  },
+  "config.scan_now": {
+    "other": "Buscar agora"
+  },
+  "config.scan_error": {
+    "other": "Erro ao buscar navegadores!"
+  },
+  "config.scan_description": {
+    "other": "Os navegadores devem ser detectados e armazenados em um arquivo de configuração\npara inicialização mais rápida e configuração personalizada.\n\nA busca pode ser executada com segurança a qualquer momento: apenas\nnavegadores recém-detectados são adicionados e os que não estão mais\npresentes são removidos.\n\nRegras existentes, ordenação ou personalizações não são afetadas."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Abrir:"
+  },
+  "picker.copy_button": {
+    "other": "Copiar"
+  },
+  "picker.remember_choice": {
+    "other": "Lembrar esta escolha para {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Pressione 'ENTER' para o primeiro, 'ESC' para sair, '{{.CopyShortcut}}' para copiar a URL"
+  },
+  "config.language_label": {
+    "other": "Idioma:"
+  },
+  "config.language_auto": {
+    "other": "Automático (padrão do sistema)"
+  },
+  "config.language_restart_note": {
+    "other": "A mudança de idioma terá efeito na próxima inicialização."
+  },
+  "config.scan_in_progress": {
+    "other": "Buscando..."
+  },
+  "config.scan_success": {
+    "other": "✓ Navegadores detectados com sucesso"
+  },
+  "config.scan_failed": {
+    "other": "✗ Falha na busca"
+  },
+  "config.log_level_label": {
+    "other": "Nível de log:"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Ocultar guia de atalhos de teclado no seletor"
+  },
+  "about.description": {
+    "other": "Um seletor de navegador rápido e configurável para Linux e macOS."
+  },
+  "about.author_label": {
+    "other": "Autor:"
+  },
+  "about.license_label": {
+    "other": "Licença:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
+  },
+  "plugin.blocked_title": {
+    "other": "Bloqueado pelo plugin"
+  },
+  "plugin.warning_title": {
+    "other": "Aviso"
+  },
+  "plugin.warn_cancel": {
+    "other": "Cancelar"
+  },
+  "plugin.warn_proceed": {
+    "other": "Abrir mesmo assim"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Ativado"
+  },
+  "config.plugins_configure": {
+    "other": "Configurar..."
+  },
+  "config.plugins_add": {
+    "other": "Adicionar"
+  },
+  "config.plugins_available": {
+    "other": "Disponíveis (não configurados):"
+  },
+  "config.plugins_none_available": {
+    "other": "Nenhum plugin adicional disponível."
+  },
+  "config.plugins_settings_title": {
+    "other": "Configurações de {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Salvar"
+  },
+  "config.plugins_cancel": {
+    "other": "Cancelar"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "As alterações de plugins terão efeito na próxima abertura de URL."
+  },
+  "config.tab_browsers": {
+    "other": "Navegadores"
+  },
+  "config.browsers_empty": {
+    "other": "Nenhum navegador configurado ainda.\n\nClique no botão abaixo para buscar navegadores instalados. Isso é necessário para que o Linkquisition funcione como seletor de navegador."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Mostrar no seletor"
+  },
+  "config.browsers_add": {
+    "other": "Adicionar navegador..."
+  },
+  "config.browsers_add_title": {
+    "other": "Adicionar navegador"
+  },
+  "config.browsers_edit": {
+    "other": "Editar..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Editar navegador"
+  },
+  "config.browsers_delete": {
+    "other": "Excluir"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Tem certeza de que deseja excluir \"{{.Name}}\"?"
+  },
+  "config.browsers_name": {
+    "other": "Nome"
+  },
+  "config.browsers_command": {
+    "other": "Comando"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "ex. Firefox Privado"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "ex. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Ícone"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/caminho/para/icone.png (opcional)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(automático)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(manual)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} regra(s)"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Nenhum navegador configurado. Vá para a aba Navegadores para buscar navegadores instalados."
+  },
+  "config.rules_no_browsers": {
+    "other": "Nenhum navegador configurado. Adicione navegadores primeiro na aba Navegadores."
+  },
+  "config.rules_empty": {
+    "other": "Nenhuma regra de correspondência configurada ainda.\n\nAs regras determinam qual navegador abre uma URL automaticamente. Use o botão \"+ Adicionar regra\" ao lado do nome de um navegador para criar uma."
+  },
+  "config.rules_add": {
+    "other": "+ Adicionar regra"
+  },
+  "config.rules_add_title": {
+    "other": "Adicionar regra para {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Tipo"
+  },
+  "config.rules_value": {
+    "other": "Valor"
+  },
+  "config.rules_value_placeholder": {
+    "other": "ex. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Nenhuma regra configurada"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Expressão regular inválida"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Filtrar regras..."
+  },
+  "config.rules_no_match": {
+    "other": "Nenhuma regra corresponde ao filtro."
+  },
+  "config.macos_picker_note": {
+    "other": "Nota: A janela do seletor de navegador não está disponível enquanto esta tela de configurações está aberta. Links clicados enquanto as configurações estão abertas serão abertos automaticamente no primeiro navegador correspondente."
+  },
+  "config.picker_layout_label": {
+    "other": "Layout do seletor:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertical (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (botões)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Máximo de itens por linha:"
+  }
+}

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Definições do Linkquisition"
+  },
+  "config.tab_general": {
+    "other": "Geral"
+  },
+  "config.tab_about": {
+    "other": "Acerca"
+  },
+  "config.tab_rules": {
+    "other": "Regras"
+  },
+  "config.rules_description": {
+    "other": "As regras de correspondência determinam qual navegador abre automaticamente um URL.\n\nAs regras podem corresponder por site (ex. www.example.com), domínio (ex. example.com) ou expressão regular.\n\nDe momento, as regras são geridas editando diretamente o ficheiro de configuração. Um editor visual será adicionado numa versão futura."
+  },
+  "config.rules_edit_button": {
+    "other": "Abrir ficheiro de configuração no editor"
+  },
+  "config.make_default_label": {
+    "other": "Para que o Linkquisition funcione como seletor de navegador,\ntem de ser definido como navegador predefinido:"
+  },
+  "config.make_default_done": {
+    "other": "Tudo pronto!"
+  },
+  "config.make_default_button": {
+    "other": "Definir como predefinido"
+  },
+  "config.make_default_error": {
+    "other": "Erro ao definir como predefinido!"
+  },
+  "config.make_default_checking": {
+    "other": "a verificar"
+  },
+  "config.scan_browsers": {
+    "other": "Procurar navegadores"
+  },
+  "config.rescan_browsers": {
+    "other": "Procurar navegadores novamente"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "A procurar\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Concluído"
+  },
+  "config.scan_now": {
+    "other": "Procurar agora"
+  },
+  "config.scan_error": {
+    "other": "Erro ao procurar navegadores!"
+  },
+  "config.scan_description": {
+    "other": "Os navegadores devem ser detetados e armazenados num ficheiro de configuração\npara arranque mais rápido e configuração personalizada.\n\nA procura pode ser executada com segurança a qualquer momento: apenas\nnavegadores recém-detetados são adicionados e os que já não estão\npresentes são removidos.\n\nRegras existentes, ordenação ou personalizações não são afetadas."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Abrir:"
+  },
+  "picker.copy_button": {
+    "other": "Copiar"
+  },
+  "picker.remember_choice": {
+    "other": "Lembrar esta escolha para {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Prima 'ENTER' para o primeiro, 'ESC' para sair, '{{.CopyShortcut}}' para copiar o URL"
+  },
+  "config.language_label": {
+    "other": "Idioma:"
+  },
+  "config.language_auto": {
+    "other": "Automático (predefinição do sistema)"
+  },
+  "config.language_restart_note": {
+    "other": "A alteração de idioma terá efeito no próximo arranque."
+  },
+  "config.scan_in_progress": {
+    "other": "A procurar..."
+  },
+  "config.scan_success": {
+    "other": "✓ Navegadores detetados com sucesso"
+  },
+  "config.scan_failed": {
+    "other": "✗ Falha na procura"
+  },
+  "config.log_level_label": {
+    "other": "Nível de registo:"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Ocultar guia de atalhos de teclado no seletor"
+  },
+  "about.description": {
+    "other": "Um seletor de navegador rápido e configurável para Linux e macOS."
+  },
+  "about.author_label": {
+    "other": "Autor:"
+  },
+  "about.license_label": {
+    "other": "Licença:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
+  },
+  "plugin.blocked_title": {
+    "other": "Bloqueado pelo plugin"
+  },
+  "plugin.warning_title": {
+    "other": "Aviso"
+  },
+  "plugin.warn_cancel": {
+    "other": "Cancelar"
+  },
+  "plugin.warn_proceed": {
+    "other": "Abrir mesmo assim"
+  },
+  "config.tab_plugins": {
+    "other": "Plugins"
+  },
+  "config.plugins_enabled": {
+    "other": "Ativado"
+  },
+  "config.plugins_configure": {
+    "other": "Configurar..."
+  },
+  "config.plugins_add": {
+    "other": "Adicionar"
+  },
+  "config.plugins_available": {
+    "other": "Disponíveis (não configurados):"
+  },
+  "config.plugins_none_available": {
+    "other": "Nenhum plugin adicional disponível."
+  },
+  "config.plugins_settings_title": {
+    "other": "Definições de {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Guardar"
+  },
+  "config.plugins_cancel": {
+    "other": "Cancelar"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "As alterações de plugins terão efeito na próxima abertura de URL."
+  },
+  "config.tab_browsers": {
+    "other": "Navegadores"
+  },
+  "config.browsers_empty": {
+    "other": "Ainda não há navegadores configurados.\n\nClique no botão abaixo para procurar navegadores instalados. Isto é necessário para que o Linkquisition funcione como seletor de navegador."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Mostrar no seletor"
+  },
+  "config.browsers_add": {
+    "other": "Adicionar navegador..."
+  },
+  "config.browsers_add_title": {
+    "other": "Adicionar navegador"
+  },
+  "config.browsers_edit": {
+    "other": "Editar..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Editar navegador"
+  },
+  "config.browsers_delete": {
+    "other": "Eliminar"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Tem a certeza de que pretende eliminar \"{{.Name}}\"?"
+  },
+  "config.browsers_name": {
+    "other": "Nome"
+  },
+  "config.browsers_command": {
+    "other": "Comando"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "ex. Firefox Privado"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "ex. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Ícone"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/caminho/para/icone.png (opcional)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(automático)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(manual)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} regra(s)"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Nenhum navegador configurado. Vá ao separador Navegadores para procurar navegadores instalados."
+  },
+  "config.rules_no_browsers": {
+    "other": "Nenhum navegador configurado. Adicione navegadores primeiro no separador Navegadores."
+  },
+  "config.rules_empty": {
+    "other": "Ainda não há regras de correspondência configuradas.\n\nAs regras determinam qual navegador abre um URL automaticamente. Use o botão \"+ Adicionar regra\" junto ao nome de um navegador para criar uma."
+  },
+  "config.rules_add": {
+    "other": "+ Adicionar regra"
+  },
+  "config.rules_add_title": {
+    "other": "Adicionar regra para {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Tipo"
+  },
+  "config.rules_value": {
+    "other": "Valor"
+  },
+  "config.rules_value_placeholder": {
+    "other": "ex. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Nenhuma regra configurada"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Expressão regular inválida"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Filtrar regras..."
+  },
+  "config.rules_no_match": {
+    "other": "Nenhuma regra corresponde ao filtro."
+  },
+  "config.macos_picker_note": {
+    "other": "Nota: A janela do seletor de navegador não está disponível enquanto este ecrã de definições está aberto. Ligações clicadas enquanto as definições estão abertas serão abertas automaticamente no primeiro navegador correspondente."
+  },
+  "config.picker_layout_label": {
+    "other": "Disposição do seletor:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Vertical (lista)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Horizontal (botões)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Máximo de itens por linha:"
+  }
+}

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -1,0 +1,260 @@
+{
+  "config.window_title": {
+    "other": "Налаштування Linkquisition"
+  },
+  "config.tab_general": {
+    "other": "Загальне"
+  },
+  "config.tab_about": {
+    "other": "Про програму"
+  },
+  "config.tab_rules": {
+    "other": "Правила"
+  },
+  "config.rules_description": {
+    "other": "Правила відповідності визначають, який браузер автоматично відкриває дану URL-адресу.\n\nПравила можуть відповідати за сайтом (напр. www.example.com), доменом (напр. example.com) або регулярним виразом.\n\nНаразі правила керуються через безпосереднє редагування конфігураційного файлу. Візуальний редактор буде додано в майбутній версії."
+  },
+  "config.rules_edit_button": {
+    "other": "Відкрити файл конфігурації в редакторі"
+  },
+  "config.make_default_label": {
+    "other": "Щоб Linkquisition працював як засіб вибору браузера,\nйого потрібно встановити як браузер за замовчуванням:"
+  },
+  "config.make_default_done": {
+    "other": "Все готово!"
+  },
+  "config.make_default_button": {
+    "other": "Встановити за замовчуванням"
+  },
+  "config.make_default_error": {
+    "other": "Помилка встановлення за замовчуванням!"
+  },
+  "config.make_default_checking": {
+    "other": "перевірка"
+  },
+  "config.scan_browsers": {
+    "other": "Пошук браузерів"
+  },
+  "config.rescan_browsers": {
+    "other": "Повторний пошук браузерів"
+  },
+  "config.scan_browsers_scanning": {
+    "other": "Пошук\u2026"
+  },
+  "config.scan_browsers_done": {
+    "other": "\u2713 Готово"
+  },
+  "config.scan_now": {
+    "other": "Шукати зараз"
+  },
+  "config.scan_error": {
+    "other": "Помилка пошуку браузерів!"
+  },
+  "config.scan_description": {
+    "other": "Браузери слід просканувати та зберегти у конфігураційному файлі\nдля швидшого запуску та зручнішої конфігурації.\n\nСканування можна безпечно виконувати будь-коли: лише нововиявлені\nбраузери додаються, а ті, що більше не присутні в системі,\nвидаляються.\n\nІснуючі правила, порядок або налаштування не будуть порушені."
+  },
+  "picker.window_title": {
+    "other": "Linkquisition"
+  },
+  "picker.open_label": {
+    "other": "Відкрити:"
+  },
+  "picker.copy_button": {
+    "other": "Копіювати"
+  },
+  "picker.remember_choice": {
+    "other": "Запам'ятати цей вибір для {{.Site}}"
+  },
+  "picker.keyboard_guide": {
+    "other": "Натисніть 'ENTER' для першого, 'ESC' для виходу, '{{.CopyShortcut}}' для копіювання URL"
+  },
+  "config.language_label": {
+    "other": "Мова:"
+  },
+  "config.language_auto": {
+    "other": "Автоматично (системна мова)"
+  },
+  "config.language_restart_note": {
+    "other": "Зміна мови набуде чинності при наступному запуску."
+  },
+  "config.scan_in_progress": {
+    "other": "Пошук..."
+  },
+  "config.scan_success": {
+    "other": "✓ Браузери успішно знайдено"
+  },
+  "config.scan_failed": {
+    "other": "✗ Пошук не вдався"
+  },
+  "config.log_level_label": {
+    "other": "Рівень журналювання:"
+  },
+  "config.hide_keyboard_guide": {
+    "other": "Приховати підказку клавіатурних скорочень у вікні вибору"
+  },
+  "about.description": {
+    "other": "Швидкий та гнучкий засіб вибору браузера для Linux та macOS."
+  },
+  "about.author_label": {
+    "other": "Автор:"
+  },
+  "about.license_label": {
+    "other": "Ліцензія:"
+  },
+  "about.github_label": {
+    "other": "GitHub:"
+  },
+  "plugin.blocked_title": {
+    "other": "Заблоковано плагіном"
+  },
+  "plugin.warning_title": {
+    "other": "Попередження"
+  },
+  "plugin.warn_cancel": {
+    "other": "Скасувати"
+  },
+  "plugin.warn_proceed": {
+    "other": "Відкрити все одно"
+  },
+  "config.tab_plugins": {
+    "other": "Плагіни"
+  },
+  "config.plugins_enabled": {
+    "other": "Увімкнено"
+  },
+  "config.plugins_configure": {
+    "other": "Налаштувати..."
+  },
+  "config.plugins_add": {
+    "other": "Додати"
+  },
+  "config.plugins_available": {
+    "other": "Доступні (не налаштовані):"
+  },
+  "config.plugins_none_available": {
+    "other": "Додаткових плагінів немає."
+  },
+  "config.plugins_settings_title": {
+    "other": "Налаштування {{.Name}}"
+  },
+  "config.plugins_save": {
+    "other": "Зберегти"
+  },
+  "config.plugins_cancel": {
+    "other": "Скасувати"
+  },
+  "config.plugins_move_up": {
+    "other": "▲"
+  },
+  "config.plugins_move_down": {
+    "other": "▼"
+  },
+  "config.plugins_restart_note": {
+    "other": "Зміни плагінів набудуть чинності при наступному відкритті URL."
+  },
+  "config.tab_browsers": {
+    "other": "Браузери"
+  },
+  "config.browsers_empty": {
+    "other": "Браузери ще не налаштовані.\n\nНатисніть кнопку нижче для пошуку встановлених браузерів. Це необхідно для роботи Linkquisition як засобу вибору браузера."
+  },
+  "config.browsers_show_in_picker": {
+    "other": "Показувати у вікні вибору"
+  },
+  "config.browsers_add": {
+    "other": "Додати браузер..."
+  },
+  "config.browsers_add_title": {
+    "other": "Додати браузер"
+  },
+  "config.browsers_edit": {
+    "other": "Редагувати..."
+  },
+  "config.browsers_edit_title": {
+    "other": "Редагувати браузер"
+  },
+  "config.browsers_delete": {
+    "other": "Видалити"
+  },
+  "config.browsers_delete_confirm": {
+    "other": "Ви впевнені, що хочете видалити \"{{.Name}}\"?"
+  },
+  "config.browsers_name": {
+    "other": "Назва"
+  },
+  "config.browsers_command": {
+    "other": "Команда"
+  },
+  "config.browsers_name_placeholder": {
+    "other": "напр. Firefox Приватний"
+  },
+  "config.browsers_command_placeholder": {
+    "other": "напр. firefox --private-window %u"
+  },
+  "config.browsers_icon_path": {
+    "other": "Іконка"
+  },
+  "config.browsers_icon_path_placeholder": {
+    "other": "/шлях/до/іконки.png (необов'язково)"
+  },
+  "config.browsers_source_auto": {
+    "other": "(автоматично)"
+  },
+  "config.browsers_source_manual": {
+    "other": "(вручну)"
+  },
+  "config.browsers_rules_count": {
+    "other": "{{.Count}} правил(о)"
+  },
+  "config.no_browsers_warning": {
+    "other": "⚠ Браузери не налаштовані. Перейдіть на вкладку Браузери для пошуку встановлених браузерів."
+  },
+  "config.rules_no_browsers": {
+    "other": "Браузери не налаштовані. Спочатку додайте браузери на вкладці Браузери."
+  },
+  "config.rules_empty": {
+    "other": "Правила відповідності ще не налаштовані.\n\nПравила визначають, який браузер автоматично відкриває URL. Використовуйте кнопку \"+ Додати правило\" біля назви браузера для створення правила."
+  },
+  "config.rules_add": {
+    "other": "+ Додати правило"
+  },
+  "config.rules_add_title": {
+    "other": "Додати правило для {{.Name}}"
+  },
+  "config.rules_type": {
+    "other": "Тип"
+  },
+  "config.rules_value": {
+    "other": "Значення"
+  },
+  "config.rules_value_placeholder": {
+    "other": "напр. www.example.com"
+  },
+  "config.rules_none_for_browser": {
+    "other": "Правила не налаштовані"
+  },
+  "config.rules_regex_invalid": {
+    "other": "Недійсний регулярний вираз"
+  },
+  "config.rules_filter_placeholder": {
+    "other": "Фільтрувати правила..."
+  },
+  "config.rules_no_match": {
+    "other": "Жодне правило не відповідає фільтру."
+  },
+  "config.macos_picker_note": {
+    "other": "Примітка: Вікно вибору браузера недоступне, поки відкрито екран налаштувань. Посилання, натиснуті під час відкритих налаштувань, будуть автоматично відкриті у першому відповідному браузері."
+  },
+  "config.picker_layout_label": {
+    "other": "Розташування вікна вибору:"
+  },
+  "config.picker_layout_vertical": {
+    "other": "Вертикальне (список)"
+  },
+  "config.picker_layout_horizontal": {
+    "other": "Горизонтальне (кнопки)"
+  },
+  "config.picker_max_per_row_label": {
+    "other": "Максимум елементів у рядку:"
+  }
+}


### PR DESCRIPTION
Add UI translations for German, French, Hungarian, Ukrainian, Brazilian Portuguese, and European Portuguese.

## Changes

- New translation files: `de.json`, `fr.json`, `hu.json`, `uk.json`, `pt-BR.json`, `pt.json`
- Added locale constants and display names in `internal/i18n/i18n.go`
- Language dropdown in settings GUI now sorted alphabetically by display name
- Updated tests to cover all 10 locales
- Updated README and AGENTS.md

## New supported languages

| Code | Language |
|------|----------|
| de | Deutsch (German) |
| fr | Français (French) |
| hu | Magyar (Hungarian) |
| uk | Українська (Ukrainian) |
| pt-BR | Português (Brasil) |
| pt | Português (European Portuguese) |

## Notes

Brazilian Portuguese and European Portuguese are kept as separate locales due to significant differences in vocabulary, grammar, and UI conventions (e.g. "configurações" vs "definições", "excluir" vs "eliminar", "tela" vs "ecrã").