### PR TITLE
feat: Add report link to safety check popup & document security feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Motivation behind this project is:
     - `Ctrl+C` to just copy the URL to clipboard and close the window
     - Number keys (1-9) to select a browser
 - Optional favicon display next to the URL in the picker (lazy-loaded, no startup delay)
+- URL safety checking via [Google Safe Browsing](https://safebrowsing.google.com/) or
+  [VirusTotal](https://www.virustotal.com/) — shows a color-coded indicator in the picker
+  with a clickable link to the full provider report
 
 ## Installation
 
@@ -143,7 +146,12 @@ it will be treated as a different browser and might be removed if not safe-guard
         }
       ]
     }
-  ]
+  ],
+  "security": {
+    "enabled": true,
+    "provider": "google_safe_browsing",
+    "apiKey": "YOUR_API_KEY"
+  }
 }
 ```
 

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"image/color"
 	"log/slog"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -340,6 +341,17 @@ func (picker *BrowserPicker) showSafetyReport(result *safety.CheckResult, w fyne
 		grid.Add(picker.whoisValue(detailsText))
 	}
 
+	var reportLink fyne.CanvasObject
+	if result.ReportURL != "" {
+		parsedURL, _ := url.Parse(result.ReportURL)
+		if parsedURL != nil {
+			reportLink = widget.NewHyperlink(
+				i18n.T("picker.safety_view_report"),
+				parsedURL,
+			)
+		}
+	}
+
 	closeButton := widget.NewButtonWithIcon(
 		i18n.T("picker.safety_close"),
 		theme.CancelIcon(),
@@ -353,8 +365,13 @@ func (picker *BrowserPicker) showSafetyReport(result *safety.CheckResult, w fyne
 	content := container.NewVBox(
 		minWidthSpacer,
 		grid,
-		container.NewCenter(closeButton),
 	)
+
+	if reportLink != nil {
+		content.Add(container.NewCenter(reportLink))
+	}
+
+	content.Add(container.NewCenter(closeButton))
 
 	popup := widget.NewModalPopUp(content, w.Canvas())
 	closeButton.OnTapped = func() { popup.Hide() }

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -345,10 +345,25 @@ func (picker *BrowserPicker) showSafetyReport(result *safety.CheckResult, w fyne
 	if result.ReportURL != "" {
 		parsedURL, _ := url.Parse(result.ReportURL)
 		if parsedURL != nil {
-			reportLink = widget.NewHyperlink(
+			hyperlink := widget.NewHyperlink(
 				i18n.T("picker.safety_view_report"),
 				parsedURL,
 			)
+
+			copyButton := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), nil)
+			copyButton.Importance = widget.LowImportance
+			copyButton.OnTapped = func() {
+				w.Clipboard().SetContent(result.ReportURL)
+				copyButton.SetIcon(theme.ConfirmIcon())
+				go func() {
+					time.Sleep(1 * time.Second)
+					fyne.Do(func() {
+						copyButton.SetIcon(theme.ContentCopyIcon())
+					})
+				}()
+			}
+
+			reportLink = container.NewHBox(hyperlink, copyButton)
 		}
 	}
 

--- a/doc/linkquisition.1.scd
+++ b/doc/linkquisition.1.scd
@@ -163,6 +163,24 @@ Plugin locations:
 - Linux: _/usr/lib/linkquisition/plugins/_
 - macOS: _Linkquisition.app/Contents/Resources/plugins/_
 
+# URL SAFETY CHECKING
+
+When enabled in the configuration (see *linkquisition*(5)), the picker shows a
+color-coded indicator next to the URL:
+
+- *Green* — URL is considered safe
+- *Yellow* — check failed or URL is suspicious
+- *Red* — URL is flagged as malicious
+
+Clicking the indicator opens a popup with the provider name, threat level, and
+a link to view the full report on the provider's website.
+
+Supported providers:
+- *Google Safe Browsing* — checks against Google's threat lists
+- *VirusTotal* — aggregates results from multiple antivirus engines
+
+The check runs asynchronously and does not block the picker from opening.
+
 # SEE ALSO
 
 *linkquisition*(5), *xdg-settings*(1)

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -37,6 +37,9 @@ and *rule* subcommands).
 *ui* (object, optional)
 	UI settings. See *UI OBJECT* below.
 
+*security* (object, optional)
+	URL safety checking settings. See *SECURITY OBJECT* below.
+
 # BROWSER OBJECT
 
 *name* (string)
@@ -117,6 +120,25 @@ and *rule* subcommands).
 	- *google* — uses Google's favicon service. Reliable and fast, but the
 	  URL is sent to Google (privacy concern).
 
+# SECURITY OBJECT
+
+*enabled* (boolean, optional)
+	If _true_, URL safety checking is active. The picker shows a color-coded
+	dot indicating the safety status of the URL being opened. Default: _false_.
+
+*provider* (string, optional)
+	The safety checking provider. One of:
+	- *google_safe_browsing* (default) — uses Google Safe Browsing Lookup API
+	  v4. Checks against Google's threat lists (malware, social engineering,
+	  unwanted software, potentially harmful applications).
+	- *virustotal* — uses the VirusTotal URL analysis API. Aggregates results
+	  from multiple antivirus engines and URL scanners.
+
+*apiKey* (string, required when enabled)
+	API key for the selected provider. Obtain from:
+	- Google Safe Browsing: _https://console.cloud.google.com/apis/credentials_
+	- VirusTotal: _https://www.virustotal.com/gui/my-apikey_
+
 # EXAMPLE
 
 ```
