### PR TITLE
feat: favicon display in browser picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,14 @@ The app has two UI modes, both in `cmd/`:
 - The `locale` config key overrides system detection
 - Plugins do NOT currently have access to the i18n system
 
+### When adding or changing i18n keys
+
+- [ ] Add the new key to `en.json` first (this is the fallback/source of truth)
+- [ ] Add translated values to ALL other locale files (`de`, `es`, `fi`, `fr`, `hu`, `pt`, `pt-BR`, `sv`, `uk`)
+- [ ] Keep the key ordering consistent across all files (append new keys at the end)
+- [ ] If a translation is uncertain, use the English text as a placeholder — it's better
+  than a missing key (which causes the raw key string to appear in the UI)
+
 ## Linux packaging
 
 The project produces `.deb`, `.rpm`, and AppImage packages.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Motivation behind this project is:
     - `Enter` to open the URL in the default browser
     - `Ctrl+C` to just copy the URL to clipboard and close the window
     - Number keys (1-9) to select a browser
+- Optional favicon display next to the URL in the picker (lazy-loaded, no startup delay)
 
 ## Installation
 

--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -15,7 +15,7 @@ tasks:
         sh: echo ${VERSION:-v0.0.0}
       OPTIONS: '{{default "" .DEVOPTIONS}}'
     cmds:
-      - CGO_ENABLED=1 GOOS={{.TARGET}} {{if .ARCH}}GOARCH={{.ARCH}}{{end}} go build -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
+      - CGO_ENABLED=1 GOOS={{.TARGET}} {{if .ARCH}}GOARCH={{.ARCH}}{{end}} go build -trimpath -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
       - echo "bin/{{.OUTPUT}}{{exeExt}} created successfully"
     sources:
       - ./**/*.go
@@ -75,7 +75,7 @@ tasks:
     cmds:
       - mkdir -p {{.OUTPUT_DIR}}
       - for: { var: PLUGINS }
-        cmd: go build -tags release -buildmode=plugin -o {{.OUTPUT_DIR}}/{{.ITEM}}.so ./plugins/{{.ITEM}}/
+        cmd: go build -trimpath -tags release -buildmode=plugin -o {{.OUTPUT_DIR}}/{{.ITEM}}.so ./plugins/{{.ITEM}}/
 
   clean:
     cmds:

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -64,7 +64,7 @@ tasks:
       - rm -rf dist/Linkquisition.app
       - mkdir -p dist/Linkquisition.app/Contents/MacOS
       - mkdir -p dist/Linkquisition.app/Contents/Resources
-      - go build -tags release -ldflags '-s -w -X main.version={{.VERSION}}' -o dist/Linkquisition.app/Contents/MacOS/linkquisition ./cmd/
+      - go build -trimpath -tags release -ldflags '-s -w -X main.version={{.VERSION}}' -o dist/Linkquisition.app/Contents/MacOS/linkquisition ./cmd/
       - task build:plugins-darwin
       - sed 's/${VERSION}/{{.VERSION}}/g' package/darwin/Info.plist > dist/Linkquisition.app/Contents/Info.plist
       - sips -s format icns Icon.png --out dist/Linkquisition.app/Contents/Resources/Icon.icns 2>/dev/null || cp Icon.png dist/Linkquisition.app/Contents/Resources/Icon.icns

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -221,7 +221,6 @@ func (picker *BrowserPicker) buildURLDisplay(urlToOpen string, w fyne.Window) []
 
 		urlRow = container.NewHBox(
 			copyButton,
-			widget.NewLabel(i18n.T("picker.open_label")),
 			faviconImg,
 			urlLabel,
 		)
@@ -231,7 +230,6 @@ func (picker *BrowserPicker) buildURLDisplay(urlToOpen string, w fyne.Window) []
 	} else {
 		urlRow = container.NewHBox(
 			copyButton,
-			widget.NewLabel(i18n.T("picker.open_label")),
 			urlLabel,
 		)
 	}

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image/color"
 	"log/slog"
+	"path/filepath"
 	"runtime"
 	"time"
 	"unicode/utf8"
@@ -18,6 +19,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/favicon"
 	"github.com/strobotti/linkquisition/internal/i18n"
 	"github.com/strobotti/linkquisition/resources"
 )
@@ -28,6 +30,7 @@ const (
 	horizontalButtonHeight   = 148
 	verticalWindowWidth      = 600
 	verticalWindowMinHeight  = 50
+	faviconDisplaySize       = 16
 )
 
 type BrowserPicker struct {
@@ -208,13 +211,56 @@ func (picker *BrowserPicker) buildURLDisplay(urlToOpen string, w fyne.Window) []
 	})
 	copyButton.Importance = widget.LowImportance
 
