### PR TITLE
feat: plugin settings UX improvements — defaults, metadata display, and reset button

### DIFF
--- a/cmd/cmd_plugin.go
+++ b/cmd/cmd_plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -227,10 +228,18 @@ func runPluginAdd(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("plugin file %q not found in %s", pluginFile, pluginDir)
 	}
 
-	// Add with default settings (just the path, enabled, no custom settings)
+	// Probe plugin metadata to get default settings
+	var pluginSettings map[string]interface{}
+	discardLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	meta, err := probePluginMetadata(pluginPath, discardLogger)
+	if err == nil && len(meta.Settings) > 0 {
+		pluginSettings = buildDefaultSettingsFromMetadata(&meta)
+	}
+
 	settings.Plugins = append(settings.Plugins, linkquisition.PluginSettings{
 		Path:       pluginFile,
 		IsDisabled: false,
+		Settings:   pluginSettings,
 	})
 
 	if err := settingsService.WriteSettings(settings); err != nil {

--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
+	"github.com/strobotti/linkquisition/internal/ui"
 )
 
 // buildDefaultSettingsFromMetadata constructs a settings map populated with default values
@@ -38,6 +39,44 @@ func buildDefaultSettingsFromMetadata(meta *linkquisition.PluginMetadata) map[st
 		}
 	}
 	return defaults
+}
+
+// buildPluginMetadataHeader creates a header section displaying plugin description,
+// author, and homepage URL. Empty optional fields are omitted.
+func (c *Configurator) buildPluginMetadataHeader(
+	meta *linkquisition.PluginMetadata, parentWindow fyne.Window,
+) fyne.CanvasObject {
+	items := make([]fyne.CanvasObject, 0, 4) //nolint:mnd
+
+	// Description (always shown if available)
+	if meta.Description != "" {
+		desc := widget.NewLabel(meta.Description)
+		desc.Wrapping = fyne.TextWrapWord
+		items = append(items, desc)
+	}
+
+	// Author (optional)
+	if meta.Author != "" {
+		authorLabel := widget.NewRichTextFromMarkdown("**" + i18n.T("config.plugins_author") + ":** " + meta.Author)
+		items = append(items, authorLabel)
+	}
+
+	// Homepage URL (optional)
+	if meta.URL != "" {
+		homepageRow := container.NewHBox(
+			ui.NewLinkWithCopy(meta.URL, meta.URL, parentWindow),
+		)
+		items = append(items, homepageRow)
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Add a separator after the metadata section
+	items = append(items, widget.NewSeparator())
+
+	return container.NewVBox(items...)
 }
 
 func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Container) {
@@ -89,7 +128,15 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 		return
 	}
 
-	scrollContent := container.NewVScroll(formContainer)
+	// Build scrollable content with optional metadata header
+	var scrollBody fyne.CanvasObject
+	if header := c.buildPluginMetadataHeader(&meta, parentWindow); header != nil {
+		scrollBody = container.NewVBox(header, formContainer)
+	} else {
+		scrollBody = formContainer
+	}
+
+	scrollContent := container.NewVScroll(scrollBody)
 	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
 
 	var d dialog.Dialog
@@ -163,7 +210,15 @@ func (c *Configurator) showAddPluginSettings(
 		return
 	}
 
-	scrollContent := container.NewVScroll(formContainer)
+	// Build scrollable content with optional metadata header
+	var scrollBody fyne.CanvasObject
+	if header := c.buildPluginMetadataHeader(meta, parentWindow); header != nil {
+		scrollBody = container.NewVBox(header, formContainer)
+	} else {
+		scrollBody = formContainer
+	}
+
+	scrollContent := container.NewVScroll(scrollBody)
 	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
 
 	var d dialog.Dialog

--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -8,11 +8,37 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/strobotti/linkquisition"
 	"github.com/strobotti/linkquisition/internal/i18n"
 )
+
+// buildDefaultSettingsFromMetadata constructs a settings map populated with default values
+// from the plugin's metadata descriptors.
+func buildDefaultSettingsFromMetadata(meta *linkquisition.PluginMetadata) map[string]interface{} {
+	defaults := make(map[string]interface{})
+	for _, desc := range meta.Settings {
+		if desc.Default == nil {
+			continue
+		}
+		switch desc.Type {
+		case linkquisition.SettingTypeStringList:
+			if list := convertToStringList(desc.Default); list != nil {
+				asIface := make([]interface{}, len(list))
+				for i, s := range list {
+					asIface[i] = s
+				}
+				defaults[desc.Key] = asIface
+			}
+		default:
+			defaults[desc.Key] = desc.Default
+		}
+	}
+	return defaults
+}
 
 func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Container) {
 	settings := c.settingsService.GetSettings()
@@ -34,8 +60,27 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 		editors[desc.Key] = getValue
 	}
 
