### PR TITLE
feat: Add manual update check and document undocumented features

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ To enable safety checking, add a `security` section to your `config.json`:
 
 Supported providers:
 
-| Provider | How to get an API key |
-|----------|----------------------|
+| Provider               | How to get an API key                                                                                                                                             |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `google_safe_browsing` | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) — enable the Safe Browsing API, then create an API key. Free tier: 10,000 requests/day. |
-| `virustotal` | [VirusTotal](https://www.virustotal.com/gui/my-apikey) — sign up for a free account. Free tier: 4 requests/minute, 500/day. |
+| `virustotal`           | [VirusTotal](https://www.virustotal.com/gui/my-apikey) — sign up for a free account. Free tier: 4 requests/minute, 500/day.                                       |
 
 The check runs asynchronously — it never blocks the picker from appearing. Results are cached
 locally (when `cache.enabled` is `true`) to reduce API calls on repeated URLs.
@@ -251,11 +251,11 @@ The picker can display the website's favicon next to the URL. Enable it in your 
 
 Available strategies:
 
-| Strategy | Description |
-|----------|-------------|
-| `direct` (default) | Fetches `/favicon.ico` from the host. Fast and privacy-friendly. |
-| `parsed` | Downloads the page HTML and parses the `<link rel="icon">` tag. More accurate but slower (two HTTP requests). |
-| `google` | Uses Google's favicon service. Reliable but sends the URL to Google. |
+| Strategy           | Description                                                                                                   |
+|--------------------|---------------------------------------------------------------------------------------------------------------|
+| `direct` (default) | Fetches `/favicon.ico` from the host. Fast and privacy-friendly.                                              |
+| `parsed`           | Downloads the page HTML and parses the `<link rel="icon">` tag. More accurate but slower (two HTTP requests). |
+| `google`           | Uses Google's favicon service. Reliable but sends the URL to Google.                                          |
 
 Favicons are cached locally for 7 days to avoid repeated network requests.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ Motivation behind this project is:
     - `Ctrl+C` to just copy the URL to clipboard and close the window
     - Number keys (1-9) to select a browser
 - Optional favicon display next to the URL in the picker (lazy-loaded, no startup delay)
+    - Three retrieval strategies: direct (`/favicon.ico`), parsed (HTML link tag), or Google's service
 - URL safety checking via [Google Safe Browsing](https://safebrowsing.google.com/) or
   [VirusTotal](https://www.virustotal.com/) — shows a color-coded indicator in the picker
   with a clickable link to the full provider report
+- WHOIS lookup — view domain registration details (registrar, age, expiry, DNSSEC status)
+  directly from the picker's context menu
+- QR code generation — generate a scannable QR code for the URL to quickly open it on a
+  mobile device
+- Manual update check in the About tab — see if a newer release is available on GitHub
 
 ## Installation
 
@@ -182,6 +188,76 @@ Currently supported languages:
 
 To contribute a new translation, add a JSON file to `internal/i18n/translations/` following the
 format of the existing files (e.g. `en.json`). The filename should be the locale code (e.g. `de.json` for German).
+
+### Picker context menu
+
+The browser picker has a context menu (⋯ button) next to the URL with these features:
+
+- **Copy URL** — copy the (possibly plugin-modified) URL to clipboard
+- **QR Code** — generates a scannable QR code for the URL, useful for quickly opening it on a
+  mobile device
+- **WHOIS** — performs a live WHOIS lookup and shows domain registration details: registrar,
+  creation/expiry dates, domain age, DNSSEC status, name servers, and EPP status codes
+
+### URL safety checking
+
+When enabled, the picker shows a color-coded dot next to the URL that indicates its safety status:
+
+- **Green** — no threats detected
+- **Yellow** — check failed or URL is suspicious
+- **Red** — URL is flagged as malicious
+
+Clicking the dot opens a popup with the provider name, threat level, details, and a link to view
+the full report on the provider's website.
+
+To enable safety checking, add a `security` section to your `config.json`:
+
+```json
+{
+  "security": {
+    "enabled": true,
+    "provider": "google_safe_browsing",
+    "apiKey": "YOUR_API_KEY",
+    "cache": {
+      "enabled": true,
+      "ttlHours": 24
+    }
+  }
+}
+```
+
+Supported providers:
+
+| Provider | How to get an API key |
+|----------|----------------------|
+| `google_safe_browsing` | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) — enable the Safe Browsing API, then create an API key. Free tier: 10,000 requests/day. |
+| `virustotal` | [VirusTotal](https://www.virustotal.com/gui/my-apikey) — sign up for a free account. Free tier: 4 requests/minute, 500/day. |
+
+The check runs asynchronously — it never blocks the picker from appearing. Results are cached
+locally (when `cache.enabled` is `true`) to reduce API calls on repeated URLs.
+
+### Favicon
+
+The picker can display the website's favicon next to the URL. Enable it in your config:
+
+```json
+{
+  "ui": {
+    "showFavicon": true,
+    "faviconStrategy": "direct"
+  }
+}
+```
+
+Available strategies:
+
+| Strategy | Description |
+|----------|-------------|
+| `direct` (default) | Fetches `/favicon.ico` from the host. Fast and privacy-friendly. |
+| `parsed` | Downloads the page HTML and parses the `<link rel="icon">` tag. More accurate but slower (two HTTP requests). |
+| `google` | Uses Google's favicon service. Reliable but sends the URL to Google. |
+
+Favicons are cached locally for 7 days to avoid repeated network requests.
 
 ## Command-line interface
 

--- a/Taskfile.package.yml
+++ b/Taskfile.package.yml
@@ -2,7 +2,7 @@ version: '3'
 
 vars:
   VERSION:
-    sh: echo ${VERSION:-0.0.0}
+    sh: echo ${VERSION:-dev}
 
 tasks:
   clean:

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -517,7 +517,6 @@ func (c *Configurator) getAboutTab(w fyne.Window) fyne.CanvasObject {
 
 func (c *Configurator) buildUpdateCheckSection(w fyne.Window) fyne.CanvasObject {
 	statusLabel := widget.NewLabel("")
-	statusLabel.Wrapping = fyne.TextWrapWord
 
 	releaseLink := container.NewHBox()
 	releaseLink.Hide()
@@ -557,11 +556,7 @@ func (c *Configurator) buildUpdateCheckSection(w fyne.Window) fyne.CanvasObject 
 		}()
 	}
 
-	return container.NewVBox(
-		container.NewHBox(checkButton),
-		statusLabel,
-		releaseLink,
-	)
+	return container.NewHBox(checkButton, statusLabel, releaseLink)
 }
 
 // openExternalURL opens a URL in a real browser, bypassing Linkquisition if it is

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
 	"github.com/strobotti/linkquisition/internal/ui"
+	"github.com/strobotti/linkquisition/internal/updater"
 	"github.com/strobotti/linkquisition/resources"
 )
 
@@ -499,12 +501,66 @@ func (c *Configurator) getAboutTab(w fyne.Window) fyne.CanvasObject {
 		container.NewHBox(widget.NewLabel(i18n.T("about.github_label")), githubLink),
 	)
 
+	// Update check section
+	updateSection := c.buildUpdateCheckSection(w)
+
 	return container.NewVBox(
 		container.NewHBox(icon, title),
 		widget.NewSeparator(),
 		description,
 		widget.NewSeparator(),
 		details,
+		widget.NewSeparator(),
+		updateSection,
+	)
+}
+
+func (c *Configurator) buildUpdateCheckSection(w fyne.Window) fyne.CanvasObject {
+	statusLabel := widget.NewLabel("")
+	statusLabel.Wrapping = fyne.TextWrapWord
+
+	releaseLink := container.NewHBox()
+	releaseLink.Hide()
+
+	checkButton := widget.NewButton(i18n.T("about.check_updates"), nil)
+	checkButton.OnTapped = func() {
+		checkButton.Disable()
+		checkButton.SetText(i18n.T("about.checking_updates"))
+		statusLabel.SetText("")
+		releaseLink.Hide()
+
+		go func() {
+			result, err := updater.Check(context.Background(), version)
+
+			fyne.Do(func() {
+				checkButton.Enable()
+				checkButton.SetText(i18n.T("about.check_updates"))
+
+				if err != nil {
+					c.logger.Error("Update check failed", "error", err)
+					statusLabel.SetText(i18n.T("about.update_error"))
+					return
+				}
+
+				if result.IsNewer {
+					statusLabel.SetText(i18n.T("about.update_available", map[string]interface{}{
+						"Version": result.LatestVersion,
+					}))
+
+					releaseLink.RemoveAll()
+					releaseLink.Add(ui.NewLinkWithCopy(i18n.T("about.view_release"), result.ReleaseURL, w))
+					releaseLink.Show()
+				} else {
+					statusLabel.SetText(i18n.T("about.up_to_date"))
+				}
+			})
+		}()
+	}
+
+	return container.NewVBox(
+		container.NewHBox(checkButton),
+		statusLabel,
+		releaseLink,
 	)
 }
 

--- a/doc/linkquisition.1.scd
+++ b/doc/linkquisition.1.scd
@@ -181,6 +181,42 @@ Supported providers:
 
 The check runs asynchronously and does not block the picker from opening.
 
+# CONTEXT MENU
+
+The browser picker has a context menu (⋯ button) next to the URL with these
+actions:
+
+*Copy URL*
+	Copy the (possibly plugin-modified) URL to clipboard.
+
+*QR Code*
+	Generate a scannable QR code for the URL, useful for quickly opening it
+	on a mobile device.
+
+*WHOIS*
+	Perform a live WHOIS lookup and display domain registration details:
+	registrar, creation/expiry dates, domain age, DNSSEC status, name servers,
+	and EPP status codes.
+
+# FAVICON
+
+When _ui.showFavicon_ is enabled in the configuration, the picker displays the
+website's favicon next to the URL. The icon is fetched lazily and does not delay
+picker startup.
+
+Available strategies (set via _ui.faviconStrategy_):
+- *direct* (default) — fetches _/favicon.ico_ from the host
+- *parsed* — downloads the page HTML and parses the _<link rel="icon">_ tag
+- *google* — uses Google's favicon service (URL is sent to Google)
+
+Favicons are cached locally for 7 days.
+
+# UPDATE CHECK
+
+The About tab in the configuration screen has a "Check for updates" button that
+queries the GitHub releases API. If a newer version is available, a link to the
+release page is shown. No automatic update checking is performed.
+
 # SEE ALSO
 
 *linkquisition*(5), *xdg-settings*(1)

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Nach Updates suchen"
+  },
+  "about.checking_updates": {
+    "other": "Prüfe..."
+  },
+  "about.update_available": {
+    "other": "Neue Version verfügbar: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Sie verwenden die neueste Version."
+  },
+  "about.update_error": {
+    "other": "Update-Prüfung fehlgeschlagen. Bitte versuchen Sie es später erneut."
+  },
+  "about.view_release": {
+    "other": "Release anzeigen"
+  },
   "plugin.blocked_title": {
     "other": "Von Plugin blockiert"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Check for updates"
+  },
+  "about.checking_updates": {
+    "other": "Checking..."
+  },
+  "about.update_available": {
+    "other": "New version available: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "You are running the latest version."
+  },
+  "about.update_error": {
+    "other": "Could not check for updates. Please try again later."
+  },
+  "about.view_release": {
+    "other": "View release"
+  },
   "plugin.blocked_title": {
     "other": "Blocked by Plugin"
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Buscar actualizaciones"
+  },
+  "about.checking_updates": {
+    "other": "Comprobando..."
+  },
+  "about.update_available": {
+    "other": "Nueva versión disponible: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Estás usando la última versión."
+  },
+  "about.update_error": {
+    "other": "No se pudo verificar actualizaciones. Inténtalo más tarde."
+  },
+  "about.view_release": {
+    "other": "Ver lanzamiento"
+  },
   "plugin.blocked_title": {
     "other": "Bloqueado por el plugin"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Tarkista päivitykset"
+  },
+  "about.checking_updates": {
+    "other": "Tarkistetaan..."
+  },
+  "about.update_available": {
+    "other": "Uusi versio saatavilla: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Käytössäsi on uusin versio."
+  },
+  "about.update_error": {
+    "other": "Päivitysten tarkistus epäonnistui. Yritä myöhemmin uudelleen."
+  },
+  "about.view_release": {
+    "other": "Näytä julkaisu"
+  },
   "plugin.blocked_title": {
     "other": "Estetty lisäosan toimesta"
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub :"
   },
