### PR TITLE
feat: Add KeyValueList setting type and improve unwrap plugin settings UI

### DIFF
--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -47,7 +47,7 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 	parentWindow := windows[0]
 
 	scrollContent := container.NewVScroll(form)
-	scrollContent.SetMinSize(fyne.NewSize(550, 300)) //nolint:mnd
+	scrollContent.SetMinSize(fyne.NewSize(700, 350)) //nolint:mnd
 
 	d := dialog.NewCustomConfirm(
 		title,
@@ -62,7 +62,7 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(600, 450)) //nolint:mnd
+	d.Resize(fyne.NewSize(780, 500)) //nolint:mnd
 	d.Show()
 }
 
@@ -101,7 +101,7 @@ func (c *Configurator) showAddPluginSettings(
 	parentWindow := windows[0]
 
 	scrollContent := container.NewVScroll(form)
-	scrollContent.SetMinSize(fyne.NewSize(550, 300)) //nolint:mnd
+	scrollContent.SetMinSize(fyne.NewSize(700, 350)) //nolint:mnd
 
 	d := dialog.NewCustomConfirm(
 		title,
@@ -123,7 +123,7 @@ func (c *Configurator) showAddPluginSettings(
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(600, 450)) //nolint:mnd
+	d.Resize(fyne.NewSize(780, 500)) //nolint:mnd
 	d.Show()
 }
 
@@ -165,6 +165,8 @@ func (c *Configurator) buildSettingWidget(
 		return c.buildStringSetting(desc, currentSettings)
 	case linkquisition.SettingTypeStringList:
 		return c.buildStringListSetting(desc, currentSettings)
+	case linkquisition.SettingTypeKeyValueList:
+		return c.buildKeyValueListSetting(desc, currentSettings)
 	default:
 		return c.buildStringSetting(desc, currentSettings)
 	}
@@ -286,6 +288,109 @@ func (c *Configurator) buildStringListSetting(
 	}
 }
 