-	// Build the form
+	// Build the form inside a container we can swap out
 	form := widget.NewForm(formItems...)
+	formContainer := container.NewStack(form)
+
+	// "Reset to defaults" button
+	resetBtn := widget.NewButton(i18n.T("config.plugins_reset_defaults"), func() {
+		defaultSettings := buildDefaultSettingsFromMetadata(&meta)
+		newEditors := make(map[string]func() interface{})
+		newFormItems := make([]*widget.FormItem, 0, len(meta.Settings))
+		for i := range meta.Settings {
+			desc := &meta.Settings[i]
+			item, getValue := c.buildSettingWidget(desc, defaultSettings)
+			newFormItems = append(newFormItems, item)
+			newEditors[desc.Key] = getValue
+		}
+		editors = newEditors
+		newForm := widget.NewForm(newFormItems...)
+		formContainer.RemoveAll()
+		formContainer.Add(newForm)
+		formContainer.Refresh()
+	})
 
 	title := i18n.T("config.plugins_settings_title", map[string]interface{}{templateKeyName: meta.Name})
 
@@ -44,23 +89,25 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 		return
 	}
 
-	scrollContent := container.NewVScroll(form)
-	scrollContent.SetMinSize(fyne.NewSize(700, 350)) //nolint:mnd
+	scrollContent := container.NewVScroll(formContainer)
+	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
 
-	d := dialog.NewCustomConfirm(
-		title,
-		i18n.T("config.plugins_save"),
-		i18n.T("config.plugins_cancel"),
-		scrollContent,
-		func(save bool) {
-			if !save {
-				return
-			}
-			c.savePluginSettings(pluginIdx, editors, listContainer)
-		},
-		parentWindow,
-	)
-	d.Resize(fyne.NewSize(780, 500)) //nolint:mnd
+	var d dialog.Dialog
+
+	saveBtn := widget.NewButton(i18n.T("config.plugins_save"), func() {
+		c.savePluginSettings(pluginIdx, editors, listContainer)
+		d.Hide()
+	})
+	saveBtn.Importance = widget.HighImportance
+	cancelBtn := widget.NewButton(i18n.T("config.plugins_cancel"), func() {
+		d.Hide()
+	})
+
+	buttonRow := container.NewHBox(resetBtn, layout.NewSpacer(), cancelBtn, saveBtn)
+	content := container.NewBorder(nil, buttonRow, nil, nil, scrollContent)
+
+	d = dialog.NewCustomWithoutButtons(title, content, parentWindow)
+	d.Resize(fyne.NewSize(820, 540)) //nolint:mnd
 	d.Show()
 }
 
@@ -76,8 +123,8 @@ func (c *Configurator) showAddPluginSettings(
 		return
 	}
 
-	// Build form items from metadata setting descriptors using defaults
-	defaultSettings := make(map[string]interface{})
+	// Pre-populate with default values from metadata descriptors
+	defaultSettings := buildDefaultSettingsFromMetadata(meta)
 	editors := make(map[string]func() interface{})
 	formItems := make([]*widget.FormItem, 0, len(meta.Settings))
 
@@ -89,6 +136,25 @@ func (c *Configurator) showAddPluginSettings(
 	}
 
 	form := widget.NewForm(formItems...)
+	formContainer := container.NewStack(form)
+
+	// "Reset to defaults" button
+	resetBtn := widget.NewButton(i18n.T("config.plugins_reset_defaults"), func() {
+		freshDefaults := buildDefaultSettingsFromMetadata(meta)
+		newEditors := make(map[string]func() interface{})
+		newFormItems := make([]*widget.FormItem, 0, len(meta.Settings))
+		for i := range meta.Settings {
+			desc := &meta.Settings[i]
+			item, getValue := c.buildSettingWidget(desc, freshDefaults)
+			newFormItems = append(newFormItems, item)
+			newEditors[desc.Key] = getValue
+		}
+		editors = newEditors
+		newForm := widget.NewForm(newFormItems...)
+		formContainer.RemoveAll()
+		formContainer.Add(newForm)
+		formContainer.Refresh()
+	})
 
 	title := i18n.T("config.plugins_settings_title", map[string]interface{}{templateKeyName: meta.Name})
 