-	return []fyne.CanvasObject{
-		container.NewHBox(
+	settings := picker.settingsService.GetSettings()
+
+	var urlRow *fyne.Container
+	if settings.Ui.ShowFavicon {
+		faviconImg := canvas.NewImageFromResource(theme.ComputerIcon())
+		faviconImg.FillMode = canvas.ImageFillContain
+		faviconImg.SetMinSize(fyne.NewSize(faviconDisplaySize, faviconDisplaySize))
+
+		urlRow = container.NewHBox(
+			copyButton,
+			widget.NewLabel(i18n.T("picker.open_label")),
+			faviconImg,
+			urlLabel,
+		)
+
+		// Fetch favicon lazily in a goroutine
+		go picker.fetchAndUpdateFavicon(urlToOpen, faviconImg, settings)
+	} else {
+		urlRow = container.NewHBox(
 			copyButton,
 			widget.NewLabel(i18n.T("picker.open_label")),
 			urlLabel,
-		),
+		)
 	}
+
+	return []fyne.CanvasObject{urlRow}
+}
+
+// fetchAndUpdateFavicon fetches the favicon in the background and updates the image widget.
+// This runs in a goroutine to avoid blocking the UI startup.
+func (picker *BrowserPicker) fetchAndUpdateFavicon(
+	urlToOpen string, img *canvas.Image, settings *linkquisition.Settings,
+) {
+	strategy := settings.Ui.GetFaviconStrategy()
+	cacheDir := filepath.Join(picker.settingsService.GetConfigFolderPath(), "favicons")
+
+	fetcher := favicon.NewFetcher(strategy, cacheDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:mnd
+	defer cancel()
+
+	data, err := fetcher.Fetch(ctx, urlToOpen)
+	if err != nil {
+		picker.logger.Debug("Failed to fetch favicon", "url", urlToOpen, "error", err)
+		return
+	}
+
+	res := fyne.NewStaticResource("favicon.png", data)
+	img.Resource = res
+	img.Refresh()
 }
 
 func (picker *BrowserPicker) buildRememberCheck(urlToOpen string, remember binding.Bool) []fyne.CanvasObject {

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"fyne.io/fyne/v2"
@@ -414,14 +416,30 @@ func (c *Configurator) buildFaviconSection(settings *linkquisition.Settings) fyn
 		strategySelect,
 	)
 
-	// Show strategy options only when favicon is enabled
+	// Clear cache button
+	clearCacheButton := widget.NewButton(i18n.T("config.favicon_clear_cache"), func() {})
+	clearCacheButton.Importance = widget.LowImportance
+	clearCacheButton.OnTapped = func() {
+		cacheDir := filepath.Join(c.settingsService.GetConfigFolderPath(), "favicons")
+		if err := os.RemoveAll(cacheDir); err != nil {
+			c.logger.Error("Error clearing favicon cache", "error", err)
+			clearCacheButton.SetText(i18n.T("config.favicon_clear_cache_error"))
+		} else {
+			clearCacheButton.SetText(i18n.T("config.favicon_clear_cache_done"))
+			clearCacheButton.Disable()
+		}
+	}
+
+	// Show strategy options and clear cache only when favicon is enabled
 	updateStrategyVisible := func(enabled bool) {
 		if enabled {
 			strategyRow.Show()
 			strategyDesc.Show()
+			clearCacheButton.Show()
 		} else {
 			strategyRow.Hide()
 			strategyDesc.Hide()
+			clearCacheButton.Hide()
 		}
 	}
 	updateStrategyVisible(settings.Ui.ShowFavicon)
@@ -440,6 +458,7 @@ func (c *Configurator) buildFaviconSection(settings *linkquisition.Settings) fyn
 		faviconCheck,
 		strategyRow,
 		strategyDesc,
+		clearCacheButton,
 	)
 }
 

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -224,6 +224,8 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 
 	layoutRow, maxItemsRow := c.buildPickerLayoutSelector(settings)
 
+	faviconSection := c.buildFaviconSection(settings)
+
 	return container.NewVBox(
 		themeRow,
 		themeNote,
@@ -232,6 +234,8 @@ func (c *Configurator) buildUiSection() fyne.CanvasObject {
 		widget.NewSeparator(),
 		layoutRow,
 		maxItemsRow,
+		widget.NewSeparator(),
+		faviconSection,
 	)
 }
 
@@ -351,6 +355,92 @@ func (c *Configurator) buildPickerLayoutSelector(settings *linkquisition.Setting
 	)
 
 	return layoutRow, maxItemsRow
