### PR TITLE
feat: add site/domain selection to remember checkbox and improve rule editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,13 @@ The app has two UI modes, both in `cmd/`:
   The General tab is composed of `build*Section()` methods. Add new sections there.
 - **BrowserPicker** (`cmd/browser_picker.go`) — the URL picker, shown when launched with a URL.
 
+### UI helpers (`internal/ui/`)
+
+- **`ui.NewLinkWithCopy(text, rawURL, window)`** — creates a clickable hyperlink with a
+  copy-to-clipboard button beside it. Use this whenever displaying a URL or link in the GUI
+  (e.g. reference links, documentation URLs, external resources). Prefer this over a plain
+  `widget.NewHyperlink` for consistency across the app.
+
 ## Settings and config model
 
 - `settings.go` — `Settings` struct, constants (`LogLevel*`, `BrowserMatchType*`, `Source*`),

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -698,7 +698,7 @@ func (picker *BrowserPicker) buildRememberCheck(
 	// If site == domain (no subdomain), just show the simple checkbox
 	if site == domain {
 		check := widget.NewCheckWithData(
-			i18n.T("picker.remember_choice")+" "+site,
+			i18n.T("picker.remember_choice"),
 			remember,
 		)
 		return []fyne.CanvasObject{check}
@@ -719,18 +719,23 @@ func (picker *BrowserPicker) buildRememberCheck(
 		},
 	)
 	radio.SetSelected(siteLabel)
-	radio.Hide()
+
+	// Indent the radio group to visually nest it under the checkbox
+	indent := canvas.NewRectangle(color.Transparent)
+	indent.SetMinSize(fyne.NewSize(theme.Padding()*4, 0))
+	indentedRadio := container.NewHBox(indent, radio)
+	indentedRadio.Hide()
 
 	check := widget.NewCheck(i18n.T("picker.remember_choice"), func(checked bool) {
 		_ = remember.Set(checked)
 		if checked {
-			radio.Show()
+			indentedRadio.Show()
 		} else {
-			radio.Hide()
+			indentedRadio.Hide()
 		}
 	})
 
-	return []fyne.CanvasObject{check, radio}
+	return []fyne.CanvasObject{check, indentedRadio}
 }
 
 func (picker *BrowserPicker) buildKeyboardGuide() []fyne.CanvasObject {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -73,7 +73,6 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	remember := binding.NewBool()
 	_ = remember.Set(false)
 	rememberMatchType := binding.NewString()
-	// TODO give user the option to choose between site and domain (and later on regex, too)
 	_ = rememberMatchType.Set(linkquisition.BrowserMatchTypeSite)
 
 	settings := picker.settingsService.GetSettings()
@@ -128,7 +127,7 @@ func (picker *BrowserPicker) Run(_ context.Context, urlToOpen string) error {
 	}
 
 	widgets = append(widgets, picker.buildURLDisplay(urlToOpen, w)...)
-	widgets = append(widgets, picker.buildRememberCheck(urlToOpen, remember)...)
+	widgets = append(widgets, picker.buildRememberCheck(urlToOpen, remember, rememberMatchType)...)
 
 	if !settings.Ui.HideKeyboardGuideLabel {
 		widgets = append(widgets, picker.buildKeyboardGuide()...)
@@ -687,15 +686,51 @@ func (picker *BrowserPicker) fetchAndUpdateFavicon(
 	img.Refresh()
 }
 
-func (picker *BrowserPicker) buildRememberCheck(urlToOpen string, remember binding.Bool) []fyne.CanvasObject {
+func (picker *BrowserPicker) buildRememberCheck(
+	urlToOpen string,
+	remember binding.Bool,
+	rememberMatchType binding.String,
+) []fyne.CanvasObject {
 	uto := linkquisition.NewURL(urlToOpen)
 	site, _ := uto.GetSite()
-	check := widget.NewCheckWithData(
-		i18n.T("picker.remember_choice", map[string]interface{}{"Site": site}),
-		remember,
-	)
+	domain, _ := uto.GetDomain()
 
-	return []fyne.CanvasObject{check}
+	// If site == domain (no subdomain), just show the simple checkbox
+	if site == domain {
+		check := widget.NewCheckWithData(
+			i18n.T("picker.remember_choice")+" "+site,
+			remember,
+		)
+		return []fyne.CanvasObject{check}
+	}
+
+	// Build radio options with actual values shown
+	siteLabel := i18n.T("picker.remember_site", map[string]interface{}{"Site": site})
+	domainLabel := i18n.T("picker.remember_domain", map[string]interface{}{"Domain": domain})
+
+	radio := widget.NewRadioGroup(
+		[]string{siteLabel, domainLabel},
+		func(selected string) {
+			if selected == domainLabel {
+				_ = rememberMatchType.Set(linkquisition.BrowserMatchTypeDomain)
+			} else {
+				_ = rememberMatchType.Set(linkquisition.BrowserMatchTypeSite)
+			}
+		},
+	)
+	radio.SetSelected(siteLabel)
+	radio.Hide()
+
+	check := widget.NewCheck(i18n.T("picker.remember_choice"), func(checked bool) {
+		_ = remember.Set(checked)
+		if checked {
+			radio.Show()
+		} else {
+			radio.Hide()
+		}
+	})
+
+	return []fyne.CanvasObject{check, radio}
 }
 
 func (picker *BrowserPicker) buildKeyboardGuide() []fyne.CanvasObject {

--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -37,6 +37,7 @@ const (
 	verticalWindowMinHeight  = 50
 	faviconDisplaySize       = 16
 	safetyCheckTimeout       = 10 * time.Second
+	rememberIndentMultiplier = 4
 )
 
 type BrowserPicker struct {
@@ -722,7 +723,7 @@ func (picker *BrowserPicker) buildRememberCheck(
 
 	// Indent the radio group to visually nest it under the checkbox
 	indent := canvas.NewRectangle(color.Transparent)
-	indent.SetMinSize(fyne.NewSize(theme.Padding()*4, 0))
+	indent.SetMinSize(fyne.NewSize(theme.Padding()*rememberIndentMultiplier, 0))
 	indentedRadio := container.NewHBox(indent, radio)
 	indentedRadio.Hide()
 

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image/color"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -396,8 +397,15 @@ func newRegexPanel() *regexPanel {
 	testResultBox := container.NewHBox(testResult)
 	testResultBox.Hide()
 
+	// Help text with link to regex reference
+	helpLabel := widget.NewLabel(i18n.T("config.rules_regex_help"))
+	helpLabel.TextStyle = fyne.TextStyle{Italic: true}
+	regexDocsURL, _ := url.Parse("https://pkg.go.dev/regexp/syntax")
+	helpLink := widget.NewHyperlink(i18n.T("config.rules_regex_help_link"), regexDocsURL)
+	helpRow := container.NewHBox(helpLabel, helpLink)
+
 	// Full panel (everything below the value entry)
-	panel := container.NewVBox(errorLabel, testEntry, testResultBox)
+	panel := container.NewVBox(errorLabel, helpRow, testEntry, testResultBox)
 	panel.Hide()
 
 	rp := &regexPanel{

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -366,6 +366,8 @@ type regexPanel struct {
 	indicator     *canvas.Text
 	indicatorBox  *fyne.Container
 	errorLabel    *widget.Label
+	typeHelpLabel *widget.Label
+	regexHelpRow  *fyne.Container
 	testEntry     *widget.Entry
 	testResult    *canvas.Text
 	testResultBox *fyne.Container
@@ -397,21 +399,29 @@ func newRegexPanel(w fyne.Window) *regexPanel {
 	testResultBox := container.NewHBox(testResult)
 	testResultBox.Hide()
 
-	// Help text with link to regex reference
-	helpLabel := widget.NewLabel(i18n.T("config.rules_regex_help"))
-	helpLabel.TextStyle = fyne.TextStyle{Italic: true}
+	// Help text with link to regex reference (only shown for regex type)
+	regexHelpLabel := widget.NewLabel(i18n.T("config.rules_regex_help"))
+	regexHelpLabel.TextStyle = fyne.TextStyle{Italic: true}
 	regexDocsURL := "https://pkg.go.dev/regexp/syntax"
-	helpLink := ui.NewLinkWithCopy(i18n.T("config.rules_regex_help_link"), regexDocsURL, w)
-	helpRow := container.NewHBox(helpLabel, helpLink)
+	regexHelpLink := ui.NewLinkWithCopy(i18n.T("config.rules_regex_help_link"), regexDocsURL, w)
+	regexHelpRow := container.NewHBox(regexHelpLabel, regexHelpLink)
+	regexHelpRow.Hide()
+
+	// Type help label (shown for all types, content changes with type)
+	typeHelpLabel := widget.NewLabel("")
+	typeHelpLabel.Wrapping = fyne.TextWrapWord
+	typeHelpLabel.TextStyle = fyne.TextStyle{Italic: true}
 
 	// Full panel (everything below the value entry)
-	panel := container.NewVBox(errorLabel, helpRow, testEntry, testResultBox)
+	panel := container.NewVBox(errorLabel, typeHelpLabel, regexHelpRow, testEntry, testResultBox)
 	panel.Hide()
 
 	rp := &regexPanel{
 		indicator:     indicator,
 		indicatorBox:  indicatorBox,
 		errorLabel:    errorLabel,
+		typeHelpLabel: typeHelpLabel,
+		regexHelpRow:  regexHelpRow,
 		testEntry:     testEntry,
 		testResult:    testResult,
 		testResultBox: testResultBox,
@@ -426,15 +436,37 @@ func newRegexPanel(w fyne.Window) *regexPanel {
 }
 
 func (rp *regexPanel) update(matchType, value string) {
+	rp.panel.Show()
+	rp.pattern = value
+
+	// Update type-specific help text
+	switch matchType {
+	case linkquisition.BrowserMatchTypeSite:
+		rp.typeHelpLabel.SetText(i18n.T("config.rules_type_help_site"))
+		rp.typeHelpLabel.Show()
+	case linkquisition.BrowserMatchTypeDomain:
+		rp.typeHelpLabel.SetText(i18n.T("config.rules_type_help_domain"))
+		rp.typeHelpLabel.Show()
+	case linkquisition.BrowserMatchTypeRegex:
+		rp.typeHelpLabel.SetText(i18n.T("config.rules_type_help_regex"))
+		rp.typeHelpLabel.Show()
+	default:
+		rp.typeHelpLabel.Hide()
+	}
+
+	// Regex-specific elements
 	if matchType != linkquisition.BrowserMatchTypeRegex {
 		rp.indicatorBox.Hide()
-		rp.panel.Hide()
+		rp.regexHelpRow.Hide()
+		rp.testEntry.Hide()
+		rp.testResultBox.Hide()
+		rp.errorLabel.Hide()
 		return
 	}
 
-	rp.pattern = value
 	rp.indicatorBox.Show()
-	rp.panel.Show()
+	rp.regexHelpRow.Show()
+	rp.testEntry.Show()
 
 	if value == "" {
 		rp.indicator.Text = "—"

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -379,7 +379,7 @@ type regexPanel struct {
 func newRegexPanel(w fyne.Window) *regexPanel {
 	// Indicator next to value entry
 	indicator := canvas.NewText("✓", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
-	indicator.TextSize = 18 //nolint:mnd
+	indicator.TextSize = 18
 	indicator.TextStyle = fyne.TextStyle{Bold: true}
 	indicatorBox := container.NewCenter(indicator)
 	indicatorBox.Hide()
@@ -395,7 +395,7 @@ func newRegexPanel(w fyne.Window) *regexPanel {
 
 	// Test match result
 	testResult := canvas.NewText("", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
-	testResult.TextSize = 14 //nolint:mnd
+	testResult.TextSize = 14
 	testResult.TextStyle = fyne.TextStyle{Bold: true}
 	testResultBox := container.NewHBox(testResult)
 	testResultBox.Hide()

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -178,16 +178,22 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 	valueEntry := widget.NewEntry()
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 
-	errorLabel := widget.NewLabel("")
-	errorLabel.TextStyle = fyne.TextStyle{Italic: true}
-	errorLabel.Hide()
+	regexIndicator := newRegexIndicator()
+
+	typeSelect.OnChanged = func(selected string) {
+		regexIndicator.update(selected, valueEntry.Text)
+	}
+	valueEntry.OnChanged = func(text string) {
+		regexIndicator.update(typeSelect.Selected, text)
+	}
 
 	form := container.NewVBox(
 		widget.NewForm(
 			widget.NewFormItem(i18n.T("config.rules_type"), typeSelect),
-			widget.NewFormItem(i18n.T("config.rules_value"), valueEntry),
+			widget.NewFormItem(i18n.T("config.rules_value"), container.NewBorder(
+				nil, nil, nil, regexIndicator.container, valueEntry,
+			)),
 		),
-		errorLabel,
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -215,8 +221,6 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 			// Validate regex
 			if typeSelect.Selected == linkquisition.BrowserMatchTypeRegex {
 				if _, err := regexp.Compile(valueEntry.Text); err != nil {
-					errorLabel.SetText(i18n.T("config.rules_regex_invalid"))
-					errorLabel.Show()
 					return
 				}
 			}
@@ -225,7 +229,7 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 220)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
 	d.Show()
 }
 
@@ -246,16 +250,24 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 	valueEntry.SetText(rule.Value)
 
-	errorLabel := widget.NewLabel("")
-	errorLabel.TextStyle = fyne.TextStyle{Italic: true}
-	errorLabel.Hide()
+	regexIndicator := newRegexIndicator()
+	// Initialize indicator state based on current rule
+	regexIndicator.update(rule.Type, rule.Value)
+
+	typeSelect.OnChanged = func(selected string) {
+		regexIndicator.update(selected, valueEntry.Text)
+	}
+	valueEntry.OnChanged = func(text string) {
+		regexIndicator.update(typeSelect.Selected, text)
+	}
 
 	form := container.NewVBox(
 		widget.NewForm(
 			widget.NewFormItem(i18n.T("config.rules_type"), typeSelect),
-			widget.NewFormItem(i18n.T("config.rules_value"), valueEntry),
+			widget.NewFormItem(i18n.T("config.rules_value"), container.NewBorder(
+				nil, nil, nil, regexIndicator.container, valueEntry,
+			)),
 		),
-		errorLabel,
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -280,8 +292,6 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 			// Validate regex
 			if typeSelect.Selected == linkquisition.BrowserMatchTypeRegex {
 				if _, err := regexp.Compile(valueEntry.Text); err != nil {
-					errorLabel.SetText(i18n.T("config.rules_regex_invalid"))
-					errorLabel.Show()
 					return
 				}
 			}
@@ -290,7 +300,7 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 220)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
 	d.Show()
 }
 
@@ -343,6 +353,54 @@ func (c *Configurator) deleteRule(browserIdx, ruleIdx int, listContainer *fyne.C
 	}
 
 	c.rebuildRulesList(listContainer, "")
+}
+
+const (
+	regexIndicatorSize = 12
+)
+
+// regexIndicator shows a colored dot next to the value entry when the rule
+// type is "regex". Green = valid regex, red = invalid regex. Hidden for
+// non-regex types.
+type regexIndicator struct {
+	dot       *canvas.Circle
+	container *fyne.Container
+}
+
+func newRegexIndicator() *regexIndicator {
+	dot := canvas.NewCircle(color.NRGBA{R: 0, G: 180, B: 0, A: 255})
+	dot.Resize(fyne.NewSize(regexIndicatorSize, regexIndicatorSize))
+
+	dotContainer := container.NewCenter(dot)
+	dotContainer.Hide()
+
+	return &regexIndicator{
+		dot:       dot,
+		container: dotContainer,
+	}
+}
+
+func (ri *regexIndicator) update(matchType, value string) {
+	if matchType != linkquisition.BrowserMatchTypeRegex {
+		ri.container.Hide()
+		return
+	}
+
+	ri.container.Show()
+
+	if value == "" {
+		ri.dot.FillColor = color.NRGBA{R: 180, G: 180, B: 0, A: 255} // yellow for empty
+		ri.dot.Refresh()
+		return
+	}
+
+	if _, err := regexp.Compile(value); err != nil {
+		ri.dot.FillColor = color.NRGBA{R: 220, G: 0, B: 0, A: 255} // red
+	} else {
+		ri.dot.FillColor = color.NRGBA{R: 0, G: 180, B: 0, A: 255} // green
+	}
+
+	ri.dot.Refresh()
 }
 
 // withSubtleBackground wraps a widget in a container with a very subtle

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -178,22 +178,23 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 	valueEntry := widget.NewEntry()
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 
-	regexIndicator := newRegexIndicator()
+	regexPanel := newRegexPanel()
 
 	typeSelect.OnChanged = func(selected string) {
-		regexIndicator.update(selected, valueEntry.Text)
+		regexPanel.update(selected, valueEntry.Text)
 	}
 	valueEntry.OnChanged = func(text string) {
-		regexIndicator.update(typeSelect.Selected, text)
+		regexPanel.update(typeSelect.Selected, text)
 	}
 
 	form := container.NewVBox(
 		widget.NewForm(
 			widget.NewFormItem(i18n.T("config.rules_type"), typeSelect),
 			widget.NewFormItem(i18n.T("config.rules_value"), container.NewBorder(
-				nil, nil, nil, regexIndicator.container, valueEntry,
+				nil, nil, nil, regexPanel.indicatorBox, valueEntry,
 			)),
 		),
+		regexPanel.panel,
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -229,7 +230,7 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 300)) //nolint:mnd
 	d.Show()
 }
 
@@ -250,24 +251,24 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 	valueEntry.SetText(rule.Value)
 
-	regexIndicator := newRegexIndicator()
-	// Initialize indicator state based on current rule
-	regexIndicator.update(rule.Type, rule.Value)
+	regexPanel := newRegexPanel()
+	regexPanel.update(rule.Type, rule.Value)
 
 	typeSelect.OnChanged = func(selected string) {
-		regexIndicator.update(selected, valueEntry.Text)
+		regexPanel.update(selected, valueEntry.Text)
 	}
 	valueEntry.OnChanged = func(text string) {
-		regexIndicator.update(typeSelect.Selected, text)
+		regexPanel.update(typeSelect.Selected, text)
 	}
 
 	form := container.NewVBox(
 		widget.NewForm(
 			widget.NewFormItem(i18n.T("config.rules_type"), typeSelect),
 			widget.NewFormItem(i18n.T("config.rules_value"), container.NewBorder(
-				nil, nil, nil, regexIndicator.container, valueEntry,
+				nil, nil, nil, regexPanel.indicatorBox, valueEntry,
 			)),
 		),
+		regexPanel.panel,
 	)
 
 	windows := c.fapp.Driver().AllWindows()
@@ -300,7 +301,7 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 		},
 		parentWindow,
 	)
-	d.Resize(fyne.NewSize(500, 200)) //nolint:mnd
+	d.Resize(fyne.NewSize(500, 300)) //nolint:mnd
 	d.Show()
 }
 
@@ -355,52 +356,126 @@ func (c *Configurator) deleteRule(browserIdx, ruleIdx int, listContainer *fyne.C
 	c.rebuildRulesList(listContainer, "")
 }
 
-// regexIndicator shows a ✓ or ✗ next to the value entry when the rule
-// type is "regex". Green ✓ = valid regex, red ✗ = invalid regex. Hidden for
-// non-regex types.
-type regexIndicator struct {
-	label     *canvas.Text
-	container *fyne.Container
+// regexPanel provides live regex validation and test-matching UI.
+// Hidden for non-regex rule types. Shows:
+// 1. ✓/✗ indicator next to the value entry
+// 2. Error message below value when invalid
+// 3. A test URL input with match result indicator
+type regexPanel struct {
+	indicator     *canvas.Text
+	indicatorBox  *fyne.Container
+	errorLabel    *widget.Label
+	testEntry     *widget.Entry
+	testResult    *canvas.Text
+	testResultBox *fyne.Container
+	panel         *fyne.Container
+	pattern       string
 }
 
-func newRegexIndicator() *regexIndicator {
-	label := canvas.NewText("✓", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
-	label.TextSize = 18 //nolint:mnd
-	label.TextStyle = fyne.TextStyle{Bold: true}
+func newRegexPanel() *regexPanel {
+	// Indicator next to value entry
+	indicator := canvas.NewText("✓", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
+	indicator.TextSize = 18 //nolint:mnd
+	indicator.TextStyle = fyne.TextStyle{Bold: true}
+	indicatorBox := container.NewCenter(indicator)
+	indicatorBox.Hide()
 
-	labelContainer := container.NewCenter(label)
-	labelContainer.Hide()
+	// Error label shown below value when regex is invalid
+	errorLabel := widget.NewLabel("")
+	errorLabel.TextStyle = fyne.TextStyle{Italic: true}
+	errorLabel.Hide()
 
-	return &regexIndicator{
-		label:     label,
-		container: labelContainer,
+	// Test URL entry
+	testEntry := widget.NewEntry()
+	testEntry.SetPlaceHolder(i18n.T("config.rules_regex_test_placeholder"))
+
+	// Test match result
+	testResult := canvas.NewText("", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
+	testResult.TextSize = 14 //nolint:mnd
+	testResult.TextStyle = fyne.TextStyle{Bold: true}
+	testResultBox := container.NewHBox(testResult)
+	testResultBox.Hide()
+
+	// Full panel (everything below the value entry)
+	panel := container.NewVBox(errorLabel, testEntry, testResultBox)
+	panel.Hide()
+
+	rp := &regexPanel{
+		indicator:     indicator,
+		indicatorBox:  indicatorBox,
+		errorLabel:    errorLabel,
+		testEntry:     testEntry,
+		testResult:    testResult,
+		testResultBox: testResultBox,
+		panel:         panel,
 	}
+
+	testEntry.OnChanged = func(_ string) {
+		rp.refreshTestResult()
+	}
+
+	return rp
 }
 
-func (ri *regexIndicator) update(matchType, value string) {
+func (rp *regexPanel) update(matchType, value string) {
 	if matchType != linkquisition.BrowserMatchTypeRegex {
-		ri.container.Hide()
+		rp.indicatorBox.Hide()
+		rp.panel.Hide()
 		return
 	}
 
-	ri.container.Show()
+	rp.pattern = value
+	rp.indicatorBox.Show()
+	rp.panel.Show()
 
 	if value == "" {
-		ri.label.Text = "—"
-		ri.label.Color = color.NRGBA{R: 150, G: 150, B: 150, A: 255} // grey for empty
-		ri.label.Refresh()
+		rp.indicator.Text = "—"
+		rp.indicator.Color = color.NRGBA{R: 150, G: 150, B: 150, A: 255}
+		rp.indicator.Refresh()
+		rp.errorLabel.Hide()
+		rp.refreshTestResult()
 		return
 	}
 
 	if _, err := regexp.Compile(value); err != nil {
-		ri.label.Text = "✗"
-		ri.label.Color = color.NRGBA{R: 220, G: 0, B: 0, A: 255} // red
+		rp.indicator.Text = "✗"
+		rp.indicator.Color = color.NRGBA{R: 220, G: 0, B: 0, A: 255}
+		rp.errorLabel.SetText("✗ " + i18n.T("config.rules_regex_invalid"))
+		rp.errorLabel.Show()
 	} else {
-		ri.label.Text = "✓"
-		ri.label.Color = color.NRGBA{R: 0, G: 180, B: 0, A: 255} // green
+		rp.indicator.Text = "✓"
+		rp.indicator.Color = color.NRGBA{R: 0, G: 180, B: 0, A: 255}
+		rp.errorLabel.Hide()
 	}
 
-	ri.label.Refresh()
+	rp.indicator.Refresh()
+	rp.refreshTestResult()
+}
+
+func (rp *regexPanel) refreshTestResult() {
+	testURL := rp.testEntry.Text
+	if testURL == "" {
+		rp.testResultBox.Hide()
+		return
+	}
+
+	re, err := regexp.Compile(rp.pattern)
+	if err != nil || rp.pattern == "" {
+		rp.testResultBox.Hide()
+		return
+	}
+
+	rp.testResultBox.Show()
+
+	if re.MatchString(testURL) {
+		rp.testResult.Text = "✓ " + i18n.T("config.rules_regex_match")
+		rp.testResult.Color = color.NRGBA{R: 0, G: 180, B: 0, A: 255}
+	} else {
+		rp.testResult.Text = "✗ " + i18n.T("config.rules_regex_no_match")
+		rp.testResult.Color = color.NRGBA{R: 220, G: 0, B: 0, A: 255}
+	}
+
+	rp.testResult.Refresh()
 }
 
 // withSubtleBackground wraps a widget in a container with a very subtle

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -186,6 +186,7 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 	parentWindow := windows[0]
 
 	regexPanel := newRegexPanel(parentWindow)
+	regexPanel.update(linkquisition.BrowserMatchTypeSite, "")
 
 	typeSelect.OnChanged = func(selected string) {
 		regexPanel.update(selected, valueEntry.Text)

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
@@ -151,11 +152,17 @@ func (c *Configurator) buildRuleRow(
 	valueLabel := widget.NewLabel(rule.Value)
 	valueLabel.Truncation = fyne.TextTruncateEllipsis
 
-	deleteBtn := widget.NewButton("🗑", func() {
+	editBtn := widget.NewButtonWithIcon("", theme.DocumentCreateIcon(), func() {
+		c.showEditRuleDialog(browserIdx, ruleIdx, listContainer)
+	})
+
+	deleteBtn := widget.NewButtonWithIcon("", theme.DeleteIcon(), func() {
 		c.deleteRule(browserIdx, ruleIdx, listContainer)
 	})
 
-	return container.NewBorder(nil, nil, typeLabel, deleteBtn, valueLabel)
+	buttons := container.NewHBox(editBtn, deleteBtn)
+
+	return container.NewBorder(nil, nil, typeLabel, buttons, valueLabel)
 }
 
 func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Container) {
@@ -220,6 +227,89 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 	)
 	d.Resize(fyne.NewSize(500, 220)) //nolint:mnd
 	d.Show()
+}
+
+func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer *fyne.Container) {
+	settings := c.settingsService.GetSettings()
+	rule := settings.Browsers[browserIdx].Matches[ruleIdx]
+
+	ruleTypes := []string{
+		linkquisition.BrowserMatchTypeSite,
+		linkquisition.BrowserMatchTypeDomain,
+		linkquisition.BrowserMatchTypeRegex,
+	}
+
+	typeSelect := widget.NewSelect(ruleTypes, nil)
+	typeSelect.SetSelected(rule.Type)
+
+	valueEntry := widget.NewEntry()
+	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
+	valueEntry.SetText(rule.Value)
+
+	errorLabel := widget.NewLabel("")
+	errorLabel.TextStyle = fyne.TextStyle{Italic: true}
+	errorLabel.Hide()
+
+	form := container.NewVBox(
+		widget.NewForm(
+			widget.NewFormItem(i18n.T("config.rules_type"), typeSelect),
+			widget.NewFormItem(i18n.T("config.rules_value"), valueEntry),
+		),
+		errorLabel,
+	)
+
+	windows := c.fapp.Driver().AllWindows()
+	if len(windows) == 0 {
+		return
+	}
+	parentWindow := windows[0]
+
+	d := dialog.NewCustomConfirm(
+		i18n.T("config.rules_edit_title"),
+		i18n.T("config.plugins_save"),
+		i18n.T("config.plugins_cancel"),
+		form,
+		func(save bool) {
+			if !save {
+				return
+			}
+			if valueEntry.Text == "" {
+				return
+			}
+
+			// Validate regex
+			if typeSelect.Selected == linkquisition.BrowserMatchTypeRegex {
+				if _, err := regexp.Compile(valueEntry.Text); err != nil {
+					errorLabel.SetText(i18n.T("config.rules_regex_invalid"))
+					errorLabel.Show()
+					return
+				}
+			}
+
+			c.updateRule(browserIdx, ruleIdx, typeSelect.Selected, valueEntry.Text, listContainer)
+		},
+		parentWindow,
+	)
+	d.Resize(fyne.NewSize(500, 220)) //nolint:mnd
+	d.Show()
+}
+
+func (c *Configurator) updateRule(
+	browserIdx, ruleIdx int, matchType, matchValue string, listContainer *fyne.Container,
+) {
+	settings := c.settingsService.GetSettings()
+
+	settings.Browsers[browserIdx].Matches[ruleIdx] = linkquisition.BrowserMatch{
+		Type:  matchType,
+		Value: matchValue,
+	}
+
+	if err := c.settingsService.WriteSettings(settings); err != nil {
+		c.logger.Error("Error updating rule", "error", err)
+		return
+	}
+
+	c.rebuildRulesList(listContainer, "")
 }
 
 func (c *Configurator) addRule(browserIdx int, matchType, matchValue string, listContainer *fyne.Container) {

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -355,28 +355,25 @@ func (c *Configurator) deleteRule(browserIdx, ruleIdx int, listContainer *fyne.C
 	c.rebuildRulesList(listContainer, "")
 }
 
-const (
-	regexIndicatorSize = 12
-)
-
-// regexIndicator shows a colored dot next to the value entry when the rule
-// type is "regex". Green = valid regex, red = invalid regex. Hidden for
+// regexIndicator shows a ✓ or ✗ next to the value entry when the rule
+// type is "regex". Green ✓ = valid regex, red ✗ = invalid regex. Hidden for
 // non-regex types.
 type regexIndicator struct {
-	dot       *canvas.Circle
+	label     *canvas.Text
 	container *fyne.Container
 }
 
 func newRegexIndicator() *regexIndicator {
-	dot := canvas.NewCircle(color.NRGBA{R: 0, G: 180, B: 0, A: 255})
-	dot.Resize(fyne.NewSize(regexIndicatorSize, regexIndicatorSize))
+	label := canvas.NewText("✓", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
+	label.TextSize = 18 //nolint:mnd
+	label.TextStyle = fyne.TextStyle{Bold: true}
 
-	dotContainer := container.NewCenter(dot)
-	dotContainer.Hide()
+	labelContainer := container.NewCenter(label)
+	labelContainer.Hide()
 
 	return &regexIndicator{
-		dot:       dot,
-		container: dotContainer,
+		label:     label,
+		container: labelContainer,
 	}
 }
 
@@ -389,18 +386,21 @@ func (ri *regexIndicator) update(matchType, value string) {
 	ri.container.Show()
 
 	if value == "" {
-		ri.dot.FillColor = color.NRGBA{R: 180, G: 180, B: 0, A: 255} // yellow for empty
-		ri.dot.Refresh()
+		ri.label.Text = "—"
+		ri.label.Color = color.NRGBA{R: 150, G: 150, B: 150, A: 255} // grey for empty
+		ri.label.Refresh()
 		return
 	}
 
 	if _, err := regexp.Compile(value); err != nil {
-		ri.dot.FillColor = color.NRGBA{R: 220, G: 0, B: 0, A: 255} // red
+		ri.label.Text = "✗"
+		ri.label.Color = color.NRGBA{R: 220, G: 0, B: 0, A: 255} // red
 	} else {
-		ri.dot.FillColor = color.NRGBA{R: 0, G: 180, B: 0, A: 255} // green
+		ri.label.Text = "✓"
+		ri.label.Color = color.NRGBA{R: 0, G: 180, B: 0, A: 255} // green
 	}
 
-	ri.dot.Refresh()
+	ri.label.Refresh()
 }
 
 // withSubtleBackground wraps a widget in a container with a very subtle

--- a/cmd/configurator_rules.go
+++ b/cmd/configurator_rules.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"image/color"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -16,6 +15,7 @@ import (
 
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
+	"github.com/strobotti/linkquisition/internal/ui"
 )
 
 func (c *Configurator) getRulesTab() fyne.CanvasObject {
@@ -179,7 +179,13 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 	valueEntry := widget.NewEntry()
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 
-	regexPanel := newRegexPanel()
+	windows := c.fapp.Driver().AllWindows()
+	if len(windows) == 0 {
+		return
+	}
+	parentWindow := windows[0]
+
+	regexPanel := newRegexPanel(parentWindow)
 
 	typeSelect.OnChanged = func(selected string) {
 		regexPanel.update(selected, valueEntry.Text)
@@ -197,12 +203,6 @@ func (c *Configurator) showAddRuleDialog(browserIdx int, listContainer *fyne.Con
 		),
 		regexPanel.panel,
 	)
-
-	windows := c.fapp.Driver().AllWindows()
-	if len(windows) == 0 {
-		return
-	}
-	parentWindow := windows[0]
 
 	settings := c.settingsService.GetSettings()
 	browserName := settings.Browsers[browserIdx].Name
@@ -252,7 +252,13 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 	valueEntry.SetPlaceHolder(i18n.T("config.rules_value_placeholder"))
 	valueEntry.SetText(rule.Value)
 
-	regexPanel := newRegexPanel()
+	windows := c.fapp.Driver().AllWindows()
+	if len(windows) == 0 {
+		return
+	}
+	parentWindow := windows[0]
+
+	regexPanel := newRegexPanel(parentWindow)
 	regexPanel.update(rule.Type, rule.Value)
 
 	typeSelect.OnChanged = func(selected string) {
@@ -271,12 +277,6 @@ func (c *Configurator) showEditRuleDialog(browserIdx, ruleIdx int, listContainer
 		),
 		regexPanel.panel,
 	)
-
-	windows := c.fapp.Driver().AllWindows()
-	if len(windows) == 0 {
-		return
-	}
-	parentWindow := windows[0]
 
 	d := dialog.NewCustomConfirm(
 		i18n.T("config.rules_edit_title"),
@@ -373,7 +373,7 @@ type regexPanel struct {
 	pattern       string
 }
 
-func newRegexPanel() *regexPanel {
+func newRegexPanel(w fyne.Window) *regexPanel {
 	// Indicator next to value entry
 	indicator := canvas.NewText("✓", color.NRGBA{R: 0, G: 180, B: 0, A: 255})
 	indicator.TextSize = 18 //nolint:mnd
@@ -400,8 +400,8 @@ func newRegexPanel() *regexPanel {
 	// Help text with link to regex reference
 	helpLabel := widget.NewLabel(i18n.T("config.rules_regex_help"))
 	helpLabel.TextStyle = fyne.TextStyle{Italic: true}
-	regexDocsURL, _ := url.Parse("https://pkg.go.dev/regexp/syntax")
-	helpLink := widget.NewHyperlink(i18n.T("config.rules_regex_help_link"), regexDocsURL)
+	regexDocsURL := "https://pkg.go.dev/regexp/syntax"
+	helpLink := ui.NewLinkWithCopy(i18n.T("config.rules_regex_help_link"), regexDocsURL, w)
 	helpRow := container.NewHBox(helpLabel, helpLink)
 
 	// Full panel (everything below the value entry)

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -30,7 +30,7 @@ func TestT_WithTemplateData(t *testing.T) {
 	Init("en")
 
 	got := T("picker.remember_choice")
-	want := "Remember this choice for:"
+	want := "Remember this choice"
 
 	if got != want {
 		t.Errorf("T(\"picker.remember_choice\") = %q, want %q", got, want)
@@ -88,7 +88,7 @@ func TestInit_FinnishLocale_WithTemplateData(t *testing.T) {
 	Init("fi")
 
 	got := T("picker.remember_choice")
-	want := "Muista tämä valinta:"
+	want := "Muista tämä valinta"
 
 	if got != want {
 		t.Errorf("T(\"picker.remember_choice\") with fi locale = %q, want %q", got, want)

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -29,11 +29,25 @@ func TestInit_ExplicitOverride(t *testing.T) {
 func TestT_WithTemplateData(t *testing.T) {
 	Init("en")
 
-	got := T("picker.remember_choice", map[string]interface{}{"Site": "example.com"})
-	want := "Remember this choice with example.com"
+	got := T("picker.remember_choice")
+	want := "Remember this choice for:"
 
 	if got != want {
 		t.Errorf("T(\"picker.remember_choice\") = %q, want %q", got, want)
+	}
+
+	got = T("picker.remember_site", map[string]interface{}{"Site": "www.example.com"})
+	want = "www.example.com (this site only)"
+
+	if got != want {
+		t.Errorf("T(\"picker.remember_site\") = %q, want %q", got, want)
+	}
+
+	got = T("picker.remember_domain", map[string]interface{}{"Domain": "example.com"})
+	want = "example.com (entire domain)"
+
+	if got != want {
+		t.Errorf("T(\"picker.remember_domain\") = %q, want %q", got, want)
 	}
 }
 
@@ -73,11 +87,18 @@ func TestInit_FinnishLocale(t *testing.T) {
 func TestInit_FinnishLocale_WithTemplateData(t *testing.T) {
 	Init("fi")
 
-	got := T("picker.remember_choice", map[string]interface{}{"Site": "example.com"})
-	want := "Muista tämä valinta sivustolle example.com"
+	got := T("picker.remember_choice")
+	want := "Muista tämä valinta:"
 
 	if got != want {
 		t.Errorf("T(\"picker.remember_choice\") with fi locale = %q, want %q", got, want)
+	}
+
+	got = T("picker.remember_site", map[string]interface{}{"Site": "www.example.com"})
+	want = "www.example.com (vain tämä sivusto)"
+
+	if got != want {
+		t.Errorf("T(\"picker.remember_site\") with fi locale = %q, want %q", got, want)
 	}
 }
 

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Regel hinzufügen für {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Regel bearbeiten"
+  },
   "config.rules_type": {
     "other": "Typ"
   },

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Ungültiger regulärer Ausdruck"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Test-URL (z.B. https://www.example.com/seite)"
+  },
+  "config.rules_regex_match": {
+    "other": "Stimmt überein"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Stimmt nicht überein"
+  },
   "config.rules_filter_placeholder": {
     "other": "Regeln filtern..."
   },

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -63,7 +63,13 @@
     "other": "Kopieren"
   },
   "picker.remember_choice": {
-    "other": "Auswahl für {{.Site}} merken"
+    "other": "Auswahl merken für:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (nur diese Seite)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (gesamte Domain)"
   },
   "picker.keyboard_guide": {
     "other": "Drücke 'ENTER' für den ersten, 'ESC' zum Beenden, '{{.CopyShortcut}}' um die URL zu kopieren"

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Syntaxreferenz"
   },
+  "config.rules_type_help_site": {
+    "other": "Stimmt mit dem vollständigen Hostnamen überein (z.B. www.example.com). Stimmt nicht mit Subdomains wie blog.example.com überein."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Stimmt mit der registrierten Domain und allen Subdomains überein (z.B. example.com passt zu www.example.com, blog.example.com usw.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Gleicht die vollständige URL mit einem Go RE2 regulären Ausdruck ab. Verwenden Sie .* als Platzhalter."
+  },
   "config.rules_filter_placeholder": {
     "other": "Regeln filtern..."
   },

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -63,7 +63,7 @@
     "other": "Kopieren"
   },
   "picker.remember_choice": {
-    "other": "Auswahl merken für:"
+    "other": "Auswahl merken"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (nur diese Seite)"

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Stimmt nicht überein"
   },
+  "config.rules_regex_help": {
+    "other": "Verwendet Go RE2-Syntax."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Syntaxreferenz"
+  },
   "config.rules_filter_placeholder": {
     "other": "Regeln filtern..."
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Add Rule to {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Edit Rule"
+  },
   "config.rules_type": {
     "other": "Type"
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Does not match"
   },
+  "config.rules_regex_help": {
+    "other": "Uses Go RE2 syntax."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Syntax reference"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filter rules..."
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -63,7 +63,13 @@
     "other": "Copy"
   },
   "picker.remember_choice": {
-    "other": "Remember this choice with {{.Site}}"
+    "other": "Remember this choice for:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (this site only)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (entire domain)"
   },
   "picker.keyboard_guide": {
     "other": "Press 'ENTER' to pick first, 'ESC' to quit, '{{.CopyShortcut}}' to copy URL to clipboard"

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -63,7 +63,7 @@
     "other": "Copy"
   },
   "picker.remember_choice": {
-    "other": "Remember this choice for:"
+    "other": "Remember this choice"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (this site only)"

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Syntax reference"
   },
+  "config.rules_type_help_site": {
+    "other": "Matches the full hostname (e.g. www.example.com). Does not match subdomains like blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Matches the registered domain and all its subdomains (e.g. example.com matches www.example.com, blog.example.com, etc.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Matches the full URL against a Go RE2 regular expression. Use .* for wildcards."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filter rules..."
   },

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Invalid regular expression"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Test URL (e.g. https://www.example.com/page)"
+  },
+  "config.rules_regex_match": {
+    "other": "Matches"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Does not match"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filter rules..."
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -63,7 +63,7 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Recordar esta elección para:"
+    "other": "Recordar esta elección"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (solo este sitio)"

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Referencia de sintaxis"
   },
+  "config.rules_type_help_site": {
+    "other": "Coincide con el nombre de host completo (ej. www.example.com). No coincide con subdominios como blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Coincide con el dominio registrado y todos sus subdominios (ej. example.com coincide con www.example.com, blog.example.com, etc.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Compara la URL completa con una expresión regular Go RE2. Use .* como comodín."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar reglas..."
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Expresión regular no válida"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "URL de prueba (ej. https://www.example.com/pagina)"
+  },
+  "config.rules_regex_match": {
+    "other": "Coincide"
+  },
+  "config.rules_regex_no_match": {
+    "other": "No coincide"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar reglas..."
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -63,7 +63,13 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Recordar esta elección para {{.Site}}"
+    "other": "Recordar esta elección para:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (solo este sitio)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (todo el dominio)"
   },
   "picker.keyboard_guide": {
     "other": "Pulsa 'ENTER' para elegir el primero, 'ESC' para salir, '{{.CopyShortcut}}' para copiar la URL al portapapeles"

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "No coincide"
   },
+  "config.rules_regex_help": {
+    "other": "Usa sintaxis Go RE2."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Referencia de sintaxis"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar reglas..."
   },

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Añadir regla a {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Editar regla"
+  },
   "config.rules_type": {
     "other": "Tipo"
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -63,7 +63,13 @@
     "other": "Kopioi"
   },
   "picker.remember_choice": {
-    "other": "Muista tämä valinta sivustolle {{.Site}}"
+    "other": "Muista tämä valinta:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (vain tämä sivusto)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (koko verkkotunnus)"
   },
   "picker.keyboard_guide": {
     "other": "Paina 'ENTER' valitaksesi ensimmäisen, 'ESC' sulkeaksesi, '{{.CopyShortcut}}' kopioidaksesi URL:n leikepöydälle"

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Virheellinen säännöllinen lauseke"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Testi-URL (esim. https://www.example.com/sivu)"
+  },
+  "config.rules_regex_match": {
+    "other": "Täsmää"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Ei täsmää"
+  },
   "config.rules_filter_placeholder": {
     "other": "Suodata sääntöjä..."
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Syntaksiohje"
   },
+  "config.rules_type_help_site": {
+    "other": "Täsmää tarkkaan isäntänimeen (esim. www.example.com). Ei täsmää aliverkkotunnuksiin kuten blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Täsmää rekisteröityyn verkkotunnukseen ja kaikkiin sen aliverkkotunnuksiin (esim. example.com täsmää www.example.com, blog.example.com jne.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Täsmää koko URL-osoitteen Go RE2 -säännölliseen lausekkeeseen. Käytä .* jokerimerkkeinä."
+  },
   "config.rules_filter_placeholder": {
     "other": "Suodata sääntöjä..."
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Ei täsmää"
   },
+  "config.rules_regex_help": {
+    "other": "Käyttää Go RE2 -syntaksia."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Syntaksiohje"
+  },
   "config.rules_filter_placeholder": {
     "other": "Suodata sääntöjä..."
   },

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -63,7 +63,7 @@
     "other": "Kopioi"
   },
   "picker.remember_choice": {
-    "other": "Muista tämä valinta:"
+    "other": "Muista tämä valinta"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (vain tämä sivusto)"

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Lisää sääntö selaimelle {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Muokkaa sääntöä"
+  },
   "config.rules_type": {
     "other": "Tyyppi"
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Ajouter une règle à {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Modifier la règle"
+  },
   "config.rules_type": {
     "other": "Type"
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -63,7 +63,7 @@
     "other": "Copier"
   },
   "picker.remember_choice": {
-    "other": "Se souvenir de ce choix pour :"
+    "other": "Se souvenir de ce choix"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (ce site uniquement)"

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -63,7 +63,13 @@
     "other": "Copier"
   },
   "picker.remember_choice": {
-    "other": "Se souvenir de ce choix pour {{.Site}}"
+    "other": "Se souvenir de ce choix pour :"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (ce site uniquement)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (tout le domaine)"
   },
   "picker.keyboard_guide": {
     "other": "Appuyez sur 'ENTRÉE' pour le premier, 'ÉCHAP' pour quitter, '{{.CopyShortcut}}' pour copier l'URL"

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Ne correspond pas"
   },
+  "config.rules_regex_help": {
+    "other": "Utilise la syntaxe Go RE2."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Référence syntaxique"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrer les règles..."
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Expression régulière invalide"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "URL de test (ex. https://www.example.com/page)"
+  },
+  "config.rules_regex_match": {
+    "other": "Correspond"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Ne correspond pas"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrer les règles..."
   },

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Référence syntaxique"
   },
+  "config.rules_type_help_site": {
+    "other": "Correspond au nom d'hôte complet (ex. www.example.com). Ne correspond pas aux sous-domaines comme blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Correspond au domaine enregistré et tous ses sous-domaines (ex. example.com correspond à www.example.com, blog.example.com, etc.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Compare l'URL complète à une expression régulière Go RE2. Utilisez .* comme joker."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrer les règles..."
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Szintaxis referencia"
   },
+  "config.rules_type_help_site": {
+    "other": "A teljes gazdanévvel egyezik (pl. www.example.com). Nem egyezik aldomainekkel, mint blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "A regisztrált domainnel és összes aldomainjével egyezik (pl. example.com egyezik a www.example.com, blog.example.com stb. címekkel)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "A teljes URL-t Go RE2 reguláris kifejezéssel hasonlítja össze. Használjon .*-ot helyettesítő karakterként."
+  },
   "config.rules_filter_placeholder": {
     "other": "Szabályok szűrése..."
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -63,7 +63,7 @@
     "other": "Másolás"
   },
   "picker.remember_choice": {
-    "other": "Választás megjegyzése:"
+    "other": "Választás megjegyzése"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (csak ez a webhely)"

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Érvénytelen reguláris kifejezés"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Teszt URL (pl. https://www.example.com/oldal)"
+  },
+  "config.rules_regex_match": {
+    "other": "Egyezik"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Nem egyezik"
+  },
   "config.rules_filter_placeholder": {
     "other": "Szabályok szűrése..."
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -63,7 +63,13 @@
     "other": "Másolás"
   },
   "picker.remember_choice": {
-    "other": "Választás megjegyzése a(z) {{.Site}} webhelyhez"
+    "other": "Választás megjegyzése:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (csak ez a webhely)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (teljes domain)"
   },
   "picker.keyboard_guide": {
     "other": "Nyomj 'ENTER'-t az első kiválasztásához, 'ESC'-t a kilépéshez, '{{.CopyShortcut}}'-t az URL vágólapra másolásához"

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Nem egyezik"
   },
+  "config.rules_regex_help": {
+    "other": "Go RE2 szintaxist használ."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Szintaxis referencia"
+  },
   "config.rules_filter_placeholder": {
     "other": "Szabályok szűrése..."
   },

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Szabály hozzáadása: {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Szabály szerkesztése"
+  },
   "config.rules_type": {
     "other": "Típus"
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -63,7 +63,7 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Lembrar esta escolha para:"
+    "other": "Lembrar esta escolha"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (somente este site)"

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Não corresponde"
   },
+  "config.rules_regex_help": {
+    "other": "Usa sintaxe Go RE2."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Referência de sintaxe"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Expressão regular inválida"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "URL de teste (ex. https://www.example.com/pagina)"
+  },
+  "config.rules_regex_match": {
+    "other": "Corresponde"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Não corresponde"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Adicionar regra para {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Editar regra"
+  },
   "config.rules_type": {
     "other": "Tipo"
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Referência de sintaxe"
   },
+  "config.rules_type_help_site": {
+    "other": "Corresponde ao nome de host completo (ex. www.example.com). Não corresponde a subdomínios como blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Corresponde ao domínio registrado e todos os seus subdomínios (ex. example.com corresponde a www.example.com, blog.example.com, etc.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Compara a URL completa com uma expressão regular Go RE2. Use .* como curinga."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -63,7 +63,13 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Lembrar esta escolha para {{.Site}}"
+    "other": "Lembrar esta escolha para:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (somente este site)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (todo o domínio)"
   },
   "picker.keyboard_guide": {
     "other": "Pressione 'ENTER' para o primeiro, 'ESC' para sair, '{{.CopyShortcut}}' para copiar a URL"

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Referência de sintaxe"
   },
+  "config.rules_type_help_site": {
+    "other": "Corresponde ao nome de host completo (ex. www.example.com). Não corresponde a subdomínios como blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Corresponde ao domínio registado e todos os seus subdomínios (ex. example.com corresponde a www.example.com, blog.example.com, etc.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Compara o URL completo com uma expressão regular Go RE2. Use .* como caractere universal."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Não corresponde"
   },
+  "config.rules_regex_help": {
+    "other": "Usa sintaxe Go RE2."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Referência de sintaxe"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Expressão regular inválida"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "URL de teste (ex. https://www.example.com/pagina)"
+  },
+  "config.rules_regex_match": {
+    "other": "Corresponde"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Não corresponde"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrar regras..."
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -63,7 +63,13 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Lembrar esta escolha para {{.Site}}"
+    "other": "Lembrar esta escolha para:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (apenas este site)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (todo o domínio)"
   },
   "picker.keyboard_guide": {
     "other": "Prima 'ENTER' para o primeiro, 'ESC' para sair, '{{.CopyShortcut}}' para copiar o URL"

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Adicionar regra para {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Editar regra"
+  },
   "config.rules_type": {
     "other": "Tipo"
   },

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -63,7 +63,7 @@
     "other": "Copiar"
   },
   "picker.remember_choice": {
-    "other": "Lembrar esta escolha para:"
+    "other": "Lembrar esta escolha"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (apenas este site)"

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Lägg till regel för {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Redigera regel"
+  },
   "config.rules_type": {
     "other": "Typ"
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -63,7 +63,7 @@
     "other": "Kopiera"
   },
   "picker.remember_choice": {
-    "other": "Kom ihåg detta val för:"
+    "other": "Kom ihåg detta val"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (bara denna webbplats)"

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Syntaxreferens"
   },
+  "config.rules_type_help_site": {
+    "other": "Matchar det fullständiga värdnamnet (t.ex. www.example.com). Matchar inte subdomäner som blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Matchar den registrerade domänen och alla dess subdomäner (t.ex. example.com matchar www.example.com, blog.example.com osv.)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Matchar hela URL:en mot ett Go RE2 reguljärt uttryck. Använd .* som jokertecken."
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrera regler..."
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Ogiltigt reguljärt uttryck"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Test-URL (t.ex. https://www.example.com/sida)"
+  },
+  "config.rules_regex_match": {
+    "other": "Matchar"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Matchar inte"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrera regler..."
   },

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -63,7 +63,13 @@
     "other": "Kopiera"
   },
   "picker.remember_choice": {
-    "other": "Kom ihåg detta val för {{.Site}}"
+    "other": "Kom ihåg detta val för:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (bara denna webbplats)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (hela domänen)"
   },
   "picker.keyboard_guide": {
     "other": "Tryck 'ENTER' för att välja första, 'ESC' för att avsluta, '{{.CopyShortcut}}' för att kopiera URL till urklipp"

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Matchar inte"
   },
+  "config.rules_regex_help": {
+    "other": "Använder Go RE2-syntax."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Syntaxreferens"
+  },
   "config.rules_filter_placeholder": {
     "other": "Filtrera regler..."
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -287,6 +287,15 @@
   "config.rules_regex_help_link": {
     "other": "Довідка з синтаксису"
   },
+  "config.rules_type_help_site": {
+    "other": "Збігається з повним іменем хоста (напр. www.example.com). Не збігається з піддоменами, як blog.example.com."
+  },
+  "config.rules_type_help_domain": {
+    "other": "Збігається з зареєстрованим доменом та всіма його піддоменами (напр. example.com збігається з www.example.com, blog.example.com тощо)."
+  },
+  "config.rules_type_help_regex": {
+    "other": "Порівнює повну URL-адресу з регулярним виразом Go RE2. Використовуйте .* як підстановку."
+  },
   "config.rules_filter_placeholder": {
     "other": "Фільтрувати правила..."
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -281,6 +281,12 @@
   "config.rules_regex_no_match": {
     "other": "Не збігається"
   },
+  "config.rules_regex_help": {
+    "other": "Використовує синтаксис Go RE2."
+  },
+  "config.rules_regex_help_link": {
+    "other": "Довідка з синтаксису"
+  },
   "config.rules_filter_placeholder": {
     "other": "Фільтрувати правила..."
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -63,7 +63,13 @@
     "other": "Копіювати"
   },
   "picker.remember_choice": {
-    "other": "Запам'ятати цей вибір для {{.Site}}"
+    "other": "Запам'ятати цей вибір для:"
+  },
+  "picker.remember_site": {
+    "other": "{{.Site}} (лише цей сайт)"
+  },
+  "picker.remember_domain": {
+    "other": "{{.Domain}} (весь домен)"
   },
   "picker.keyboard_guide": {
     "other": "Натисніть 'ENTER' для першого, 'ESC' для виходу, '{{.CopyShortcut}}' для копіювання URL"

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -254,6 +254,9 @@
   "config.rules_add_title": {
     "other": "Додати правило для {{.Name}}"
   },
+  "config.rules_edit_title": {
+    "other": "Редагувати правило"
+  },
   "config.rules_type": {
     "other": "Тип"
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -272,6 +272,15 @@
   "config.rules_regex_invalid": {
     "other": "Недійсний регулярний вираз"
   },
+  "config.rules_regex_test_placeholder": {
+    "other": "Тестова URL (напр. https://www.example.com/сторінка)"
+  },
+  "config.rules_regex_match": {
+    "other": "Збігається"
+  },
+  "config.rules_regex_no_match": {
+    "other": "Не збігається"
+  },
   "config.rules_filter_placeholder": {
     "other": "Фільтрувати правила..."
   },

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -63,7 +63,7 @@
     "other": "Копіювати"
   },
   "picker.remember_choice": {
-    "other": "Запам'ятати цей вибір для:"
+    "other": "Запам'ятати цей вибір"
   },
   "picker.remember_site": {
     "other": "{{.Site}} (лише цей сайт)"


### PR DESCRIPTION
Add the ability to choose between "site" and "domain" match types when remembering a browser choice from the picker. Previously, the remember feature always saved a site-level rule.

**Picker changes:**
- Replace the single checkbox with a checkbox + radio group that lets users choose between remembering by exact hostname (site) or registered domain (all subdomains)
- Radio options are hidden until the checkbox is ticked; when site == domain (no subdomain), the simple checkbox is shown instead
- Default remains "site" to preserve existing behavior

**Rules tab improvements:**
- Add edit button (pencil icon) to each rule row
- Add contextual help text that explains what each rule type does (site, domain, regex)
- Add live regex validation with ✓/✗ indicator
- Add regex test URL input with live match result feedback
- Add "Syntax reference" link to Go RE2 docs using `ui.NewLinkWithCopy`

All new strings translated in all 10 supported locales.