### PR TITLE
feat: Add security check result caching and improve safety report UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ it will be treated as a different browser and might be removed if not safe-guard
   "security": {
     "enabled": true,
     "provider": "google_safe_browsing",
-    "apiKey": "YOUR_API_KEY"
+    "apiKey": "YOUR_API_KEY",
+    "cache": {
+      "enabled": true,
+      "ttlHours": 24
+    }
   }
 }
 ```

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -46,6 +46,7 @@ type BrowserPicker struct {
 	settingsService linkquisition.SettingsService
 	logger          *slog.Logger
 	uiHooks         []linkquisition.PluginUIHook
+	modalOpen       bool
 }
 
 func NewBrowserPicker(
@@ -161,6 +162,9 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 func (picker *BrowserPicker) setupKeyboardShortcuts(w fyne.Window, buttons []fyne.CanvasObject) {
 	w.Canvas().SetOnTypedKey(
 		func(keyEvent *fyne.KeyEvent) {
+			if picker.modalOpen {
+				return
+			}
 			if keyEvent.Name == fyne.KeyEscape {
 				picker.fapp.Quit()
 			}
@@ -394,20 +398,7 @@ func (picker *BrowserPicker) showSafetyReport(result *safety.CheckResult, w fyne
 				parsedURL,
 			)
 
-			copyButton := widget.NewButtonWithIcon("", theme.ContentCopyIcon(), nil)
-			copyButton.Importance = widget.LowImportance
-			copyButton.OnTapped = func() {
-				w.Clipboard().SetContent(result.ReportURL)
-				copyButton.SetIcon(theme.ConfirmIcon())
-				go func() {
-					time.Sleep(1 * time.Second)
-					fyne.Do(func() {
-						copyButton.SetIcon(theme.ContentCopyIcon())
-					})
-				}()
-			}
-
-			reportLink = container.NewHBox(hyperlink, copyButton)
+			reportLink = container.NewHBox(hyperlink)
 		}
 	}
 
@@ -433,7 +424,27 @@ func (picker *BrowserPicker) showSafetyReport(result *safety.CheckResult, w fyne
 	content.Add(container.NewCenter(closeButton))
 
 	popup := widget.NewModalPopUp(content, w.Canvas())
-	closeButton.OnTapped = func() { popup.Hide() }
+
+	// Block picker keyboard shortcuts while modal is open
+	picker.modalOpen = true
+
+	// Override typed key handler to intercept Esc for the modal
+	originalHandler := w.Canvas().OnTypedKey()
+
+	closeModal := func() {
+		popup.Hide()
+		picker.modalOpen = false
+		w.Canvas().SetOnTypedKey(originalHandler)
+	}
+
+	closeButton.OnTapped = closeModal
+
+	w.Canvas().SetOnTypedKey(func(keyEvent *fyne.KeyEvent) {
+		if keyEvent.Name == fyne.KeyEscape {
+			closeModal()
+		}
+	})
+
 	popup.Show()
 }
 

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -273,7 +273,35 @@ func (picker *BrowserPicker) buildSafetyIndicator(
 
 	// Run check in background
 	go func() {
-		checker, err := safety.NewChecker(settings.Security.GetProvider(), settings.Security.APIKey)
+		provider := settings.Security.GetProvider()
+
+		// Check cache first (if caching is enabled)
+		var cache *safety.Cache
+		if settings.Security.Cache.Enabled {
+			cache = safety.NewCache(
+				picker.settingsService.GetConfigFolderPath(),
+				provider,
+				settings.Security.Cache.GetTTL(),
+			)
+
+			if cached, ok := cache.Get(urlToOpen); ok {
+				checkResult = cached
+				fyne.Do(func() {
+					switch cached.Level {
+					case safety.ThreatLevelSafe:
+						indicator.Color = color.NRGBA{R: 50, G: 180, B: 50, A: 255}
+					case safety.ThreatLevelSuspicious:
+						indicator.Color = color.NRGBA{R: 220, G: 180, B: 50, A: 255}
+					case safety.ThreatLevelDangerous:
+						indicator.Color = color.NRGBA{R: 220, G: 50, B: 50, A: 255}
+					}
+					indicator.Refresh()
+				})
+				return
+			}
+		}
+
+		checker, err := safety.NewChecker(provider, settings.Security.APIKey)
 		if err != nil {
 			picker.logger.Error("Failed to create safety checker", "error", err)
 			return
@@ -293,6 +321,13 @@ func (picker *BrowserPicker) buildSafetyIndicator(
 		}
 
 		checkResult = result
+
+		// Store result in cache (best-effort)
+		if cache != nil {
+			if cacheErr := cache.Put(urlToOpen, result); cacheErr != nil {
+				picker.logger.Debug("Failed to cache safety result", "url", urlToOpen, "error", cacheErr)
+			}
+		}
 
 		fyne.Do(func() {
 			switch result.Level {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -78,6 +78,15 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	settings := picker.settingsService.GetSettings()
 	pickerLayout := settings.Ui.GetPickerLayout()
 
+	// Prune expired security cache entries in the background
+	if settings.Security.Cache.Enabled && settings.Security.IsConfigured() {
+		go safety.NewCache(
+			picker.settingsService.GetConfigFolderPath(),
+			settings.Security.GetProvider(),
+			settings.Security.Cache.GetTTL(),
+		).PruneExpired()
+	}
+
 	for i := range picker.browsers {
 		if pickerLayout == linkquisition.PickerLayoutHorizontal {
 			buttons = append(

--- a/cmd/configurator_security.go
+++ b/cmd/configurator_security.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -111,9 +113,70 @@ func (c *Configurator) getSecurityTab() fyne.CanvasObject {
 		widget.NewLabel(""), container.NewHBox(testButton, testStatus),
 	)
 
+	// Cache section
+	cacheCheck := widget.NewCheck(i18n.T("config.security_cache_enabled"), nil)
+	cacheCheck.Checked = settings.Security.Cache.Enabled
+
+	ttlEntry := widget.NewEntry()
+	ttlEntry.SetText(fmt.Sprintf("%d", settings.Security.Cache.GetTTL()/time.Hour))
+
+	clearCacheButton := widget.NewButton(i18n.T("config.security_cache_clear"), func() {})
+	clearCacheButton.Importance = widget.LowImportance
+	clearCacheButton.OnTapped = func() {
+		configDir := c.settingsService.GetConfigFolderPath()
+		if err := safety.ClearAll(configDir); err != nil {
+			c.logger.Error("Error clearing security cache", "error", err)
+			clearCacheButton.SetText(i18n.T("config.security_cache_clear_error"))
+		} else {
+			clearCacheButton.SetText(i18n.T("config.security_cache_clear_done"))
+			clearCacheButton.Disable()
+		}
+	}
+
+	cacheForm := container.New(layout.NewFormLayout(),
+		widget.NewLabel(i18n.T("config.security_cache_ttl_label")), ttlEntry,
+	)
+
+	// Show/hide cache options based on checkbox
+	updateCacheVisible := func(enabled bool) {
+		if enabled {
+			cacheForm.Show()
+			clearCacheButton.Show()
+		} else {
+			cacheForm.Hide()
+			clearCacheButton.Hide()
+		}
+	}
+	updateCacheVisible(settings.Security.Cache.Enabled)
+
+	cacheCheck.OnChanged = func(checked bool) {
+		s := c.settingsService.GetSettings()
+		s.Security.Cache.Enabled = checked
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Failed to save security cache setting", "error", err)
+		}
+		updateCacheVisible(checked)
+	}
+
+	ttlEntry.OnChanged = func(val string) {
+		hours, err := strconv.Atoi(val)
+		if err != nil || hours <= 0 {
+			return
+		}
+		s := c.settingsService.GetSettings()
+		s.Security.Cache.TTLHours = hours
+		if err := c.settingsService.WriteSettings(s); err != nil {
+			c.logger.Error("Failed to save security cache TTL", "error", err)
+		}
+	}
+
 	return container.NewVBox(
 		enabledCheck,
 		form,
+		widget.NewSeparator(),
+		cacheCheck,
+		cacheForm,
+		clearCacheButton,
 	)
 }
 

--- a/cmd/configurator_security.go
+++ b/cmd/configurator_security.go
@@ -113,7 +113,15 @@ func (c *Configurator) getSecurityTab() fyne.CanvasObject {
 		widget.NewLabel(""), container.NewHBox(testButton, testStatus),
 	)
 
-	// Cache section
+	return container.NewVBox(
+		enabledCheck,
+		form,
+		widget.NewSeparator(),
+		c.buildSecurityCacheSection(settings),
+	)
+}
+
+func (c *Configurator) buildSecurityCacheSection(settings *linkquisition.Settings) fyne.CanvasObject {
 	cacheCheck := widget.NewCheck(i18n.T("config.security_cache_enabled"), nil)
 	cacheCheck.Checked = settings.Security.Cache.Enabled
 
@@ -171,9 +179,6 @@ func (c *Configurator) getSecurityTab() fyne.CanvasObject {
 	}
 
 	return container.NewVBox(
-		enabledCheck,
-		form,
-		widget.NewSeparator(),
 		cacheCheck,
 		cacheForm,
 		clearCacheButton,

--- a/doc/linkquisition.5.scd
+++ b/doc/linkquisition.5.scd
@@ -139,6 +139,18 @@ and *rule* subcommands).
 	- Google Safe Browsing: _https://console.cloud.google.com/apis/credentials_
 	- VirusTotal: _https://www.virustotal.com/gui/my-apikey_
 
+*cache* (object, optional)
+	Settings for caching security check results. When enabled, results are
+	stored locally and reused within the TTL window to reduce API calls and
+	improve picker responsiveness. Results are cached separately per provider.
+
+	*enabled* (boolean, optional)
+		If _true_, security check results are cached. Default: _false_.
+
+	*ttlHours* (integer, optional)
+		Cache time-to-live in hours. Entries older than this are discarded and
+		re-checked on next use. Default: _24_.
+
 # EXAMPLE
 
 ```