@@ -97,30 +163,32 @@ func (c *Configurator) showAddPluginSettings(
 		return
 	}
 
-	scrollContent := container.NewVScroll(form)
-	scrollContent.SetMinSize(fyne.NewSize(700, 350)) //nolint:mnd
+	scrollContent := container.NewVScroll(formContainer)
+	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
 
-	d := dialog.NewCustomConfirm(
-		title,
-		i18n.T("config.plugins_save"),
-		i18n.T("config.plugins_cancel"),
-		scrollContent,
-		func(save bool) {
-			if !save {
-				return
+	var d dialog.Dialog
+
+	saveBtn := widget.NewButton(i18n.T("config.plugins_save"), func() {
+		// Collect settings from editors
+		pluginSettings := make(map[string]interface{})
+		for key, getValue := range editors {
+			if val := getValue(); val != nil {
+				pluginSettings[key] = val
 			}
-			// Collect settings from editors
-			pluginSettings := make(map[string]interface{})
-			for key, getValue := range editors {
-				if val := getValue(); val != nil {
-					pluginSettings[key] = val
-				}
-			}
-			c.addPluginWithSettings(pluginName, pluginSettings, listContainer)
-		},
-		parentWindow,
-	)
-	d.Resize(fyne.NewSize(780, 500)) //nolint:mnd
+		}
+		c.addPluginWithSettings(pluginName, pluginSettings, listContainer)
+		d.Hide()
+	})
+	saveBtn.Importance = widget.HighImportance
+	cancelBtn := widget.NewButton(i18n.T("config.plugins_cancel"), func() {
+		d.Hide()
+	})
+
+	buttonRow := container.NewHBox(resetBtn, layout.NewSpacer(), cancelBtn, saveBtn)
+	content := container.NewBorder(nil, buttonRow, nil, nil, scrollContent)
+
+	d = dialog.NewCustomWithoutButtons(title, content, parentWindow)
+	d.Resize(fyne.NewSize(820, 540)) //nolint:mnd
 	d.Show()
 }
 