+}
+
+func (c *Configurator) buildFaviconSection(settings *linkquisition.Settings) fyne.CanvasObject {
+	strategyOptions := []string{
+		i18n.T("config.favicon_strategy_direct"),
+		i18n.T("config.favicon_strategy_parsed"),
+		i18n.T("config.favicon_strategy_google"),
+	}
+
+	currentStrategy := settings.Ui.GetFaviconStrategy()
+	selectedStrategy := strategyOptions[0]
+	switch currentStrategy {
+	case linkquisition.FaviconStrategyParsed:
+		selectedStrategy = strategyOptions[1]
+	case linkquisition.FaviconStrategyGoogle:
+		selectedStrategy = strategyOptions[2]
+	}
+
+	strategyDesc := widget.NewLabel(i18n.T("config.favicon_strategy_direct_desc"))
+	strategyDesc.TextStyle = fyne.TextStyle{Italic: true}
+	strategyDesc.Wrapping = fyne.TextWrapWord
+
+	updateDescription := func(strategy string) {
+		switch strategy {
+		case linkquisition.FaviconStrategyParsed:
+			strategyDesc.SetText(i18n.T("config.favicon_strategy_parsed_desc"))
+		case linkquisition.FaviconStrategyGoogle:
+			strategyDesc.SetText(i18n.T("config.favicon_strategy_google_desc"))
+		default:
+			strategyDesc.SetText(i18n.T("config.favicon_strategy_direct_desc"))
+		}
+	}
+	updateDescription(currentStrategy)
+
+	strategySelect := widget.NewSelect(strategyOptions, func(selected string) {
+		s := c.settingsService.GetSettings()
+		switch selected {
+		case strategyOptions[1]:
+			s.Ui.FaviconStrategy = linkquisition.FaviconStrategyParsed
+			updateDescription(linkquisition.FaviconStrategyParsed)
+		case strategyOptions[2]:
+			s.Ui.FaviconStrategy = linkquisition.FaviconStrategyGoogle
+			updateDescription(linkquisition.FaviconStrategyGoogle)
+		default:
+			s.Ui.FaviconStrategy = linkquisition.FaviconStrategyDirect
+			updateDescription(linkquisition.FaviconStrategyDirect)
+		}
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving favicon strategy setting", "error", err)
+		}
+	})
+	strategySelect.Selected = selectedStrategy
+
+	strategyRow := container.NewBorder(
+		nil, nil,
+		widget.NewLabel(i18n.T("config.favicon_strategy_label")), nil,
+		strategySelect,
+	)
+
+	// Show strategy options only when favicon is enabled
+	updateStrategyVisible := func(enabled bool) {
+		if enabled {
+			strategyRow.Show()
+			strategyDesc.Show()
+		} else {
+			strategyRow.Hide()
+			strategyDesc.Hide()
+		}
+	}
+	updateStrategyVisible(settings.Ui.ShowFavicon)
+
+	faviconCheck := widget.NewCheck(i18n.T("config.favicon_label"), func(checked bool) {
+		s := c.settingsService.GetSettings()
+		s.Ui.ShowFavicon = checked
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Error saving favicon setting", "error", err)
+		}
+		updateStrategyVisible(checked)
+	})
+	faviconCheck.Checked = settings.Ui.ShowFavicon
+
+	return container.NewVBox(
+		faviconCheck,
+		strategyRow,
+		strategyDesc,
+	)
 }
 
 func (c *Configurator) getAboutTab() fyne.CanvasObject {

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -101,6 +101,22 @@ and *rule* subcommands).
 	UI color theme. One of: _system_ (default, follows the operating system
 	preference), _dark_, or _light_. Changes take effect on next launch.
 
+*showFavicon* (boolean, optional)
+	If _true_, the browser picker displays the website's favicon next to the
+	URL. The icon is fetched lazily (does not block startup) and a placeholder
+	is shown until loading completes. Default: _false_.
+
+*faviconStrategy* (string, optional)
+	How to retrieve the favicon. Only relevant when _showFavicon_ is _true_.
+	One of:
+	- *direct* (default) — fetches _/favicon.ico_ from the host. Fast and
+	  privacy-friendly.
+	- *parsed* — downloads the site's HTML root page and parses the
+	  _<link rel="icon">_ tag. More accurate (finds custom icon paths) but
+	  requires two HTTP requests and may be slower.
+	- *google* — uses Google's favicon service. Reliable and fast, but the
+	  URL is sent to Google (privacy concern).
+
 # EXAMPLE
 
 ```
@@ -130,7 +146,9 @@ and *rule* subcommands).
   "ui": {
     "theme": "system",
     "pickerLayout": "horizontal",
-    "maxItemsPerRow": 5
+    "maxItemsPerRow": 5,
+    "showFavicon": true,
+    "faviconStrategy": "direct"
   }
 }
 ```