+func (c *Configurator) buildKeyValueListSetting(
+	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
+) (item *widget.FormItem, getValue func() interface{}) {
+	keyLabel := desc.KeyFieldLabel
+	if keyLabel == "" {
+		keyLabel = desc.KeyField
+	}
+	valueLabel := desc.ValueFieldLabel
+	if valueLabel == "" {
+		valueLabel = desc.ValueField
+	}
+
+	current := getSettingKeyValueListStructured(currentSettings, desc.Key, desc.KeyField, desc.ValueField)
+
+	// rows holds the mutable state of key-value entries
+	type rowEntry struct {
+		keyEntry   *widget.Entry
+		valueEntry *widget.Entry
+	}
+	rows := make([]*rowEntry, 0, len(current))
+
+	// listContainer holds the rendered rows
+	listContainer := container.NewVBox()
+
+	var rebuildList func()
+	rebuildList = func() {
+		listContainer.RemoveAll()
+
+		// Header row
+		headerKey := widget.NewLabel(keyLabel)
+		headerKey.TextStyle.Bold = true
+		headerVal := widget.NewLabel(valueLabel)
+		headerVal.TextStyle.Bold = true
+		headerRow := container.NewGridWithColumns(
+			3, //nolint:mnd
+			headerKey,
+			headerVal,
+			widget.NewLabel(""),
+		)
+		listContainer.Add(headerRow)
+
+		for i := range rows {
+			idx := i
+			removeBtn := widget.NewButton("✕", func() {
+				rows = append(rows[:idx], rows[idx+1:]...)
+				rebuildList()
+			})
+			row := container.NewGridWithColumns(
+				3, //nolint:mnd
+				rows[idx].keyEntry,
+				rows[idx].valueEntry,
+				removeBtn,
+			)
+			listContainer.Add(row)
+		}
+	}
+
+	// Initialize rows from current values
+	for _, pair := range current {
+		keyE := widget.NewEntry()
+		keyE.SetText(pair.Key)
+		keyE.SetPlaceHolder(keyLabel)
+		valE := widget.NewEntry()
+		valE.SetText(pair.Value)
+		valE.SetPlaceHolder(valueLabel)
+		rows = append(rows, &rowEntry{keyEntry: keyE, valueEntry: valE})
+	}
+
+	rebuildList()
+
+	addBtn := widget.NewButton(i18n.T("config.plugins_kv_add_row"), func() {
+		keyE := widget.NewEntry()
+		keyE.SetPlaceHolder(keyLabel)
+		valE := widget.NewEntry()
+		valE.SetPlaceHolder(valueLabel)
+		rows = append(rows, &rowEntry{keyEntry: keyE, valueEntry: valE})
+		rebuildList()
+	})
+
+	content := container.NewVBox(listContainer, addBtn)
+	item = widget.NewFormItem(desc.Label, content)
+	item.HintText = desc.Description
+
+	return item, func() interface{} {
+		result := make([]interface{}, 0, len(rows))
+		for _, row := range rows {
+			k := strings.TrimSpace(row.keyEntry.Text)
+			v := strings.TrimSpace(row.valueEntry.Text)
+			if k == "" && v == "" {
+				continue
+			}
+			result = append(result, map[string]interface{}{
+				desc.KeyField:   k,
+				desc.ValueField: v,
+			})
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	}
+}
+
 // Helper functions to extract current setting values from the untyped map
 
 func getSettingString(settings map[string]interface{}, key string, defaultVal interface{}) string {
@@ -333,4 +438,40 @@ func getSettingStringList(settings map[string]interface{}, key string) []string 
 	}
 
 	return nil
+}
+
+// kvPair represents a single key-value pair for the KeyValueList setting type.
+type kvPair struct {
+	Key   string
+	Value string
+}
+
+// getSettingKeyValueListStructured extracts key-value pairs using the actual JSON field names
+// from the stored map objects.
+func getSettingKeyValueListStructured(
+	settings map[string]interface{}, key, keyFieldName, valueFieldName string,
+) []kvPair {
+	v, ok := settings[key]
+	if !ok {
+		return nil
+	}
+
+	list, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]kvPair, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pair := kvPair{
+			Key:   fmt.Sprintf("%v", m[keyFieldName]),
+			Value: fmt.Sprintf("%v", m[valueFieldName]),
+		}
+		result = append(result, pair)
+	}
+	return result
 }

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Vollständigen Bericht anzeigen"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Regel hinzufügen"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "View full report"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Add rule"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Ver informe completo"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Añadir regla"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Näytä täysi raportti"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Lisää sääntö"
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Voir le rapport complet"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Ajouter une règle"
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Teljes jelentés megtekintése"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Szabály hozzáadása"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Ver relatório completo"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Adicionar regra"
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Ver relatório completo"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Adicionar regra"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Visa fullständig rapport"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Lägg till regel"
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -454,5 +454,8 @@
   },
   "picker.safety_view_report": {
     "other": "Переглянути повний звіт"
+  },
+  "config.plugins_kv_add_row": {
+    "other": "Додати правило"
   }
 }