@@ -256,7 +324,7 @@ func (c *Configurator) buildStringSetting(
 func (c *Configurator) buildStringListSetting(
 	desc *linkquisition.PluginSettingDescriptor, currentSettings map[string]interface{},
 ) (item *widget.FormItem, getValue func() interface{}) {
-	current := getSettingStringList(currentSettings, desc.Key)
+	current := getSettingStringList(currentSettings, desc.Key, desc.Default)
 	entry := widget.NewMultiLineEntry()
 	entry.SetText(strings.Join(current, "\n"))
 	entry.SetMinRowsVisible(3) //nolint:mnd
@@ -318,26 +386,19 @@ func (c *Configurator) buildKeyValueListSetting(
 		headerKey.TextStyle.Bold = true
 		headerVal := widget.NewLabel(valueLabel)
 		headerVal.TextStyle.Bold = true
-		headerRow := container.NewGridWithColumns(
-			3, //nolint:mnd
-			headerKey,
-			headerVal,
-			widget.NewLabel(""),
+		headerRow := container.NewBorder(nil, nil, nil, widget.NewLabel(""),
+			container.NewGridWithColumns(2, headerKey, headerVal), //nolint:mnd
 		)
 		listContainer.Add(headerRow)
 
 		for i := range rows {
 			idx := i
-			removeBtn := widget.NewButton("✕", func() {
+			removeBtn := widget.NewButtonWithIcon("", theme.DeleteIcon(), func() {
 				rows = append(rows[:idx], rows[idx+1:]...)
 				rebuildList()
 			})
-			row := container.NewGridWithColumns(
-				3, //nolint:mnd
-				rows[idx].keyEntry,
-				rows[idx].valueEntry,
-				removeBtn,
-			)
+			entries := container.NewGridWithColumns(2, rows[idx].keyEntry, rows[idx].valueEntry) //nolint:mnd
+			row := container.NewBorder(nil, nil, nil, removeBtn, entries)
 			listContainer.Add(row)
 		}
 	}
@@ -417,12 +478,19 @@ func getSettingBool(settings map[string]interface{}, key string, defaultVal inte
 	return false
 }
 
-func getSettingStringList(settings map[string]interface{}, key string) []string {
+func getSettingStringList(settings map[string]interface{}, key string, defaultVal interface{}) []string {
 	v, ok := settings[key]
 	if !ok {
+		if defaultVal != nil {
+			return convertToStringList(defaultVal)
+		}
 		return nil
 	}
 
+	return convertToStringList(v)
+}
+
+func convertToStringList(v interface{}) []string {
 	switch list := v.(type) {
 	case []interface{}:
 		result := make([]string, 0, len(list))

--- a/cmd/configurator_plugin_settings.go
+++ b/cmd/configurator_plugin_settings.go
@@ -21,7 +21,8 @@ import (
 // from the plugin's metadata descriptors.
 func buildDefaultSettingsFromMetadata(meta *linkquisition.PluginMetadata) map[string]interface{} {
 	defaults := make(map[string]interface{})
-	for _, desc := range meta.Settings {
+	for i := range meta.Settings {
+		desc := &meta.Settings[i]
 		if desc.Default == nil {
 			continue
 		}
@@ -29,12 +30,14 @@ func buildDefaultSettingsFromMetadata(meta *linkquisition.PluginMetadata) map[st
 		case linkquisition.SettingTypeStringList:
 			if list := convertToStringList(desc.Default); list != nil {
 				asIface := make([]interface{}, len(list))
-				for i, s := range list {
-					asIface[i] = s
+				for j, s := range list {
+					asIface[j] = s
 				}
 				defaults[desc.Key] = asIface
 			}
-		default:
+		case linkquisition.SettingTypeString, linkquisition.SettingTypeBool,
+			linkquisition.SettingTypeInt, linkquisition.SettingTypeDuration,
+			linkquisition.SettingTypeChoice, linkquisition.SettingTypeKeyValueList:
 			defaults[desc.Key] = desc.Default
 		}
 	}
@@ -137,7 +140,7 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 	}
 
 	scrollContent := container.NewVScroll(scrollBody)
-	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
+	scrollContent.SetMinSize(fyne.NewSize(780, 420)) //nolint:mnd
 
 	var d dialog.Dialog
 
@@ -154,7 +157,7 @@ func (c *Configurator) showPluginSettings(pluginIdx int, listContainer *fyne.Con
 	content := container.NewBorder(nil, buttonRow, nil, nil, scrollContent)
 
 	d = dialog.NewCustomWithoutButtons(title, content, parentWindow)
-	d.Resize(fyne.NewSize(820, 540)) //nolint:mnd
+	d.Resize(fyne.NewSize(900, 700)) //nolint:mnd
 	d.Show()
 }
 
@@ -219,7 +222,7 @@ func (c *Configurator) showAddPluginSettings(
 	}
 
 	scrollContent := container.NewVScroll(scrollBody)
-	scrollContent.SetMinSize(fyne.NewSize(740, 380)) //nolint:mnd
+	scrollContent.SetMinSize(fyne.NewSize(780, 420)) //nolint:mnd
 
 	var d dialog.Dialog
 
@@ -243,7 +246,7 @@ func (c *Configurator) showAddPluginSettings(
 	content := container.NewBorder(nil, buttonRow, nil, nil, scrollContent)
 
 	d = dialog.NewCustomWithoutButtons(title, content, parentWindow)
-	d.Resize(fyne.NewSize(820, 540)) //nolint:mnd
+	d.Resize(fyne.NewSize(900, 700)) //nolint:mnd
 	d.Show()
 }
 

--- a/cmd/configurator_plugin_settings_test.go
+++ b/cmd/configurator_plugin_settings_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/strobotti/linkquisition"
+)
+
+func TestBuildDefaultSettingsFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta := &linkquisition.PluginMetadata{
+		Name: "TestPlugin",
+		Settings: []linkquisition.PluginSettingDescriptor{
+			{
+				Key:     "stringVal",
+				Type:    linkquisition.SettingTypeString,
+				Default: "hello",
+			},
+			{
+				Key:     "boolVal",
+				Type:    linkquisition.SettingTypeBool,
+				Default: true,
+			},
+			{
+				Key:     "choiceVal",
+				Type:    linkquisition.SettingTypeChoice,
+				Default: "option1",
+				Options: []string{"option1", "option2"},
+			},
+			{
+				Key:  "noDefault",
+				Type: linkquisition.SettingTypeString,
+			},
+			{
+				Key:     "stringList",
+				Type:    linkquisition.SettingTypeStringList,
+				Default: []string{"a", "b", "c"},
+			},
+			{
+				Key:     "duration",
+				Type:    linkquisition.SettingTypeDuration,
+				Default: "168h",
+			},
+		},
+	}
+
+	defaults := buildDefaultSettingsFromMetadata(meta)
+
+	// String default
+	if v, ok := defaults["stringVal"]; !ok || v != "hello" {
+		t.Errorf("expected stringVal = 'hello', got %v", v)
+	}
+
+	// Bool default
+	if v, ok := defaults["boolVal"]; !ok || v != true {
+		t.Errorf("expected boolVal = true, got %v", v)
+	}
+
+	// Choice default
+	if v, ok := defaults["choiceVal"]; !ok || v != "option1" {
+		t.Errorf("expected choiceVal = 'option1', got %v", v)
+	}
+
+	// No default — should not be in the map
+	if _, ok := defaults["noDefault"]; ok {
+		t.Error("expected noDefault to not be in the map")
+	}
+
+	// StringList default — should be converted to []interface{}
+	if v, ok := defaults["stringList"]; !ok {
+		t.Error("expected stringList to be in the map")
+	} else {
+		list, ok := v.([]interface{})
+		if !ok {
+			t.Fatalf("expected stringList to be []interface{}, got %T", v)
+		}
+		if len(list) != 3 {
+			t.Fatalf("expected 3 items, got %d", len(list))
+		}
+		if list[0] != "a" || list[1] != "b" || list[2] != "c" {
+			t.Errorf("expected [a b c], got %v", list)
+		}
+	}
+
+	// Duration default (falls through to default case)
+	if v, ok := defaults["duration"]; !ok || v != "168h" {
+		t.Errorf("expected duration = '168h', got %v", v)
+	}
+}
+
+func TestGetSettingStringList_WithDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when no value and no default", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]interface{}{}
+		result := getSettingStringList(settings, "key", nil)
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("returns default when no value in settings", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]interface{}{}
+		defaultVal := []string{"x", "y"}
+		result := getSettingStringList(settings, "key", defaultVal)
+		if len(result) != 2 || result[0] != "x" || result[1] != "y" {
+			t.Errorf("expected [x y], got %v", result)
+		}
+	})
+
+	t.Run("returns value from settings over default", func(t *testing.T) {
+		t.Parallel()
+		settings := map[string]interface{}{
+			"key": []interface{}{"actual1", "actual2"},
+		}
+		defaultVal := []string{"default1"}
+		result := getSettingStringList(settings, "key", defaultVal)
+		if len(result) != 2 || result[0] != "actual1" || result[1] != "actual2" {
+			t.Errorf("expected [actual1 actual2], got %v", result)
+		}
+	})
+}

--- a/cmd/configurator_plugin_settings_test.go
+++ b/cmd/configurator_plugin_settings_test.go
@@ -6,10 +6,8 @@ import (
 	"github.com/strobotti/linkquisition"
 )
 
-func TestBuildDefaultSettingsFromMetadata(t *testing.T) {
-	t.Parallel()
-
-	meta := &linkquisition.PluginMetadata{
+func testPluginMetadata() *linkquisition.PluginMetadata {
+	return &linkquisition.PluginMetadata{
 		Name: "TestPlugin",
 		Settings: []linkquisition.PluginSettingDescriptor{
 			{
@@ -44,48 +42,58 @@ func TestBuildDefaultSettingsFromMetadata(t *testing.T) {
 			},
 		},
 	}
+}
 
-	defaults := buildDefaultSettingsFromMetadata(meta)
+func TestBuildDefaultSettings_ScalarTypes(t *testing.T) {
+	t.Parallel()
+	defaults := buildDefaultSettingsFromMetadata(testPluginMetadata())
 
-	// String default
 	if v, ok := defaults["stringVal"]; !ok || v != "hello" {
 		t.Errorf("expected stringVal = 'hello', got %v", v)
 	}
 
-	// Bool default
 	if v, ok := defaults["boolVal"]; !ok || v != true {
 		t.Errorf("expected boolVal = true, got %v", v)
 	}
 
-	// Choice default
 	if v, ok := defaults["choiceVal"]; !ok || v != "option1" {
 		t.Errorf("expected choiceVal = 'option1', got %v", v)
 	}
 
-	// No default — should not be in the map
+	if v, ok := defaults["duration"]; !ok || v != "168h" {
+		t.Errorf("expected duration = '168h', got %v", v)
+	}
+}
+
+func TestBuildDefaultSettings_NoDefaultOmitted(t *testing.T) {
+	t.Parallel()
+	defaults := buildDefaultSettingsFromMetadata(testPluginMetadata())
+
 	if _, ok := defaults["noDefault"]; ok {
 		t.Error("expected noDefault to not be in the map")
 	}
+}
 
-	// StringList default — should be converted to []interface{}
-	if v, ok := defaults["stringList"]; !ok {
-		t.Error("expected stringList to be in the map")
-	} else {
-		list, ok := v.([]interface{})
-		if !ok {
-			t.Fatalf("expected stringList to be []interface{}, got %T", v)
-		}
-		if len(list) != 3 {
-			t.Fatalf("expected 3 items, got %d", len(list))
-		}
-		if list[0] != "a" || list[1] != "b" || list[2] != "c" {
-			t.Errorf("expected [a b c], got %v", list)
-		}
+func TestBuildDefaultSettings_StringList(t *testing.T) {
+	t.Parallel()
+	defaults := buildDefaultSettingsFromMetadata(testPluginMetadata())
+
+	v, ok := defaults["stringList"]
+	if !ok {
+		t.Fatal("expected stringList to be in the map")
 	}
 
-	// Duration default (falls through to default case)
-	if v, ok := defaults["duration"]; !ok || v != "168h" {
-		t.Errorf("expected duration = '168h', got %v", v)
+	list, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected stringList to be []interface{}, got %T", v)
+	}
+
+	if len(list) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(list))
+	}
+
+	if list[0] != "a" || list[1] != "b" || list[2] != "c" {
+		t.Errorf("expected [a b c], got %v", list)
 	}
 }
 

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Regel hinzufügen"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Auf Standardwerte zurücksetzen"
   }
 }

--- a/internal/i18n/translations/de.json
+++ b/internal/i18n/translations/de.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Auf Standardwerte zurücksetzen"
+  },
+  "config.plugins_author": {
+    "other": "Autor"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Add rule"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Reset to defaults"
   }
 }

--- a/internal/i18n/translations/en.json
+++ b/internal/i18n/translations/en.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Reset to defaults"
+  },
+  "config.plugins_author": {
+    "other": "Author"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Restablecer valores predeterminados"
+  },
+  "config.plugins_author": {
+    "other": "Autor"
   }
 }

--- a/internal/i18n/translations/es.json
+++ b/internal/i18n/translations/es.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Añadir regla"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Restablecer valores predeterminados"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Palauta oletusarvot"
+  },
+  "config.plugins_author": {
+    "other": "Tekijä"
   }
 }

