### PR TITLE
ci: add security scanning workflows (govulncheck, CodeQL, Scorecard)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
+      - name: Build
+        run: go build ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,9 @@ jobs:
           languages: go
 
       - name: Build
-        run: go build ./...
+        run: |
+          # Build main binary and internal packages (exclude plugins — they require -buildmode=plugin)
+          go build $(go list ./... | grep -v '/plugins/')
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: Scorecard
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          publish_results: true
+
+      - name: Upload results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,34 @@
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Install build dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gcc libgl1-mesa-dev xorg-dev
+          version: 1.0
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.5'
 
       - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strobotti/linkquisition
 
-go 1.26.0
+go 1.26.5
 
 require (
 	fyne.io/fyne/v2 v2.7.4


### PR DESCRIPTION
Adds three GitHub Actions workflows for automated security scanning:

- **govulncheck** — checks whether the codebase calls functions in dependencies with known vulnerabilities (Go's official vuln database)
- **CodeQL** — GitHub's semantic code analysis for detecting injection, path traversal, hardcoded credentials, and other security anti-patterns
- **OpenSSF Scorecard** — evaluates the repository's supply-chain security posture (pinned dependencies, branch protection, CI practices, etc.)

All workflows run on pushes to `main` and weekly. Govulncheck and CodeQL also run on pull requests to catch issues before merge. Results appear in the Security → Code scanning tab.