@@ -175,7 +187,11 @@ and *rule* subcommands).
   "security": {
     "enabled": true,
     "provider": "google_safe_browsing",
-    "apiKey": "YOUR_API_KEY"
+    "apiKey": "YOUR_API_KEY",
+    "cache": {
+      "enabled": true,
+      "ttlHours": 24
+    }
   }
 }
 ```

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Zugangsdaten gültig"
   },
+  "config.security_cache_enabled": {
+    "other": "Sicherheitsprüfungsergebnisse zwischenspeichern"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Cache-Dauer (Stunden):"
+  },
+  "config.security_cache_clear": {
+    "other": "Sicherheits-Cache leeren"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache geleert"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Fehler beim Leeren des Caches"
+  },
   "picker.safety_level_safe": {
     "other": "Sicher"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Credentials valid"
   },
+  "config.security_cache_enabled": {
+    "other": "Cache security check results"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Cache duration (hours):"
+  },
+  "config.security_cache_clear": {
+    "other": "Clear security cache"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache cleared"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Error clearing cache"
+  },
   "picker.safety_level_safe": {
     "other": "Safe"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Credenciales válidas"
   },
+  "config.security_cache_enabled": {
+    "other": "Almacenar en caché los resultados de seguridad"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Duración de la caché (horas):"
+  },
+  "config.security_cache_clear": {
+    "other": "Limpiar caché de seguridad"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Caché limpiada"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Error al limpiar la caché"
+  },
   "picker.safety_level_safe": {
     "other": "Seguro"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Tunnisteet kelvolliset"
   },
+  "config.security_cache_enabled": {
+    "other": "Välimuistita turvatarkistuksen tulokset"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Välimuistin kesto (tuntia):"
+  },
+  "config.security_cache_clear": {
+    "other": "Tyhjennä turvavälimuisti"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Välimuisti tyhjennetty"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Virhe välimuistia tyhjennettäessä"
+  },
   "picker.safety_level_safe": {
     "other": "Turvallinen"
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Identifiants valides"
   },
+  "config.security_cache_enabled": {
+    "other": "Mettre en cache les résultats de sécurité"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Durée du cache (heures) :"
+  },
+  "config.security_cache_clear": {
+    "other": "Vider le cache de sécurité"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache vidé"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Erreur lors du vidage du cache"
+  },
   "picker.safety_level_safe": {
     "other": "Sûr"
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Hitelesítő adatok érvényesek"
   },
+  "config.security_cache_enabled": {
+    "other": "Biztonsági ellenőrzés eredményeinek gyorsítótárazása"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Gyorsítótár élettartama (óra):"
+  },
+  "config.security_cache_clear": {
+    "other": "Biztonsági gyorsítótár törlése"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Gyorsítótár törölve"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Hiba a gyorsítótár törlésekor"
+  },
   "picker.safety_level_safe": {
     "other": "Biztonságos"
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Credenciais válidas"
   },
+  "config.security_cache_enabled": {
+    "other": "Armazenar em cache os resultados de segurança"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Duração do cache (horas):"
+  },
+  "config.security_cache_clear": {
+    "other": "Limpar cache de segurança"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache limpo"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Erro ao limpar o cache"
+  },
   "picker.safety_level_safe": {
     "other": "Seguro"
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Credenciais válidas"
   },
+  "config.security_cache_enabled": {
+    "other": "Armazenar em cache os resultados de segurança"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Duração da cache (horas):"
+  },
+  "config.security_cache_clear": {
+    "other": "Limpar cache de segurança"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache limpa"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Erro ao limpar a cache"
+  },
   "picker.safety_level_safe": {
     "other": "Seguro"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Uppgifter giltiga"
   },
+  "config.security_cache_enabled": {
+    "other": "Cachelagra säkerhetskontrollresultat"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Cachens varaktighet (timmar):"
+  },
+  "config.security_cache_clear": {
+    "other": "Rensa säkerhetscache"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Cache rensad"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Fel vid rensning av cache"
+  },
   "picker.safety_level_safe": {
     "other": "Säker"
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -401,6 +401,21 @@
   "config.security_test_success": {
     "other": "✓ Облікові дані дійсні"
   },
+  "config.security_cache_enabled": {
+    "other": "Кешувати результати перевірки безпеки"
+  },
+  "config.security_cache_ttl_label": {
+    "other": "Тривалість кешу (години):"
+  },
+  "config.security_cache_clear": {
+    "other": "Очистити кеш безпеки"
+  },
+  "config.security_cache_clear_done": {
+    "other": "Кеш очищено"
+  },
+  "config.security_cache_clear_error": {
+    "other": "Помилка очищення кешу"
+  },
   "picker.safety_level_safe": {
     "other": "Безпечно"
   },

--- a/internal/safety/cache.go
+++ b/internal/safety/cache.go
@@ -1,0 +1,99 @@
+package safety
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	cacheDirPerms    = 0o755
+	cacheFilePerms   = 0o600
+	securityCacheDir = "security_cache"
+)
+
+// Cache provides file-based caching of security check results, separated by provider.
+type Cache struct {
+	dir string
+	ttl time.Duration
+}
+
+type cachedEntry struct {
+	Result   CheckResult `json:"result"`
+	CachedAt time.Time   `json:"cachedAt"`
+}
+
+// NewCache creates a new security result cache for the given provider.
+// The cache directory is: <configDir>/security_cache/<provider>/
+func NewCache(configDir, provider string, ttl time.Duration) *Cache {
+	return &Cache{
+		dir: filepath.Join(configDir, securityCacheDir, provider),
+		ttl: ttl,
+	}
+}
+
+// Get retrieves a cached result for the given URL.
+// Returns the result and true if a valid (non-expired) entry exists, or nil and false otherwise.
+func (c *Cache) Get(url string) (*CheckResult, bool) {
+	path := filepath.Join(c.dir, cacheKey(url))
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+
+	var entry cachedEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		// Corrupted cache entry — remove it
+		_ = os.Remove(path)
+		return nil, false
+	}
+
+	if time.Since(entry.CachedAt) > c.ttl {
+		_ = os.Remove(path)
+		return nil, false
+	}
+
+	return &entry.Result, true
+}
+
+// Put stores a check result in the cache for the given URL.
+func (c *Cache) Put(url string, result *CheckResult) error {
+	if err := os.MkdirAll(c.dir, cacheDirPerms); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	entry := cachedEntry{
+		Result:   *result,
+		CachedAt: time.Now(),
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshaling cache entry: %w", err)
+	}
+
+	path := filepath.Join(c.dir, cacheKey(url))
+
+	return os.WriteFile(path, data, cacheFilePerms)
+}
+
+// Clear removes all cached entries for this provider.
+func (c *Cache) Clear() error {
+	return os.RemoveAll(c.dir)
+}
+
+// ClearAll removes the entire security cache directory (all providers).
+func ClearAll(configDir string) error {
+	return os.RemoveAll(filepath.Join(configDir, securityCacheDir))
+}
+
+// cacheKey returns a filesystem-safe key for a URL.
+func cacheKey(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(h[:]) + ".json"
+}

--- a/internal/safety/cache.go
+++ b/internal/safety/cache.go
@@ -87,6 +87,30 @@ func (c *Cache) Clear() error {
 	return os.RemoveAll(c.dir)
 }
 
+// PruneExpired removes all expired cache entries for this provider.
+// Intended to be called in the background to keep the cache directory tidy.
+func (c *Cache) PruneExpired() {
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		if time.Since(info.ModTime()) > c.ttl {
+			_ = os.Remove(filepath.Join(c.dir, entry.Name()))
+		}
+	}
+}
+
 // ClearAll removes the entire security cache directory (all providers).
 func ClearAll(configDir string) error {
 	return os.RemoveAll(filepath.Join(configDir, securityCacheDir))

--- a/internal/safety/cache_test.go
+++ b/internal/safety/cache_test.go
@@ -127,3 +127,40 @@ func TestClearAll(t *testing.T) {
 	_, ok = vtCache.Get("https://b.com")
 	assert.False(t, ok)
 }
+
+func TestCache_PruneExpired(t *testing.T) {
+	cacheDir := t.TempDir()
+	// Use a very short TTL
+	cache := NewCache(cacheDir, "google_safe_browsing", 1*time.Millisecond)
+
+	result := &CheckResult{Level: ThreatLevelSafe, Provider: "Google Safe Browsing"}
+
+	// Store multiple entries
+	require.NoError(t, cache.Put("https://a.com", result))
+	require.NoError(t, cache.Put("https://b.com", result))
+	require.NoError(t, cache.Put("https://c.com", result))
+
+	// Wait for TTL to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Add one fresh entry
+	freshCache := NewCache(cacheDir, "google_safe_browsing", 24*time.Hour)
+	require.NoError(t, freshCache.Put("https://fresh.com", result))
+
+	// Prune with the short TTL — only expired entries should be removed
+	cache.PruneExpired()
+
+	// Expired entries should be gone
+	_, ok := cache.Get("https://a.com")
+	assert.False(t, ok)
+
+	_, ok = cache.Get("https://b.com")
+	assert.False(t, ok)
+
+	_, ok = cache.Get("https://c.com")
+	assert.False(t, ok)
+
+	// Fresh entry should still exist (checked with a longer TTL cache)
+	_, ok = freshCache.Get("https://fresh.com")
+	assert.True(t, ok)
+}

--- a/internal/safety/cache_test.go
+++ b/internal/safety/cache_test.go
@@ -1,0 +1,129 @@
+package safety
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_PutAndGet(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir, "google_safe_browsing", 24*time.Hour)
+
+	result := &CheckResult{
+		Level:     ThreatLevelSafe,
+		Provider:  "Google Safe Browsing",
+		Details:   nil,
+		ReportURL: "https://example.com/report",
+		CheckedAt: time.Now(),
+	}
+
+	err := cache.Put("https://example.com", result)
+	require.NoError(t, err)
+
+	cached, ok := cache.Get("https://example.com")
+	require.True(t, ok)
+	assert.Equal(t, ThreatLevelSafe, cached.Level)
+	assert.Equal(t, "Google Safe Browsing", cached.Provider)
+	assert.Equal(t, "https://example.com/report", cached.ReportURL)
+}
+
+func TestCache_Miss(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir, "virustotal", 24*time.Hour)
+
+	cached, ok := cache.Get("https://not-cached.com")
+	assert.False(t, ok)
+	assert.Nil(t, cached)
+}
+
+func TestCache_Expired(t *testing.T) {
+	cacheDir := t.TempDir()
+	// Use a very short TTL so entries expire immediately
+	cache := NewCache(cacheDir, "google_safe_browsing", 1*time.Nanosecond)
+
+	result := &CheckResult{
+		Level:    ThreatLevelDangerous,
+		Provider: "Google Safe Browsing",
+		Details:  []string{"MALWARE"},
+	}
+
+	err := cache.Put("https://malware.example.com", result)
+	require.NoError(t, err)
+
+	// Wait for TTL to expire
+	time.Sleep(2 * time.Millisecond)
+
+	cached, ok := cache.Get("https://malware.example.com")
+	assert.False(t, ok)
+	assert.Nil(t, cached)
+}
+
+func TestCache_SeparateProviders(t *testing.T) {
+	cacheDir := t.TempDir()
+	googleCache := NewCache(cacheDir, "google_safe_browsing", 24*time.Hour)
+	vtCache := NewCache(cacheDir, "virustotal", 24*time.Hour)
+
+	googleResult := &CheckResult{
+		Level:    ThreatLevelSafe,
+		Provider: "Google Safe Browsing",
+	}
+	vtResult := &CheckResult{
+		Level:    ThreatLevelDangerous,
+		Provider: "VirusTotal",
+		Details:  []string{"3 engine(s) flagged as malicious"},
+	}
+
+	url := "https://example.com"
+
+	require.NoError(t, googleCache.Put(url, googleResult))
+	require.NoError(t, vtCache.Put(url, vtResult))
+
+	// Each provider returns its own result
+	cached, ok := googleCache.Get(url)
+	require.True(t, ok)
+	assert.Equal(t, ThreatLevelSafe, cached.Level)
+
+	cached, ok = vtCache.Get(url)
+	require.True(t, ok)
+	assert.Equal(t, ThreatLevelDangerous, cached.Level)
+	assert.Equal(t, []string{"3 engine(s) flagged as malicious"}, cached.Details)
+}
+
+func TestCache_Clear(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir, "virustotal", 24*time.Hour)
+
+	result := &CheckResult{Level: ThreatLevelSafe, Provider: "VirusTotal"}
+	require.NoError(t, cache.Put("https://example.com", result))
+
+	// Verify it's cached
+	_, ok := cache.Get("https://example.com")
+	require.True(t, ok)
+
+	// Clear and verify gone
+	require.NoError(t, cache.Clear())
+
+	_, ok = cache.Get("https://example.com")
+	assert.False(t, ok)
+}
+
+func TestClearAll(t *testing.T) {
+	cacheDir := t.TempDir()
+	googleCache := NewCache(cacheDir, "google_safe_browsing", 24*time.Hour)
+	vtCache := NewCache(cacheDir, "virustotal", 24*time.Hour)
+
+	result := &CheckResult{Level: ThreatLevelSafe, Provider: "test"}
+	require.NoError(t, googleCache.Put("https://a.com", result))
+	require.NoError(t, vtCache.Put("https://b.com", result))
+
+	require.NoError(t, ClearAll(cacheDir))
+
+	_, ok := googleCache.Get("https://a.com")
+	assert.False(t, ok)
+
+	_, ok = vtCache.Get("https://b.com")
+	assert.False(t, ok)
+}

--- a/internal/safety/cache_test.go
+++ b/internal/safety/cache_test.go
@@ -14,7 +14,7 @@ func TestCache_PutAndGet(t *testing.T) {
 
 	result := &CheckResult{
 		Level:     ThreatLevelSafe,
-		Provider:  "Google Safe Browsing",
+		Provider:  ProviderNameGoogleSafeBrowsing,
 		Details:   nil,
 		ReportURL: "https://example.com/report",
 		CheckedAt: time.Now(),
@@ -26,7 +26,7 @@ func TestCache_PutAndGet(t *testing.T) {
 	cached, ok := cache.Get("https://example.com")
 	require.True(t, ok)
 	assert.Equal(t, ThreatLevelSafe, cached.Level)
-	assert.Equal(t, "Google Safe Browsing", cached.Provider)
+	assert.Equal(t, ProviderNameGoogleSafeBrowsing, cached.Provider)
 	assert.Equal(t, "https://example.com/report", cached.ReportURL)
 }
 
@@ -46,8 +46,8 @@ func TestCache_Expired(t *testing.T) {
 
 	result := &CheckResult{
 		Level:    ThreatLevelDangerous,
-		Provider: "Google Safe Browsing",
-		Details:  []string{"MALWARE"},
+		Provider: ProviderNameGoogleSafeBrowsing,
+		Details:  []string{threatTypeMalware},
 	}
 
 	err := cache.Put("https://malware.example.com", result)
@@ -68,11 +68,11 @@ func TestCache_SeparateProviders(t *testing.T) {
 
 	googleResult := &CheckResult{
 		Level:    ThreatLevelSafe,
-		Provider: "Google Safe Browsing",
+		Provider: ProviderNameGoogleSafeBrowsing,
 	}
 	vtResult := &CheckResult{
 		Level:    ThreatLevelDangerous,
-		Provider: "VirusTotal",
+		Provider: ProviderNameVirusTotal,
 		Details:  []string{"3 engine(s) flagged as malicious"},
 	}
 
@@ -96,7 +96,7 @@ func TestCache_Clear(t *testing.T) {
 	cacheDir := t.TempDir()
 	cache := NewCache(cacheDir, "virustotal", 24*time.Hour)
 
-	result := &CheckResult{Level: ThreatLevelSafe, Provider: "VirusTotal"}
+	result := &CheckResult{Level: ThreatLevelSafe, Provider: ProviderNameVirusTotal}
 	require.NoError(t, cache.Put("https://example.com", result))
 
 	// Verify it's cached
@@ -133,7 +133,7 @@ func TestCache_PruneExpired(t *testing.T) {
 	// Use a very short TTL
 	cache := NewCache(cacheDir, "google_safe_browsing", 1*time.Millisecond)
 
-	result := &CheckResult{Level: ThreatLevelSafe, Provider: "Google Safe Browsing"}
+	result := &CheckResult{Level: ThreatLevelSafe, Provider: ProviderNameGoogleSafeBrowsing}
 
 	// Store multiple entries
 	require.NoError(t, cache.Put("https://a.com", result))

--- a/internal/safety/safebrowsing.go
+++ b/internal/safety/safebrowsing.go
@@ -15,6 +15,11 @@ const (
 	safeBrowsingLookupURL = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
 	safeBrowsingTestURL   = "https://safebrowsing.googleapis.com/v4/threatLists"
 	safeBrowsingReportURL = "https://transparencyreport.google.com/safe-browsing/search?url="
+
+	threatTypeMalware            = "MALWARE"
+	threatTypeSocialEngineering  = "SOCIAL_ENGINEERING"
+	threatTypeUnwantedSoftware   = "UNWANTED_SOFTWARE"
+	threatTypePotentiallyHarmful = "POTENTIALLY_HARMFUL_APPLICATION"
 )
 
 type googleSafeBrowsing struct {
@@ -26,7 +31,7 @@ func newGoogleSafeBrowsing(apiKey string) *googleSafeBrowsing {
 }
 
 func (g *googleSafeBrowsing) Name() string {
-	return "Google Safe Browsing"
+	return ProviderNameGoogleSafeBrowsing
 }
 
 func (g *googleSafeBrowsing) TestCredentials(ctx context.Context) error {
@@ -61,7 +66,7 @@ func (g *googleSafeBrowsing) Check(ctx context.Context, targetURL string) (*Chec
 			ClientVersion: "1.0.0",
 		},
 		ThreatInfo: sbThreatInfo{
-			ThreatTypes:      []string{"MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE", "POTENTIALLY_HARMFUL_APPLICATION"},
+			ThreatTypes:      []string{threatTypeMalware, threatTypeSocialEngineering, threatTypeUnwantedSoftware, threatTypePotentiallyHarmful},
 			PlatformTypes:    []string{"ANY_PLATFORM"},
 			ThreatEntryTypes: []string{"URL"},
 			ThreatEntries:    []sbThreatEntry{{URL: targetURL}},

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -19,6 +19,13 @@ const (
 	ThreatLevelDangerous
 )
 
+const (
+	// ProviderNameGoogleSafeBrowsing is the display name for Google Safe Browsing.
+	ProviderNameGoogleSafeBrowsing = "Google Safe Browsing"
+	// ProviderNameVirusTotal is the display name for VirusTotal.
+	ProviderNameVirusTotal = "VirusTotal"
+)
+
 // CheckResult holds the outcome of a URL safety check.
 type CheckResult struct {
 	Level     ThreatLevel

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -11,13 +11,13 @@ func TestNewChecker(t *testing.T) {
 	t.Run("google safe browsing", func(t *testing.T) {
 		checker, err := NewChecker("google_safe_browsing", "test-key")
 		require.NoError(t, err)
-		assert.Equal(t, "Google Safe Browsing", checker.Name())
+		assert.Equal(t, ProviderNameGoogleSafeBrowsing, checker.Name())
 	})
 
 	t.Run("virustotal", func(t *testing.T) {
 		checker, err := NewChecker("virustotal", "test-key")
 		require.NoError(t, err)
-		assert.Equal(t, "VirusTotal", checker.Name())
+		assert.Equal(t, ProviderNameVirusTotal, checker.Name())
 	})
 
 	t.Run("unknown provider", func(t *testing.T) {

--- a/internal/safety/virustotal.go
+++ b/internal/safety/virustotal.go
@@ -24,7 +24,7 @@ func newVirusTotal(apiKey string) *virusTotal {
 }
 
 func (v *virusTotal) Name() string {
-	return "VirusTotal"
+	return ProviderNameVirusTotal
 }
 
 func (v *virusTotal) TestCredentials(ctx context.Context) error {

--- a/settings.go
+++ b/settings.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var ErrNoMatchFound = errors.New("no match found")
@@ -35,6 +36,8 @@ const (
 
 	SecurityProviderGoogleSafeBrowsing = "google_safe_browsing"
 	SecurityProviderVirusTotal         = "virustotal"
+
+	DefaultSecurityCacheTTLHours = 24
 
 	DefaultMaxItemsPerRow = 5
 )
@@ -165,11 +168,27 @@ func (u *UiSettings) GetFaviconStrategy() string {
 	}
 }
 
+// SecurityCacheSettings holds configuration for caching security check results.
+type SecurityCacheSettings struct {
+	Enabled  bool `json:"enabled,omitempty"`
+	TTLHours int  `json:"ttlHours,omitempty"`
+}
+
+// GetTTL returns the effective cache TTL duration.
+func (s *SecurityCacheSettings) GetTTL() time.Duration {
+	if s.TTLHours > 0 {
+		return time.Duration(s.TTLHours) * time.Hour
+	}
+
+	return DefaultSecurityCacheTTLHours * time.Hour
+}
+
 // SecuritySettings holds configuration for URL safety checking.
 type SecuritySettings struct {
-	Enabled  bool   `json:"enabled,omitempty"`
-	Provider string `json:"provider,omitempty"`
-	APIKey   string `json:"apiKey,omitempty"`
+	Enabled  bool                  `json:"enabled,omitempty"`
+	Provider string                `json:"provider,omitempty"`
+	APIKey   string                `json:"apiKey,omitempty"`
+	Cache    SecurityCacheSettings `json:"cache,omitempty"`
 }
 
 // GetProvider returns the effective security provider, defaulting to Google Safe Browsing.

--- a/settings_test.go
+++ b/settings_test.go
@@ -2,6 +2,7 @@ package linkquisition_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1078,6 +1079,36 @@ func TestUiSettings_GetFaviconStrategy(t *testing.T) {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				assert.Equal(t, tt.expected, tt.ui.GetFaviconStrategy())
+			},
+		)
+	}
+}
+
+func TestSecurityCacheSettings_GetTTL(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		cache    SecurityCacheSettings
+		expected time.Duration
+	}{
+		{
+			name:     "defaults to 24h when TTLHours is zero",
+			cache:    SecurityCacheSettings{},
+			expected: 24 * time.Hour,
+		},
+		{
+			name:     "returns configured TTL",
+			cache:    SecurityCacheSettings{TTLHours: 12},
+			expected: 12 * time.Hour,
+		},
+		{
+			name:     "defaults to 24h for negative value",
+			cache:    SecurityCacheSettings{TTLHours: -1},
+			expected: 24 * time.Hour,
+		},
+	} {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.cache.GetTTL())
 			},
 		)
 	}


### PR DESCRIPTION
Add optional caching for URL security check results to reduce API calls and improve picker responsiveness. Results are cached per-provider (Google Safe Browsing / VirusTotal) with a configurable TTL (default 24 hours). Expired entries are pruned in the background when the picker opens.

New settings UI on the Security tab:
- Toggle caching on/off
- Configure cache duration in hours
- Clear cache button

The safety report popup is now a blocking modal — keyboard shortcuts (Enter, Esc, number keys) are suppressed while it's open, preventing accidental browser launches. The modal is dismissible with Esc or the close button.