--- a/internal/i18n/translations/fi.json
+++ b/internal/i18n/translations/fi.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Lisää sääntö"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Palauta oletusarvot"
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Réinitialiser aux valeurs par défaut"
+  },
+  "config.plugins_author": {
+    "other": "Auteur"
   }
 }

--- a/internal/i18n/translations/fr.json
+++ b/internal/i18n/translations/fr.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Ajouter une règle"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Réinitialiser aux valeurs par défaut"
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Visszaállítás alapértelmezésre"
+  },
+  "config.plugins_author": {
+    "other": "Szerző"
   }
 }

--- a/internal/i18n/translations/hu.json
+++ b/internal/i18n/translations/hu.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Szabály hozzáadása"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Visszaállítás alapértelmezésre"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Restaurar padrões"
+  },
+  "config.plugins_author": {
+    "other": "Autor"
   }
 }

--- a/internal/i18n/translations/pt-BR.json
+++ b/internal/i18n/translations/pt-BR.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Adicionar regra"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Restaurar padrões"
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Repor predefinições"
+  },
+  "config.plugins_author": {
+    "other": "Autor"
   }
 }

--- a/internal/i18n/translations/pt.json
+++ b/internal/i18n/translations/pt.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Adicionar regra"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Repor predefinições"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Lägg till regel"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Återställ standardvärden"
   }
 }