--- a/internal/favicon/favicon.go
+++ b/internal/favicon/favicon.go
@@ -116,7 +116,7 @@ func (f *Fetcher) fetchParsed(ctx context.Context, parsed *url.URL) ([]byte, err
 	// First try to parse the HTML for a link icon
 	pageURL := fmt.Sprintf("%s://%s/", parsed.Scheme, parsed.Host)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -139,7 +139,8 @@ func (f *Fetcher) fetchParsed(ctx context.Context, parsed *url.URL) ([]byte, err
 	}
 
 	matches := linkIconRegex.FindSubmatch(body)
-	if len(matches) < 2 {
+	const minRegexGroups = 2
+	if len(matches) < minRegexGroups {
 		// No icon link found, fall back to /favicon.ico
 		return f.fetchDirect(ctx, parsed)
 	}
@@ -168,7 +169,7 @@ func (f *Fetcher) fetchGoogle(ctx context.Context, rawURL string) ([]byte, error
 
 // download performs the actual HTTP GET and returns the body bytes.
 func (f *Fetcher) download(ctx context.Context, fetchURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/favicon/favicon.go
+++ b/internal/favicon/favicon.go
@@ -1,0 +1,257 @@
+// Package favicon provides lazy favicon retrieval for URLs.
+// It supports three strategies: direct (/favicon.ico), parsed (HTML link tag),
+// and google (Google's favicon service).
+package favicon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	// StrategyDirect fetches /favicon.ico directly from the host.
+	StrategyDirect = "direct"
+
+	// StrategyParsed fetches the HTML page and parses the <link rel="icon"> tag.
+	StrategyParsed = "parsed"
+
+	// StrategyGoogle uses Google's favicon service (privacy concern: URL is sent to Google).
+	StrategyGoogle = "google"
+
+	fetchTimeout    = 5 * time.Second
+	maxFaviconBytes = 256 * 1024 // 256 KB max favicon size
+	cacheDirPerms   = 0755
+	cacheFilePerms  = 0644
+	cacheTTL        = 7 * 24 * time.Hour // 1 week
+
+	googleFaviconURL = "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=%s&size=32"
+)
+
+var linkIconRegex = regexp.MustCompile(
+	`<link[^>]+rel=["'](?:icon|shortcut icon|apple-touch-icon)["'][^>]*href=["']([^"']+)["']`,
+)
+
+// Fetcher retrieves favicons using a configurable strategy.
+type Fetcher struct {
+	strategy string
+	cacheDir string
+	client   *http.Client
+}
+
+// NewFetcher creates a new favicon Fetcher with the given strategy and cache directory.
+// If cacheDir is empty, caching is disabled.
+func NewFetcher(strategy, cacheDir string) *Fetcher {
+	return &Fetcher{
+		strategy: strategy,
+		cacheDir: cacheDir,
+		client: &http.Client{
+			Timeout: fetchTimeout,
+		},
+	}
+}
+
+// Fetch retrieves the favicon for the given URL.
+// It checks the cache first (if enabled), then fetches using the configured strategy.
+// Returns the image bytes or an error. The caller should handle errors gracefully
+// (e.g. show a placeholder).
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string) ([]byte, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("no host in URL")
+	}
+
+	// Check cache first
+	if f.cacheDir != "" {
+		if data, cacheErr := f.readCache(host); cacheErr == nil {
+			return data, nil
+		}
+	}
+
+	var data []byte
+
+	switch f.strategy {
+	case StrategyParsed:
+		data, err = f.fetchParsed(ctx, parsed)
+	case StrategyGoogle:
+		data, err = f.fetchGoogle(ctx, rawURL)
+	default:
+		data, err = f.fetchDirect(ctx, parsed)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Write to cache (best-effort)
+	if f.cacheDir != "" {
+		_ = f.writeCache(host, data)
+	}
+
+	return data, nil
+}
+
+// fetchDirect downloads {scheme}://{host}/favicon.ico
+func (f *Fetcher) fetchDirect(ctx context.Context, parsed *url.URL) ([]byte, error) {
+	faviconURL := fmt.Sprintf("%s://%s/favicon.ico", parsed.Scheme, parsed.Host)
+	return f.download(ctx, faviconURL)
+}
+
+// fetchParsed downloads the HTML page and parses <link rel="icon"> to find the favicon URL.
+func (f *Fetcher) fetchParsed(ctx context.Context, parsed *url.URL) ([]byte, error) {
+	// First try to parse the HTML for a link icon
+	pageURL := fmt.Sprintf("%s://%s/", parsed.Scheme, parsed.Host)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Linkquisition/1.0")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		// Fallback to direct if page fetch fails
+		return f.fetchDirect(ctx, parsed)
+	}
+	defer resp.Body.Close()
+
+	// Read a limited amount of HTML to find the icon link
+	// (don't download the entire page for large sites)
+	const maxHTMLBytes = 64 * 1024
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTMLBytes))
+	if err != nil {
+		return f.fetchDirect(ctx, parsed)
+	}
+
+	matches := linkIconRegex.FindSubmatch(body)
+	if len(matches) < 2 {
+		// No icon link found, fall back to /favicon.ico
+		return f.fetchDirect(ctx, parsed)
+	}
+
+	iconHref := string(matches[1])
+	iconURL := resolveIconURL(iconHref, parsed)
+
+	if iconURL == "" {
+		return f.fetchDirect(ctx, parsed)
+	}
+
+	data, err := f.download(ctx, iconURL)
+	if err != nil {
+		// Fall back to direct if the parsed icon URL fails
+		return f.fetchDirect(ctx, parsed)
+	}
+
+	return data, nil
+}
+
+// fetchGoogle uses Google's favicon service.
+func (f *Fetcher) fetchGoogle(ctx context.Context, rawURL string) ([]byte, error) {
+	fetchURL := fmt.Sprintf(googleFaviconURL, url.QueryEscape(rawURL))
+	return f.download(ctx, fetchURL)
+}
+
+// download performs the actual HTTP GET and returns the body bytes.
+func (f *Fetcher) download(ctx context.Context, fetchURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Linkquisition/1.0")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching favicon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("favicon returned HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxFaviconBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading favicon: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty favicon response")
+	}
+
+	return data, nil
+}
+
+// cacheKey returns a filesystem-safe cache key for a hostname.
+func cacheKey(host string) string {
+	h := sha256.Sum256([]byte(host))
+	return hex.EncodeToString(h[:8])
+}
+
+// readCache reads a cached favicon if it exists and is not expired.
+func (f *Fetcher) readCache(host string) ([]byte, error) {
+	path := filepath.Join(f.cacheDir, cacheKey(host))
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if time.Since(info.ModTime()) > cacheTTL {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("cache expired")
+	}
+
+	return os.ReadFile(path)
+}
+
+// writeCache writes favicon bytes to the cache directory.
+func (f *Fetcher) writeCache(host string, data []byte) error {
+	if err := os.MkdirAll(f.cacheDir, cacheDirPerms); err != nil {
+		return err
+	}
+
+	path := filepath.Join(f.cacheDir, cacheKey(host))
+	return os.WriteFile(path, data, cacheFilePerms)
+}
+
+// resolveIconURL resolves a potentially relative icon href to an absolute URL.
+func resolveIconURL(href string, base *url.URL) string {
+	href = strings.TrimSpace(href)
+	if href == "" {
+		return ""
+	}
+
+	// Already absolute
+	if strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "https://") {
+		return href
+	}
+
+	// Protocol-relative
+	if strings.HasPrefix(href, "//") {
+		return base.Scheme + ":" + href
+	}
+
+	// Relative path
+	ref, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+
+	return base.ResolveReference(ref).String()
+}

