### PR TITLE
fix: improve whois error dialog layout and messages

### DIFF
--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -613,10 +613,34 @@ func (picker *BrowserPicker) buildWhoisContent(
 }
 
 func (picker *BrowserPicker) buildWhoisError(err error, w fyne.Window) fyne.CanvasObject {
-	errLabel := widget.NewLabel(i18n.T("picker.whois_error", map[string]interface{}{
-		"Error": err.Error(),
-	}))
+	errorMsg := i18n.T("picker.whois_error_generic")
+	hint := ""
+
+	errText := err.Error()
+	switch {
+	case strings.Contains(errText, "timed out") || strings.Contains(errText, "deadline exceeded"):
+		errorMsg = i18n.T("picker.whois_error_timeout")
+		hint = i18n.T("picker.whois_error_hint_network")
+	case strings.Contains(errText, "connection refused") || strings.Contains(errText, "no route"):
+		errorMsg = i18n.T("picker.whois_error_connection")
+		hint = i18n.T("picker.whois_error_hint_network")
+	case strings.Contains(errText, "no host") || strings.Contains(errText, "parse"):
+		errorMsg = i18n.T("picker.whois_error_invalid_url")
+	}
+
+	errLabel := widget.NewLabel(errorMsg)
 	errLabel.Wrapping = fyne.TextWrapWord
+	errLabel.Alignment = fyne.TextAlignCenter
+
+	content := container.NewVBox(errLabel)
+
+	if hint != "" {
+		hintLabel := widget.NewLabel(hint)
+		hintLabel.Wrapping = fyne.TextWrapWord
+		hintLabel.Alignment = fyne.TextAlignCenter
+		hintLabel.Importance = widget.MediumImportance
+		content.Add(hintLabel)
+	}
 
 	closeButton := widget.NewButtonWithIcon(
 		i18n.T("picker.whois_close"),
@@ -624,10 +648,9 @@ func (picker *BrowserPicker) buildWhoisError(err error, w fyne.Window) fyne.Canv
 		func() { w.Close() },
 	)
 
-	return container.NewVBox(
-		container.NewCenter(errLabel),
-		container.NewCenter(closeButton),
-	)
+	content.Add(container.NewCenter(closeButton))
+
+	return content
 }
 
 func (picker *BrowserPicker) whoisValue(value string) *widget.Label {

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Domain-Informationen konnten nicht abgerufen werden:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Domain-Informationen konnten nicht abgerufen werden"
+  },
+  "picker.whois_error_timeout": {
+    "other": "Die WHOIS-Abfrage ist abgelaufen"
+  },
+  "picker.whois_error_connection": {
+    "other": "Verbindung zum WHOIS-Server konnte nicht hergestellt werden"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Die Domain konnte nicht aus der URL ermittelt werden"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Eine Firewall oder ein VPN blockiert möglicherweise ausgehende Verbindungen auf Port 43"
+  },
   "config.tab_security": {
     "other": "Sicherheit"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Failed to look up domain information:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Failed to look up domain information"
+  },
+  "picker.whois_error_timeout": {
+    "other": "The WHOIS lookup timed out"
+  },
+  "picker.whois_error_connection": {
+    "other": "Could not connect to the WHOIS server"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Could not determine the domain from the URL"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "A firewall or VPN may be blocking outbound connections on port 43"
+  },
   "config.tab_security": {
     "other": "Security"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "No se pudo obtener la información del dominio:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "No se pudo obtener la información del dominio"
+  },
+  "picker.whois_error_timeout": {
+    "other": "La consulta WHOIS ha expirado"
+  },
+  "picker.whois_error_connection": {
+    "other": "No se pudo conectar al servidor WHOIS"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "No se pudo determinar el dominio a partir de la URL"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Un cortafuegos o VPN puede estar bloqueando las conexiones salientes en el puerto 43"
+  },
   "config.tab_security": {
     "other": "Seguridad"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Verkkotunnuksen tietojen haku epäonnistui:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Verkkotunnuksen tietojen haku epäonnistui"
+  },
+  "picker.whois_error_timeout": {
+    "other": "WHOIS-haku aikakatkaistiin"
+  },
+  "picker.whois_error_connection": {
+    "other": "Yhteyttä WHOIS-palvelimeen ei voitu muodostaa"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Verkkotunnusta ei voitu määrittää URL-osoitteesta"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Palomuuri tai VPN saattaa estää yhteydet porttiin 43"
+  },
   "config.tab_security": {
     "other": "Turvallisuus"
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Impossible de récupérer les informations du domaine :\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Impossible de récupérer les informations du domaine"
+  },
+  "picker.whois_error_timeout": {
+    "other": "La requête WHOIS a expiré"
+  },
+  "picker.whois_error_connection": {
+    "other": "Impossible de se connecter au serveur WHOIS"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Impossible de déterminer le domaine à partir de l'URL"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Un pare-feu ou un VPN peut bloquer les connexions sortantes sur le port 43"
+  },
   "config.tab_security": {
     "other": "Sécurité"
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Nem sikerült lekérdezni a domain információkat:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Nem sikerült lekérdezni a domain információkat"
+  },
+  "picker.whois_error_timeout": {
+    "other": "A WHOIS lekérdezés időtúllépés miatt megszakadt"
+  },
+  "picker.whois_error_connection": {
+    "other": "Nem sikerült csatlakozni a WHOIS szerverhez"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Nem sikerült meghatározni a domaint az URL-ből"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Egy tűzfal vagy VPN blokkolhatja a kimenő kapcsolatokat a 43-as porton"
+  },
   "config.tab_security": {
     "other": "Biztonság"
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Falha ao consultar informações do domínio:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Falha ao consultar informações do domínio"
+  },
+  "picker.whois_error_timeout": {
+    "other": "A consulta WHOIS expirou"
+  },
+  "picker.whois_error_connection": {
+    "other": "Não foi possível conectar ao servidor WHOIS"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Não foi possível determinar o domínio a partir da URL"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Um firewall ou VPN pode estar bloqueando conexões de saída na porta 43"
+  },
   "config.tab_security": {
     "other": "Segurança"
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Falha ao consultar informações do domínio:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Falha ao consultar informações do domínio"
+  },
+  "picker.whois_error_timeout": {
+    "other": "A consulta WHOIS expirou"
+  },
+  "picker.whois_error_connection": {
+    "other": "Não foi possível ligar ao servidor WHOIS"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Não foi possível determinar o domínio a partir do URL"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Uma firewall ou VPN pode estar a bloquear ligações de saída na porta 43"
+  },
   "config.tab_security": {
     "other": "Segurança"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Kunde inte hämta domäninformation:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Kunde inte hämta domäninformation"
+  },
+  "picker.whois_error_timeout": {
+    "other": "WHOIS-förfrågan tog för lång tid"
+  },
+  "picker.whois_error_connection": {
+    "other": "Kunde inte ansluta till WHOIS-servern"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Kunde inte avgöra domänen från URL:en"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "En brandvägg eller VPN kan blockera utgående anslutningar på port 43"
+  },
   "config.tab_security": {
     "other": "Säkerhet"
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -368,6 +368,21 @@
   "picker.whois_error": {
     "other": "Не вдалося отримати інформацію про домен:\n{{.Error}}"
   },
+  "picker.whois_error_generic": {
+    "other": "Не вдалося отримати інформацію про домен"
+  },
+  "picker.whois_error_timeout": {
+    "other": "Час очікування WHOIS-запиту минув"
+  },
+  "picker.whois_error_connection": {
+    "other": "Не вдалося підключитися до WHOIS-сервера"
+  },
+  "picker.whois_error_invalid_url": {
+    "other": "Не вдалося визначити домен з URL-адреси"
+  },
+  "picker.whois_error_hint_network": {
+    "other": "Брандмауер або VPN може блокувати вихідні з'єднання на порту 43"
+  },
   "config.tab_security": {
     "other": "Безпека"
   },


### PR DESCRIPTION
Fix the error text alignment by using TextAlignCenter instead of wrapping the label in a Center container (which prevented word wrap from working).

Replace the generic raw error dump with user-friendly messages that detect the failure mode:
- Timeout → "The WHOIS lookup timed out"
- Connection refused → "Could not connect to the WHOIS server"
- Invalid URL → "Could not determine the domain from the URL"

When the error is network-related, show a hint explaining that a firewall or VPN may be blocking port 43.

Add translations for all 10 supported locales.