--- a/internal/i18n/translations/sv.json
+++ b/internal/i18n/translations/sv.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Återställ standardvärden"
+  },
+  "config.plugins_author": {
+    "other": "Författare"
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -511,5 +511,8 @@
   },
   "config.plugins_reset_defaults": {
     "other": "Скинути до стандартних"
+  },
+  "config.plugins_author": {
+    "other": "Автор"
   }
 }

--- a/internal/i18n/translations/uk.json
+++ b/internal/i18n/translations/uk.json
@@ -508,5 +508,8 @@
   },
   "config.plugins_kv_add_row": {
     "other": "Додати правило"
+  },
+  "config.plugins_reset_defaults": {
+    "other": "Скинути до стандартних"
   }
 }

--- a/plugins/defang/defang.go
+++ b/plugins/defang/defang.go
@@ -74,6 +74,7 @@ func (p *defang) Metadata() linkquisition.PluginMetadata {
 				Label:       "Blocklist Sources",
 				Description: "URLs to download hosts-format blocklists from",
 				Type:        linkquisition.SettingTypeStringList,
+				Default:     defaultSources,
 			},
 			{
 				Key:         "updateInterval",

--- a/plugins/defang/defang.go
+++ b/plugins/defang/defang.go
@@ -65,7 +65,7 @@ func (p *defang) Metadata() linkquisition.PluginMetadata {
 	return linkquisition.PluginMetadata{
 		Name:        "Defang",
 		Description: "Checks URLs against known-malicious domain blocklists and blocks or warns before opening",
-		Author:      "Strobotti",
+		Author:      "Juha Jantunen",
 		Version:     "2.0.0",
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{

--- a/plugins/sanitize/sanitize.go
+++ b/plugins/sanitize/sanitize.go
@@ -96,7 +96,7 @@ func (p *sanitize) Metadata() linkquisition.PluginMetadata {
 	return linkquisition.PluginMetadata{
 		Name:        "Sanitize",
 		Description: "Strips tracking and marketing query parameters (UTM tags, click IDs, etc.) from URLs",
-		Author:      "Strobotti",
+		Author:      "Juha Jantunen",
 		Version:     "2.0.0",
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{

--- a/plugins/shenanigans/shenanigans.go
+++ b/plugins/shenanigans/shenanigans.go
@@ -66,7 +66,7 @@ func (p *shenanigans) Metadata() linkquisition.PluginMetadata {
 	return linkquisition.PluginMetadata{
 		Name:        "Shenanigans",
 		Description: "Adds completely useless but entertaining visual effects to the browser picker window",
-		Author:      "Strobotti",
+		Author:      "Juha Jantunen",
 		Version:     "1.0.0",
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{

--- a/plugins/terminus/terminus.go
+++ b/plugins/terminus/terminus.go
@@ -31,7 +31,7 @@ func (p *terminus) Metadata() linkquisition.PluginMetadata {
 	return linkquisition.PluginMetadata{
 		Name:        "Terminus",
 		Description: "Resolves redirect chains to find the final destination URL before browser matching",
-		Author:      "Strobotti",
+		Author:      "Juha Jantunen",
 		Version:     "2.0.0",
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{

--- a/plugins/unwrap/unwrap.go
+++ b/plugins/unwrap/unwrap.go
@@ -40,7 +40,7 @@ func (p *unwrap) Metadata() linkquisition.PluginMetadata {
 	return linkquisition.PluginMetadata{
 		Name:        "Unwrap",
 		Description: "Unwraps URLs that are wrapped inside redirect/tracking URLs (e.g. Microsoft Defender SafeLinks)",
-		Author:      "Strobotti",
+		Author:      "Juha Jantunen",
 		Version:     "2.0.0",
 		URL:         "https://github.com/Strobotti/linkquisition",
 		Settings: []linkquisition.PluginSettingDescriptor{


### PR DESCRIPTION
Improves the plugin configuration dialog with better discoverability and usability:

- **Default settings support**: Plugins can declare default values for all setting types (including string lists). The defang plugin now declares its blocklist source URLs as defaults, making them visible when adding the plugin.
- **Pre-populated defaults**: When adding a plugin via UI or CLI, settings are pre-populated from the plugin's declared defaults instead of being empty.
- **"Reset to defaults" button**: Both the edit and add plugin dialogs include a reset button (bottom-left, alongside Cancel/Save) that restores all fields to their declared defaults.
- **Plugin metadata header**: The settings dialog displays the plugin's description, author (optional), and homepage link (optional) above the form fields.
- **UI polish**: Key-value list delete buttons use the standard trash icon instead of a text "✕" button. Dialog size increased to 900×700 for better readability.
- **Author update**: Plugin author changed from "Strobotti" to "Juha Jantunen" across all five plugins.