@@ -149,6 +171,11 @@ and *rule* subcommands).
     "maxItemsPerRow": 5,
     "showFavicon": true,
     "faviconStrategy": "direct"
+  },
+  "security": {
+    "enabled": true,
+    "provider": "google_safe_browsing",
+    "apiKey": "YOUR_API_KEY"
   }
 }
 ```

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Schließen"
+  },
+  "picker.safety_view_report": {
+    "other": "Vollständigen Bericht anzeigen"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Close"
+  },
+  "picker.safety_view_report": {
+    "other": "View full report"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Cerrar"
+  },
+  "picker.safety_view_report": {
+    "other": "Ver informe completo"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Sulje"
+  },
+  "picker.safety_view_report": {
+    "other": "Näytä täysi raportti"
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Fermer"
+  },
+  "picker.safety_view_report": {
+    "other": "Voir le rapport complet"
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Bezárás"
+  },
+  "picker.safety_view_report": {
+    "other": "Teljes jelentés megtekintése"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Fechar"
+  },
+  "picker.safety_view_report": {
+    "other": "Ver relatório completo"
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Fechar"
+  },
+  "picker.safety_view_report": {
+    "other": "Ver relatório completo"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Stäng"
+  },
+  "picker.safety_view_report": {
+    "other": "Visa fullständig rapport"
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -421,5 +421,8 @@
   },
   "picker.safety_close": {
     "other": "Закрити"
+  },
+  "picker.safety_view_report": {
+    "other": "Переглянути повний звіт"
   }
 }

--- a/internal/safety/safebrowsing.go
+++ b/internal/safety/safebrowsing.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
 const (
 	safeBrowsingLookupURL = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
 	safeBrowsingTestURL   = "https://safebrowsing.googleapis.com/v4/threatLists"
+	safeBrowsingReportURL = "https://transparencyreport.google.com/safe-browsing/search?url="
 )
 
 type googleSafeBrowsing struct {
@@ -51,6 +53,8 @@ func (g *googleSafeBrowsing) TestCredentials(ctx context.Context) error {
 
 //nolint:cyclop
 func (g *googleSafeBrowsing) Check(ctx context.Context, targetURL string) (*CheckResult, error) {
+	reportURL := safeBrowsingReportURL + url.QueryEscape(targetURL)
+
 	payload := safeBrowsingRequest{
 		Client: sbClient{
 			ClientID:      "linkquisition",
@@ -69,9 +73,9 @@ func (g *googleSafeBrowsing) Check(ctx context.Context, targetURL string) (*Chec
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := safeBrowsingLookupURL + "?key=" + g.apiKey
+	apiURL := safeBrowsingLookupURL + "?key=" + g.apiKey
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -97,6 +101,7 @@ func (g *googleSafeBrowsing) Check(ctx context.Context, targetURL string) (*Chec
 	checkResult := &CheckResult{
 		Level:     ThreatLevelSafe,
 		Provider:  g.Name(),
+		ReportURL: reportURL,
 		CheckedAt: time.Now(),
 	}
 

--- a/internal/safety/safebrowsing.go
+++ b/internal/safety/safebrowsing.go
@@ -30,9 +30,9 @@ func (g *googleSafeBrowsing) Name() string {
 }
 
 func (g *googleSafeBrowsing) TestCredentials(ctx context.Context) error {
-	url := safeBrowsingTestURL + "?key=" + g.apiKey
+	apiURL := safeBrowsingTestURL + "?key=" + g.apiKey
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -24,6 +24,7 @@ type CheckResult struct {
 	Level     ThreatLevel
 	Provider  string
 	Details   []string
+	ReportURL string
 	CheckedAt time.Time
 }
 

--- a/internal/safety/virustotal.go
+++ b/internal/safety/virustotal.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	virusTotalBaseURL = "https://www.virustotal.com/api/v3"
+	virusTotalBaseURL   = "https://www.virustotal.com/api/v3"
+	virusTotalReportURL = "https://www.virustotal.com/gui/url/"
 )
 
 type virusTotal struct {
@@ -54,6 +55,7 @@ func (v *virusTotal) TestCredentials(ctx context.Context) error {
 func (v *virusTotal) Check(ctx context.Context, targetURL string) (*CheckResult, error) {
 	// VirusTotal URL lookup uses base64-encoded URL (without padding) as identifier
 	urlID := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(targetURL))
+	reportURL := virusTotalReportURL + urlID
 	apiURL := virusTotalBaseURL + "/urls/" + urlID
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
@@ -75,6 +77,7 @@ func (v *virusTotal) Check(ctx context.Context, targetURL string) (*CheckResult,
 			Level:     ThreatLevelSafe,
 			Provider:  v.Name(),
 			Details:   []string{"URL not previously scanned"},
+			ReportURL: reportURL,
 			CheckedAt: time.Now(),
 		}, nil
 	}
@@ -89,14 +92,15 @@ func (v *virusTotal) Check(ctx context.Context, targetURL string) (*CheckResult,
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return v.interpretResult(&result), nil
+	return v.interpretResult(&result, reportURL), nil
 }
 
-func (v *virusTotal) interpretResult(result *vtResponse) *CheckResult {
+func (v *virusTotal) interpretResult(result *vtResponse, reportURL string) *CheckResult {
 	stats := result.Data.Attributes.LastAnalysisStats
 	checkResult := &CheckResult{
 		Level:     ThreatLevelSafe,
 		Provider:  v.Name(),
+		ReportURL: reportURL,
 		CheckedAt: time.Now(),
 	}
 


### PR DESCRIPTION
Adds a "View full report" hyperlink in the URL safety check popup that links directly to the provider's analysis page (VirusTotal GUI or Google Transparency Report). Includes a clipboard copy button with visual confirmation.

Also documents the security checking feature across all documentation surfaces — it was previously undocumented:
- README: features list + example config
- `linkquisition(5)`: SECURITY OBJECT section with field descriptions
- `linkquisition(1)`: URL SAFETY CHECKING section explaining the indicator behavior