--- a/internal/favicon/favicon.go
+++ b/internal/favicon/favicon.go
@@ -205,6 +205,8 @@ func cacheKey(host string) string {
 }
 
 // readCache reads a cached favicon if it exists and is not expired.
+// TODO: there is no proactive eviction of old cache entries — expired entries are only
+// removed lazily when accessed. A startup pruner or max cache size could be added if needed.
 func (f *Fetcher) readCache(host string) ([]byte, error) {
 	path := filepath.Join(f.cacheDir, cacheKey(host))
 

--- a/internal/favicon/favicon_test.go
+++ b/internal/favicon/favicon_test.go
@@ -1,0 +1,326 @@
+package favicon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetcher_FetchDirect(t *testing.T) {
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47} // PNG magic bytes
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, "")
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/some/page")
+
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestFetcher_FetchDirect_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, "")
+	_, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestFetcher_FetchParsed(t *testing.T) {
+	faviconData := []byte{0x00, 0x00, 0x01, 0x00} // ICO magic bytes
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `<html><head><link rel="icon" href="/assets/icon.png"></head></html>`)
+		case "/assets/icon.png":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyParsed, "")
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestFetcher_FetchParsed_FallbackToDirect(t *testing.T) {
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			// HTML without any link icon tag
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `<html><head><title>No Icon</title></head></html>`)
+		case "/favicon.ico":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyParsed, "")
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestFetcher_FetchGoogle(t *testing.T) {
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(faviconData)
+	}))
+	defer server.Close()
+
+	// Override the google URL to point to our test server
+	fetcher := &Fetcher{
+		strategy: StrategyGoogle,
+		cacheDir: "",
+		client:   &http.Client{Timeout: fetchTimeout},
+	}
+
+	// We can't easily test the actual Google URL, so test the download mechanism
+	data, err := fetcher.download(context.Background(), server.URL+"/favicon")
+
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestFetcher_Cache(t *testing.T) {
+	cacheDir := t.TempDir()
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, cacheDir)
+
+	// First fetch should hit the server
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+	assert.Equal(t, 1, callCount)
+
+	// Second fetch should come from cache
+	data, err = fetcher.Fetch(context.Background(), server.URL+"/other-page")
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+	assert.Equal(t, 1, callCount) // no additional server call
+}
+
+func TestFetcher_Cache_Expired(t *testing.T) {
+	cacheDir := t.TempDir()
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, cacheDir)
+
+	// Write an expired cache entry manually
+	host := "127.0.0.1"
+	cachePath := filepath.Join(cacheDir, cacheKey(host))
+	require.NoError(t, os.MkdirAll(cacheDir, cacheDirPerms))
+	require.NoError(t, os.WriteFile(cachePath, []byte("old data"), cacheFilePerms))
+
+	// Set modification time to the past
+	expiredTime := time.Now().Add(-cacheTTL - time.Hour)
+	require.NoError(t, os.Chtimes(cachePath, expiredTime, expiredTime))
+
+	// Should fetch fresh data, not use the expired cache
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestFetcher_InvalidURL(t *testing.T) {
+	fetcher := NewFetcher(StrategyDirect, "")
+
+	_, err := fetcher.Fetch(context.Background(), "://invalid")
+	assert.Error(t, err)
+}
+
+func TestFetcher_EmptyHost(t *testing.T) {
+	fetcher := NewFetcher(StrategyDirect, "")
+
+	_, err := fetcher.Fetch(context.Background(), "file:///local/path")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no host")
+}
+
+func TestFetcher_ContextCanceled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := fetcher.Fetch(ctx, server.URL+"/page")
+	assert.Error(t, err)
+}
+
+func TestResolveIconURL(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		href     string
+		baseURL  string
+		expected string
+	}{
+		{
+			name:     "absolute https URL",
+			href:     "https://cdn.example.com/icon.png",
+			baseURL:  "https://example.com/",
+			expected: "https://cdn.example.com/icon.png",
+		},
+		{
+			name:     "absolute http URL",
+			href:     "http://cdn.example.com/icon.png",
+			baseURL:  "https://example.com/",
+			expected: "http://cdn.example.com/icon.png",
+		},
+		{
+			name:     "protocol-relative URL",
+			href:     "//cdn.example.com/icon.png",
+			baseURL:  "https://example.com/",
+			expected: "https://cdn.example.com/icon.png",
+		},
+		{
+			name:     "relative path",
+			href:     "/assets/favicon.ico",
+			baseURL:  "https://example.com/",
+			expected: "https://example.com/assets/favicon.ico",
+		},
+		{
+			name:     "relative path without leading slash",
+			href:     "images/icon.png",
+			baseURL:  "https://example.com/pages/",
+			expected: "https://example.com/pages/images/icon.png",
+		},
+		{
+			name:     "empty href",
+			href:     "",
+			baseURL:  "https://example.com/",
+			expected: "",
+		},
+		{
+			name:     "whitespace-only href",
+			href:     "   ",
+			baseURL:  "https://example.com/",
+			expected: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			base, err := parseBaseURL(tt.baseURL)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, resolveIconURL(tt.href, base))
+		})
+	}
+}
+
+func TestLinkIconRegex(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "standard rel=icon",
+			html:     `<link rel="icon" href="/favicon.png">`,
+			expected: "/favicon.png",
+		},
+		{
+			name:     "shortcut icon",
+			html:     `<link rel="shortcut icon" href="/icon.ico">`,
+			expected: "/icon.ico",
+		},
+		{
+			name:     "apple-touch-icon",
+			html:     `<link rel="apple-touch-icon" href="/apple-icon.png">`,
+			expected: "/apple-icon.png",
+		},
+		{
+			name:     "with type attribute",
+			html:     `<link rel="icon" type="image/png" href="/icon.png">`,
+			expected: "/icon.png",
+		},
+		{
+			name:     "single quotes",
+			html:     `<link rel='icon' href='/icon.svg'>`,
+			expected: "/icon.svg",
+		},
+		{
+			name:     "no match",
+			html:     `<link rel="stylesheet" href="/style.css">`,
+			expected: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := linkIconRegex.FindSubmatch([]byte(tt.html))
+			if tt.expected == "" {
+				assert.Less(t, len(matches), 2)
+			} else {
+				require.GreaterOrEqual(t, len(matches), 2)
+				assert.Equal(t, tt.expected, string(matches[1]))
+			}
+		})
+	}
+}
+
+func parseBaseURL(rawURL string) (*url.URL, error) {
+	return url.Parse(rawURL)
+}

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Designänderung wird beim nächsten Start wirksam."
+  },
+  "config.favicon_label": {
+    "other": "Favicon der Website neben der URL anzeigen"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Favicon-Abrufmethode:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direkt (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Geparst (HTML-Link-Tag)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (externer Dienst)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Ruft /favicon.ico direkt von der Website ab. Schnell und datenschutzfreundlich."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Parst das HTML der Website, um das Icon zu finden. Genauer, aber möglicherweise langsamer."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Nutzt Googles Favicon-Dienst. Zuverlässig, aber die URL wird an Google gesendet (Datenschutzbedenken)."
   }
 }

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Nutzt Googles Favicon-Dienst. Zuverlässig, aber die URL wird an Google gesendet (Datenschutzbedenken)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Favicon-Cache leeren"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache geleert"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Fehler beim Leeren des Cache"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Theme change takes effect on next launch."
+  },
+  "config.favicon_label": {
+    "other": "Show site favicon next to URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Favicon retrieval method:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direct (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Parsed (HTML link tag)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (external service)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Fetches /favicon.ico directly from the site. Fast and private."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Parses the site's HTML to find the icon. More accurate but may be slower."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Uses Google's favicon service. Reliable but sends the URL to Google (privacy concern)."
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Uses Google's favicon service. Reliable but sends the URL to Google (privacy concern)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Clear favicon cache"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache cleared"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Error clearing cache"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "El cambio de tema se aplicará en el próximo inicio."
+  },
+  "config.favicon_label": {
+    "other": "Mostrar favicon del sitio junto a la URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Método de obtención del favicon:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Directo (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Analizado (etiqueta HTML link)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (servicio externo)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Obtiene /favicon.ico directamente del sitio. Rápido y privado."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Analiza el HTML del sitio para encontrar el icono. Más preciso, pero puede ser más lento."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Usa el servicio de favicon de Google. Fiable, pero la URL se envía a Google (problema de privacidad)."
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Usa el servicio de favicon de Google. Fiable, pero la URL se envía a Google (problema de privacidad)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Limpiar caché de favicons"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Caché limpiada"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Error al limpiar la caché"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Käyttää Googlen favicon-palvelua. Luotettava, mutta URL lähetetään Googlelle (tietosuojariski)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Tyhjennä favicon-välimuisti"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Välimuisti tyhjennetty"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Virhe välimuistin tyhjentämisessä"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Teeman vaihto tulee voimaan seuraavalla käynnistyksellä."
+  },
+  "config.favicon_label": {
+    "other": "Näytä sivuston favicon URL:n vieressä"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Faviconin hakutapa:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Suora (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Jäsennetty (HTML link-tagi)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (ulkoinen palvelu)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Hakee /favicon.ico suoraan sivustolta. Nopea ja yksityinen."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Jäsentää sivuston HTML:n kuvakkeen löytämiseksi. Tarkempi, mutta saattaa olla hitaampi."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Käyttää Googlen favicon-palvelua. Luotettava, mutta URL lähetetään Googlelle (tietosuojariski)."
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Utilise le service de favicon de Google. Fiable, mais l'URL est envoyée à Google (problème de confidentialité)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Vider le cache des favicons"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache vidé"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Erreur lors du vidage du cache"
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Le changement de thème prendra effet au prochain lancement."
+  },
+  "config.favicon_label": {
+    "other": "Afficher le favicon du site à côté de l'URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Méthode de récupération du favicon :"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direct (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Analysé (balise HTML link)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (service externe)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Récupère /favicon.ico directement depuis le site. Rapide et respectueux de la vie privée."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Analyse le HTML du site pour trouver l'icône. Plus précis, mais potentiellement plus lent."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Utilise le service de favicon de Google. Fiable, mais l'URL est envoyée à Google (problème de confidentialité)."
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "A témaváltás a következő indításkor lép érvénybe."
+  },
+  "config.favicon_label": {
+    "other": "Weboldal favicon megjelenítése az URL mellett"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Favicon lekérési módszer:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Közvetlen (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Elemzett (HTML link címke)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (külső szolgáltatás)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "A /favicon.ico közvetlen letöltése az oldalról. Gyors és adatvédelmi szempontból biztonságos."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Az oldal HTML-jének elemzése az ikon megtalálásához. Pontosabb, de lassabb lehet."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "A Google favicon szolgáltatását használja. Megbízható, de az URL-t elküldi a Google-nek (adatvédelmi aggály)."
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "A Google favicon szolgáltatását használja. Megbízható, de az URL-t elküldi a Google-nek (adatvédelmi aggály)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Favicon gyorsítótár törlése"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Gyorsítótár törölve"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Hiba a gyorsítótár törlésekor"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Usa o serviço de favicon do Google. Confiável, mas a URL é enviada ao Google (preocupação com privacidade)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Limpar cache de favicons"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache limpo"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Erro ao limpar o cache"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "A alteração do tema terá efeito na próxima inicialização."
+  },
+  "config.favicon_label": {
+    "other": "Mostrar favicon do site ao lado da URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Método de obtenção do favicon:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direto (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Analisado (tag HTML link)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (serviço externo)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Obtém /favicon.ico diretamente do site. Rápido e privado."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Analisa o HTML do site para encontrar o ícone. Mais preciso, mas pode ser mais lento."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Usa o serviço de favicon do Google. Confiável, mas a URL é enviada ao Google (preocupação com privacidade)."
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "A alteração do tema terá efeito no próximo arranque."
+  },
+  "config.favicon_label": {
+    "other": "Mostrar favicon do site junto ao URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Método de obtenção do favicon:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direto (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Analisado (tag HTML link)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (serviço externo)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Obtém /favicon.ico diretamente do site. Rápido e privado."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Analisa o HTML do site para encontrar o ícone. Mais preciso, mas pode ser mais lento."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Usa o serviço de favicon do Google. Fiável, mas o URL é enviado ao Google (preocupação de privacidade)."
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Usa o serviço de favicon do Google. Fiável, mas o URL é enviado ao Google (preocupação de privacidade)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Limpar cache de favicons"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache limpa"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Erro ao limpar a cache"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Använder Googles favicon-tjänst. Pålitligt, men URL:en skickas till Google (integritetsproblem)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Rensa favicon-cache"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Cache rensad"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Fel vid rensning av cache"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Temaändring träder i kraft vid nästa start."
+  },
+  "config.favicon_label": {
+    "other": "Visa webbplatsens favicon bredvid URL:en"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Metod för att hämta favicon:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Direkt (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Tolkad (HTML link-tagg)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (extern tjänst)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Hämtar /favicon.ico direkt från webbplatsen. Snabbt och integritetsvänligt."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Tolkar webbplatsens HTML för att hitta ikonen. Mer exakt, men kan vara långsammare."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Använder Googles favicon-tjänst. Pålitligt, men URL:en skickas till Google (integritetsproblem)."
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -304,5 +304,14 @@
   },
   "config.favicon_strategy_google_desc": {
     "other": "Використовує сервіс favicon від Google. Надійно, але URL надсилається до Google (проблема конфіденційності)."
+  },
+  "config.favicon_clear_cache": {
+    "other": "Очистити кеш favicon"
+  },
+  "config.favicon_clear_cache_done": {
+    "other": "✓ Кеш очищено"
+  },
+  "config.favicon_clear_cache_error": {
+    "other": "✗ Помилка очищення кешу"
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -280,5 +280,29 @@
   },
   "config.theme_restart_note": {
     "other": "Зміна теми набуде чинності при наступному запуску."
+  },
+  "config.favicon_label": {
+    "other": "Показувати favicon сайту поруч з URL"
+  },
+  "config.favicon_strategy_label": {
+    "other": "Спосіб отримання favicon:"
+  },
+  "config.favicon_strategy_direct": {
+    "other": "Прямий (/favicon.ico)"
+  },
+  "config.favicon_strategy_parsed": {
+    "other": "Розібраний (HTML тег link)"
+  },
+  "config.favicon_strategy_google": {
+    "other": "Google (зовнішній сервіс)"
+  },
+  "config.favicon_strategy_direct_desc": {
+    "other": "Завантажує /favicon.ico безпосередньо з сайту. Швидко та конфіденційно."
+  },
+  "config.favicon_strategy_parsed_desc": {
+    "other": "Аналізує HTML сайту для пошуку іконки. Точніше, але може бути повільніше."
+  },
+  "config.favicon_strategy_google_desc": {
+    "other": "Використовує сервіс favicon від Google. Надійно, але URL надсилається до Google (проблема конфіденційності)."
   }
 }

--- a/settings.go
+++ b/settings.go
@@ -29,6 +29,10 @@ const (
 	ThemeDark   = "dark"
 	ThemeLight  = "light"
 
+	FaviconStrategyDirect = "direct"
+	FaviconStrategyParsed = "parsed"
+	FaviconStrategyGoogle = "google"
+
 	DefaultMaxItemsPerRow = 5
 )
 
@@ -118,6 +122,8 @@ type UiSettings struct {
 	PickerLayout           string `json:"pickerLayout,omitempty"`
 	MaxItemsPerRow         int    `json:"maxItemsPerRow,omitempty"`
 	Theme                  string `json:"theme,omitempty"`
+	ShowFavicon            bool   `json:"showFavicon,omitempty"`
+	FaviconStrategy        string `json:"faviconStrategy,omitempty"`
 }
 
 // GetPickerLayout returns the effective picker layout, defaulting to horizontal.
@@ -143,6 +149,16 @@ func (u *UiSettings) GetTheme() string {
 		return u.Theme
 	default:
 		return ThemeSystem
+	}
+}
+
+// GetFaviconStrategy returns the effective favicon retrieval strategy, defaulting to direct.
+func (u *UiSettings) GetFaviconStrategy() string {
+	switch u.FaviconStrategy {
+	case FaviconStrategyParsed, FaviconStrategyGoogle:
+		return u.FaviconStrategy
+	default:
+		return FaviconStrategyDirect
 	}
 }
 

--- a/settings_test.go
+++ b/settings_test.go
@@ -1042,3 +1042,43 @@ func TestUiSettings_GetTheme(t *testing.T) {
 		)
 	}
 }