--- a/plugin.go
+++ b/plugin.go
@@ -43,12 +43,13 @@ type PluginResult struct {
 type PluginSettingType int
 
 const (
-	SettingTypeString     PluginSettingType = iota // free-form string
-	SettingTypeBool                                // boolean toggle
-	SettingTypeInt                                 // integer number
-	SettingTypeDuration                            // Go duration string (e.g. "5s", "168h")
-	SettingTypeStringList                          // list of strings
-	SettingTypeChoice                              // one of the values in Options
+	SettingTypeString       PluginSettingType = iota // free-form string
+	SettingTypeBool                                  // boolean toggle
+	SettingTypeInt                                   // integer number
+	SettingTypeDuration                              // Go duration string (e.g. "5s", "168h")
+	SettingTypeStringList                            // list of strings
+	SettingTypeChoice                                // one of the values in Options
+	SettingTypeKeyValueList                          // list of {key, value} pairs (rendered as two-column table)
 )
 
 // PluginSettingDescriptor tells the host application (and eventually the GUI)
@@ -74,6 +75,18 @@ type PluginSettingDescriptor struct {
 
 	// Options lists the valid values when Type is SettingTypeChoice
 	Options []string
+
+	// KeyField is the JSON field name for the first column when Type is SettingTypeKeyValueList
+	KeyField string
+
+	// KeyFieldLabel is the display label for the first column (defaults to KeyField if empty)
+	KeyFieldLabel string
+
+	// ValueField is the JSON field name for the second column when Type is SettingTypeKeyValueList
+	ValueField string
+
+	// ValueFieldLabel is the display label for the second column (defaults to ValueField if empty)
+	ValueFieldLabel string
 }
 
 // PluginMetadata describes a plugin to the host application and GUI.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,15 +5,19 @@ Each plugin can inspect, modify, block, or warn about URLs before they reach the
 
 ## [Unwrap](./unwrap/unwrap.go) -plugin
 
-This is the first plugin that I have written for Linkquisition. I use it to "unwrap" the internal links (in my company)
-that are "wrapped" inside Microsoft Defender (Evergreen) URL when they are passed via Microsoft Teams or Outlook.
+This plugin "unwraps" URLs that are wrapped inside redirect/tracking URLs, extracting the actual
+destination. Common use cases include:
 
-Now, the actual Defender URL is a good feature, but it is not very useful when the links refer to internal resources,
-such as GitLab, Jira, Confluence, whatnot. To leverage the actually safeguarding part of the Defender URL, the plugin
-can (and should) be configured to only unwrap the known sources, and leave the rest to be opened via the Defender URL.
+- **Microsoft Teams SafeLinks** — links wrapped via `statics.teams.cdn.office.net/evergreen-assets/safelinks`
+- **Outlook SafeLinks** — links wrapped via `*.safelinks.protection.outlook.com`
 
-To enable the plugin and configure it to unwrap the Defender links from Microsoft Teams you can use the following
-configuration:
+The plugin matches URLs against configurable regex rules and extracts the target from a specified
+query parameter. To leverage the safety features of SafeLinks for unknown URLs, the plugin can be
+configured to only unwrap URLs where the destination matches a browser rule (`requireBrowserMatchToUnwrap`).
+
+### Configuration
+
+To unwrap both Teams and Outlook SafeLinks:
 
 ```json
 {
@@ -35,10 +39,14 @@ configuration:
     {
       "path": "unwrap.so",
       "settings": {
-        "requireBrowserMatchToUnwrap": true,
+        "requireBrowserMatchToUnwrap": false,
         "rules": [
           {
             "match": "^https://statics\\.teams\\.cdn\\.office\\.net/evergreen-assets/safelinks",
+            "parameter": "url"
+          },
+          {
+            "match": "^https://[a-z0-9]+\\.safelinks\\.protection\\.outlook\\.com/",
             "parameter": "url"
           }
         ]
@@ -48,9 +56,21 @@ configuration:
 }
 ```
 
-In the above example, the `requireBrowserMatchToUnwrap` -setting is set to `true`, which means that the plugin will only
-unwrap the links if there is a matching browser-rule for that URL and all the rest of the URLs are opened with full
-Evergreen-protected URL.
+### Settings
+
+| Setting                       | Type                     | Default | Description                                                         |
+|-------------------------------|--------------------------|---------|---------------------------------------------------------------------|
+| `rules`                       | []{"match", "parameter"} | `[]`    | List of regex/parameter pairs defining which URLs to unwrap         |
+| `requireBrowserMatchToUnwrap` | bool                     | `false` | Only unwrap if a browser rule matches the unwrapped destination URL |
+
+Each rule has two fields:
+
+- `match` — a regex that the incoming URL is tested against
+- `parameter` — the query parameter name containing the actual destination URL
+
+If `requireBrowserMatchToUnwrap` is `true`, the plugin will only unwrap URLs when the extracted
+destination matches one of your configured browser rules. This preserves the SafeLinks protection
+for unknown/external URLs while unwrapping known internal ones.
 
 ## [Terminus](./terminus/terminus.go) -plugin
 

--- a/plugins/sanitize/sanitize.go
+++ b/plugins/sanitize/sanitize.go
@@ -110,13 +110,13 @@ func (p *sanitize) Metadata() linkquisition.PluginMetadata {
 			{
 				Key:         "extraParams",
 				Label:       "Extra Parameters",
-				Description: "Additional exact parameter names to strip",
+				Description: "Additional exact parameter names to strip (e.g. source, ref, igshid)",
 				Type:        linkquisition.SettingTypeStringList,
 			},
 			{
 				Key:         "extraPatterns",
 				Label:       "Extra Patterns",
-				Description: "Regex patterns to match parameter names against (e.g. ^_ga)",
+				Description: "Regex patterns to match parameter names against (e.g. ^_ga matches _ga, _gac, etc.)",
 				Type:        linkquisition.SettingTypeStringList,
 			},
 			{

--- a/plugins/unwrap/unwrap.go
+++ b/plugins/unwrap/unwrap.go
@@ -45,10 +45,14 @@ func (p *unwrap) Metadata() linkquisition.PluginMetadata {
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{
 			{
-				Key:         "rules",
-				Label:       "Unwrap Rules",
-				Description: "List of match/parameter pairs defining which URLs to unwrap",
-				Type:        linkquisition.SettingTypeStringList,
+				Key:             "rules",
+				Label:           "Unwrap Rules",
+				Description:     "List of match/parameter pairs defining which URLs to unwrap",
+				Type:            linkquisition.SettingTypeKeyValueList,
+				KeyField:        "match",
+				KeyFieldLabel:   "Match (regex)",
+				ValueField:      "parameter",
+				ValueFieldLabel: "URL Parameter",
 			},
 			{
 				Key:         "requireBrowserMatchToUnwrap",

--- a/plugins/unwrap/unwrap_test.go
+++ b/plugins/unwrap/unwrap_test.go
@@ -208,6 +208,20 @@ func TestUnwrap_ProcessURL(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Outlook SafeLinks (safelinks.protection.outlook.com) are unwrapped",
+			config: map[string]interface{}{
+				"requireBrowserMatchToUnwrap": false,
+				"rules": []map[string]interface{}{
+					{
+						"match":     `^https://[a-z0-9]+\.safelinks\.protection\.outlook\.com/`,
+						"parameter": "url",
+					},
+				},
+			},
+			inputURL:    "https://eur02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fmedium.com%2F%40user%2Farticle-123&data=05%7C02%7Cuser%40example.com%7Cabc123&sdata=xyz&reserved=0",
+			expectedURL: "https://medium.com/@user/article-123",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			testedPlugin := Plugin


### PR DESCRIPTION
The unwrap plugin's "rules" setting was rendered as a plain multi-line text box (SettingTypeStringList), making it confusing to configure structured match/parameter pairs. This PR introduces a proper UI for it.

**Changes:**

- Add `SettingTypeKeyValueList` to the plugin setting type system with field name and label support
- Implement a two-column table UI with labeled headers, per-row text entries, and add/remove buttons
- Switch the unwrap plugin to use the new setting type for its rules
- Widen the plugin settings dialog (780×500) to accommodate the table layout
- Rewrite the unwrap plugin README with Outlook SafeLinks example, settings table, and field documentation
- Add concrete examples to the sanitize plugin's setting descriptions
- Add test case for Outlook SafeLinks URL unwrapping
- Add `config.plugins_kv_add_row` i18n key to all 10 locale files