### PR TITLE
fix: hide "no browsers configured" warning on General tab after scanning

### DIFF
--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -28,6 +28,10 @@ type Configurator struct {
 	browserService  linkquisition.BrowserService
 	settingsService linkquisition.SettingsService
 	logger          *slog.Logger
+
+	// noBrowsersWarning holds the warning container shown on the General tab
+	// when no browsers are configured. It is hidden after a successful scan.
+	noBrowsersWarning fyne.CanvasObject
 }
 
 func NewConfigurator(
@@ -95,8 +99,8 @@ func (c *Configurator) getGeneralTab() fyne.CanvasObject {
 
 	// Onboarding: show a warning if no browsers are configured
 	if settings := c.settingsService.GetSettings(); len(settings.Browsers) == 0 {
-		sections.Add(c.buildNoBrowsersWarning())
-		sections.Add(widget.NewSeparator())
+		c.noBrowsersWarning = container.NewVBox(c.buildNoBrowsersWarning(), widget.NewSeparator())
+		sections.Add(c.noBrowsersWarning)
 	}
 
 	sections.Add(c.buildLanguageSection())
@@ -121,6 +125,13 @@ func (c *Configurator) buildNoBrowsersWarning() fyne.CanvasObject {
 	warningLabel.TextStyle = fyne.TextStyle{Bold: true}
 
 	return container.NewVBox(warningLabel)
+}
+
+func (c *Configurator) hideNoBrowsersWarning() {
+	if c.noBrowsersWarning != nil {
+		c.noBrowsersWarning.Hide()
+		c.noBrowsersWarning = nil
+	}
 }
 
 func (c *Configurator) buildMakeDefaultSection() fyne.CanvasObject {

--- a/cmd/configurator_browsers.go
+++ b/cmd/configurator_browsers.go
@@ -394,6 +394,7 @@ func (c *Configurator) scanBrowsersAndRebuild(listContainer *fyne.Container, btn
 		}
 		fyne.Do(func() {
 			btn.SetText(i18n.T("config.scan_browsers_done"))
+			c.hideNoBrowsersWarning()
 		})
 		time.AfterFunc(time.Second, func() {
 			fyne.Do(func() { c.rebuildBrowsersList(listContainer) })


### PR DESCRIPTION
The "no browsers configured" warning on the General tab was never removed after scanning browsers — it persisted until the app was restarted. Now the warning hides immediately after a successful scan.