+
+func TestUiSettings_GetFaviconStrategy(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		ui       UiSettings
+		expected string
+	}{
+		{
+			name:     "defaults to direct when empty",
+			ui:       UiSettings{},
+			expected: FaviconStrategyDirect,
+		},
+		{
+			name:     "returns direct when explicitly set",
+			ui:       UiSettings{FaviconStrategy: FaviconStrategyDirect},
+			expected: FaviconStrategyDirect,
+		},
+		{
+			name:     "returns parsed when set",
+			ui:       UiSettings{FaviconStrategy: FaviconStrategyParsed},
+			expected: FaviconStrategyParsed,
+		},
+		{
+			name:     "returns google when set",
+			ui:       UiSettings{FaviconStrategy: FaviconStrategyGoogle},
+			expected: FaviconStrategyGoogle,
+		},
+		{
+			name:     "defaults to direct for unknown value",
+			ui:       UiSettings{FaviconStrategy: "unknown"},
+			expected: FaviconStrategyDirect,
+		},
+	} {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.ui.GetFaviconStrategy())
+			},
+		)
+	}
+}


### PR DESCRIPTION
Add optional favicon display next to the URL in the browser picker window. The icon is fetched lazily in a background goroutine so it never blocks startup — a placeholder reserves the space to prevent layout shift.

### Changes

- **New setting `ui.showFavicon`** (default: off) — enables favicon display
- **New setting `ui.faviconStrategy`** — user picks the retrieval method:
  - `direct` — fetches `/favicon.ico` from the host (fast, private, default)
  - `parsed` — parses HTML `<link rel="icon">` tag (more accurate, slower)
  - `google` — uses Google's favicon service (reliable, but sends URL to Google)
- **`internal/favicon` package** — fetcher with file-based cache (7-day TTL, stored in `~/.config/linkquisition/favicons/`)
- **Configurator UI** — checkbox toggle + strategy dropdown with descriptive disclaimers
- **Privacy-safe by design** — plugins run first, so the favicon is fetched using the post-plugin (sanitized/unwrapped) URL
- **Removed "Open:" label** from the picker URL row (unnecessary clutter)
- **Build fix** — added `-trimpath` to all `go build` invocations to prevent plugin ABI mismatches
- **AGENTS.md** — added i18n sync checklist
- **All 10 locales updated** with translated favicon setting strings