+  "about.check_updates": {
+    "other": "Vérifier les mises à jour"
+  },
+  "about.checking_updates": {
+    "other": "Vérification..."
+  },
+  "about.update_available": {
+    "other": "Nouvelle version disponible : {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Vous utilisez la dernière version."
+  },
+  "about.update_error": {
+    "other": "Impossible de vérifier les mises à jour. Réessayez plus tard."
+  },
+  "about.view_release": {
+    "other": "Voir la version"
+  },
   "plugin.blocked_title": {
     "other": "Bloqué par le plugin"
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Frissítések keresése"
+  },
+  "about.checking_updates": {
+    "other": "Ellenőrzés..."
+  },
+  "about.update_available": {
+    "other": "Új verzió érhető el: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "A legújabb verziót használod."
+  },
+  "about.update_error": {
+    "other": "Nem sikerült ellenőrizni a frissítéseket. Próbáld újra később."
+  },
+  "about.view_release": {
+    "other": "Kiadás megtekintése"
+  },
   "plugin.blocked_title": {
     "other": "Bővítmény által blokkolva"
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Verificar atualizações"
+  },
+  "about.checking_updates": {
+    "other": "Verificando..."
+  },
+  "about.update_available": {
+    "other": "Nova versão disponível: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Você está usando a versão mais recente."
+  },
+  "about.update_error": {
+    "other": "Não foi possível verificar atualizações. Tente novamente mais tarde."
+  },
+  "about.view_release": {
+    "other": "Ver lançamento"
+  },
   "plugin.blocked_title": {
     "other": "Bloqueado pelo plugin"
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Verificar atualizações"
+  },
+  "about.checking_updates": {
+    "other": "A verificar..."
+  },
+  "about.update_available": {
+    "other": "Nova versão disponível: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Está a utilizar a versão mais recente."
+  },
+  "about.update_error": {
+    "other": "Não foi possível verificar atualizações. Tente novamente mais tarde."
+  },
+  "about.view_release": {
+    "other": "Ver lançamento"
+  },
   "plugin.blocked_title": {
     "other": "Bloqueado pelo plugin"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Sök efter uppdateringar"
+  },
+  "about.checking_updates": {
+    "other": "Kontrollerar..."
+  },
+  "about.update_available": {
+    "other": "Ny version tillgänglig: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "Du använder den senaste versionen."
+  },
+  "about.update_error": {
+    "other": "Kunde inte söka efter uppdateringar. Försök igen senare."
+  },
+  "about.view_release": {
+    "other": "Visa utgåva"
+  },
   "plugin.blocked_title": {
     "other": "Blockerad av plugin"
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -104,6 +104,24 @@
   "about.github_label": {
     "other": "GitHub:"
   },
+  "about.check_updates": {
+    "other": "Перевірити оновлення"
+  },
+  "about.checking_updates": {
+    "other": "Перевірка..."
+  },
+  "about.update_available": {
+    "other": "Доступна нова версія: {{.Version}}"
+  },
+  "about.up_to_date": {
+    "other": "У вас встановлена найновіша версія."
+  },
+  "about.update_error": {
+    "other": "Не вдалося перевірити оновлення. Спробуйте пізніше."
+  },
+  "about.view_release": {
+    "other": "Переглянути реліз"
+  },
   "plugin.blocked_title": {
     "other": "Заблоковано плагіном"
   },

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,141 @@
+// Package updater checks for newer releases on GitHub.
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const requestTimeout = 10 * time.Second
+
+//nolint:gochecknoglobals // mutable for testing
+var githubReleasesURL = "https://api.github.com/repos/Strobotti/linkquisition/releases/latest"
+
+// setGithubReleasesURL overrides the API endpoint (used in tests).
+func setGithubReleasesURL(url string) {
+	githubReleasesURL = url
+}
+
+// ReleaseInfo holds information about the latest GitHub release.
+type ReleaseInfo struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+	Name    string `json:"name"`
+}
+
+// CheckResult holds the outcome of an update check.
+type CheckResult struct {
+	// CurrentVersion is the running version.
+	CurrentVersion string
+
+	// LatestVersion is the newest release tag on GitHub (e.g. "v2.13.0").
+	LatestVersion string
+
+	// ReleaseURL is the link to the release page.
+	ReleaseURL string
+
+	// IsNewer is true when LatestVersion is newer than CurrentVersion.
+	IsNewer bool
+}
+
+// Check queries the GitHub releases API and compares the latest release tag
+// against the running version. Returns a CheckResult or an error.
+func Check(ctx context.Context, currentVersion string) (*CheckResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubReleasesURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "Linkquisition/"+currentVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned HTTP %d", resp.StatusCode)
+	}
+
+	var release ReleaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	cleanCurrent := strings.TrimPrefix(currentVersion, "v")
+
+	return &CheckResult{
+		CurrentVersion: currentVersion,
+		LatestVersion:  release.TagName,
+		ReleaseURL:     release.HTMLURL,
+		IsNewer:        isNewerVersion(latestVersion, cleanCurrent),
+	}, nil
+}
+
+// isNewerVersion returns true if latest is a newer semver than current.
+// Falls back to string comparison if parsing fails.
+func isNewerVersion(latest, current string) bool {
+	// Don't report updates for dev builds
+	if current == "dev" || current == "" {
+		return false
+	}
+
+	latestParts := parseSemver(latest)
+	currentParts := parseSemver(current)
+
+	if latestParts == nil || currentParts == nil {
+		return latest != current
+	}
+
+	for i := range 3 {
+		if latestParts[i] > currentParts[i] {
+			return true
+		}
+
+		if latestParts[i] < currentParts[i] {
+			return false
+		}
+	}
+
+	return false
+}
+
+// parseSemver parses "major.minor.patch" into [3]int. Returns nil on failure.
+func parseSemver(v string) []int {
+	parts := strings.SplitN(v, ".", 3) //nolint:mnd
+	if len(parts) != 3 {               //nolint:mnd
+		return nil
+	}
+
+	result := make([]int, 3) //nolint:mnd
+
+	for i, p := range parts {
+		// Strip any pre-release suffix (e.g. "0-rc1")
+		if idx := strings.IndexByte(p, '-'); idx >= 0 {
+			p = p[:idx]
+		}
+
+		var n int
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil
+			}
+
+			n = n*10 + int(c-'0')
+		}
+
+		result[i] = n
+	}
+
+	return result
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -12,6 +12,9 @@ import (
 
 const requestTimeout = 10 * time.Second
 
+// VersionDev is the version string used during development builds.
+const VersionDev = "dev"
+
 //nolint:gochecknoglobals // mutable for testing
 var githubReleasesURL = "https://api.github.com/repos/Strobotti/linkquisition/releases/latest"
 
@@ -86,7 +89,7 @@ func Check(ctx context.Context, currentVersion string) (*CheckResult, error) {
 // Falls back to string comparison if parsing fails.
 func isNewerVersion(latest, current string) bool {
 	// Don't report updates for dev builds
-	if current == "dev" || current == "" {
+	if current == VersionDev || current == "" {
 		return false
 	}
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -23,7 +23,7 @@ func TestIsNewerVersion(t *testing.T) {
 		{"minor newer", "2.14.0", "2.13.0", true},
 		{"major newer", "3.0.0", "2.13.0", true},
 		{"current is newer", "2.12.0", "2.13.0", false},
-		{"dev build", "2.13.0", "dev", false},
+		{"dev build", "2.13.0", VersionDev, false},
 		{"empty current", "2.13.0", "", false},
 		{"pre-release suffix", "2.14.0-rc1", "2.13.0", true},
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,122 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		current string
+		want    bool
+	}{
+		{"same version", "2.13.0", "2.13.0", false},
+		{"patch newer", "2.13.1", "2.13.0", true},
+		{"minor newer", "2.14.0", "2.13.0", true},
+		{"major newer", "3.0.0", "2.13.0", true},
+		{"current is newer", "2.12.0", "2.13.0", false},
+		{"dev build", "2.13.0", "dev", false},
+		{"empty current", "2.13.0", "", false},
+		{"pre-release suffix", "2.14.0-rc1", "2.13.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNewerVersion(tt.latest, tt.current)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []int
+	}{
+		{"2.13.0", []int{2, 13, 0}},
+		{"0.1.0", []int{0, 1, 0}},
+		{"10.20.30", []int{10, 20, 30}},
+		{"1.0.0-rc1", []int{1, 0, 0}},
+		{"invalid", nil},
+		{"1.2", nil},
+		{"a.b.c", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseSemver(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheck(t *testing.T) {
+	release := ReleaseInfo{
+		TagName: "v2.14.0",
+		HTMLURL: "https://github.com/Strobotti/linkquisition/releases/tag/v2.14.0",
+		Name:    "v2.14.0",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	// Override the URL for testing
+	origURL := githubReleasesURL
+	t.Cleanup(func() { setGithubReleasesURL(origURL) })
+	setGithubReleasesURL(server.URL)
+
+	result, err := Check(context.Background(), "2.13.0")
+	require.NoError(t, err)
+	assert.Equal(t, "2.13.0", result.CurrentVersion)
+	assert.Equal(t, "v2.14.0", result.LatestVersion)
+	assert.True(t, result.IsNewer)
+	assert.Contains(t, result.ReleaseURL, "v2.14.0")
+}
+
+func TestCheckUpToDate(t *testing.T) {
+	release := ReleaseInfo{
+		TagName: "v2.13.0",
+		HTMLURL: "https://github.com/Strobotti/linkquisition/releases/tag/v2.13.0",
+		Name:    "v2.13.0",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	origURL := githubReleasesURL
+	t.Cleanup(func() { setGithubReleasesURL(origURL) })
+	setGithubReleasesURL(server.URL)
+
+	result, err := Check(context.Background(), "2.13.0")
+	require.NoError(t, err)
+	assert.False(t, result.IsNewer)
+}
+
+func TestCheckHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origURL := githubReleasesURL
+	t.Cleanup(func() { setGithubReleasesURL(origURL) })
+	setGithubReleasesURL(server.URL)
+
+	_, err := Check(context.Background(), "2.13.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
+}


### PR DESCRIPTION
Adds a "Check for updates" button to the About tab and documents several picker features that were missing from README and man pages.

## Changes

**New feature: manual update check**
- New `internal/updater` package that queries the GitHub releases API
- "Check for updates" button in the About tab with async loading state
- Shows version comparison result and a link to the release page
- No automatic checking — only triggered by user action
- i18n keys added for all 10 supported locales

**Documentation**
- README: document picker context menu (QR code, WHOIS, Copy URL), favicon strategies with config examples, security provider setup with API key links
- README: update features list to reflect all current capabilities
- Man page (`linkquisition.1`): add sections for context menu, favicon, and update check