### PR TITLE
fix(ci): update coverage badge on every push to main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  coverage:
+    name: Update Coverage Badge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
+
+      - uses: arduino/setup-task@v3
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Tests
+        run: task test
+
+      - name: Update Coverage Badge
+        uses: action-badges/cobertura-coverage-xml-badges@0.4.1
+        with:
+          file-name: coverage.svg
+          badge-branch: gh-pages
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file-name: test/coverage.latest/coverage.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,6 @@ jobs:
       - name: Run Tests
         run: task test
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: test/coverage.latest/coverage.xml
-
   build:
     name: Build (${{ matrix.target }})
     needs: [ test ]
@@ -242,27 +236,3 @@ jobs:
           git add Casks/linkquisition.rb
           git commit -m "Update linkquisition to v${VERSION}" || echo "No changes to commit"
           git push
-
-  coverage:
-    name: Coverage Badge
-    needs: [ test ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Download coverage artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: coverage-report
-          path: test/coverage.latest/
-
-      - name: Make Coverage Badge
-        uses: action-badges/cobertura-coverage-xml-badges@0.4.1
-        with:
-          file-name: coverage.svg
-          badge-branch: gh-pages
-          coverage-file-name: test/coverage.latest/coverage.xml
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Coverage badge was stuck at 31% because it only updated during releases (tag pushes). Now it refreshes on every push to main.

- Add standalone `.github/workflows/coverage.yml` triggered on push to `main`
- Remove the coverage job and artifact upload from `publish.yml`