### PR TITLE
fix(ci): add NSIS to PATH after Chocolatey install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,7 +128,10 @@ jobs:
 
       - name: Install NSIS
         if: matrix.target == 'windows-amd64'
-        run: choco install nsis -y
+        shell: pwsh
+        run: |
+          choco install nsis -y
+          echo "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build Windows installer (NSIS)
         if: matrix.target == 'windows-amd64'


### PR DESCRIPTION
The "Build Windows installer (NSIS)" step in the publish workflow fails because `makensis` is not on PATH after `choco install nsis`. Chocolatey installs it to `C:\Program Files (x86)\NSIS\` but doesn't update PATH for subsequent GitHub Actions steps.

Fix: write the NSIS install directory to `$GITHUB_PATH` so it persists across steps.