### PR TITLE
fix: NSIS installer icon format error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,7 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}" -replace '^v', ''
+          magick Icon.png -define icon:auto-resize=256,128,64,48,32,16 Icon.ico
           makensis /DVERSION=$version scripts/installer.nsi
         env:
           VERSION: ${{ github.ref_name }}

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -31,7 +31,7 @@ RequestExecutionLevel admin
 
 ; --- MUI Settings ---
 !define MUI_ABORTWARNING
-!define MUI_ICON "Icon.png"
+!define MUI_ICON "Icon.ico"
 
 ; --- Pages ---
 !insertmacro MUI_PAGE_WELCOME


### PR DESCRIPTION
NSIS requires `.ico` format for the installer icon but `MUI_ICON` was pointing at `Icon.png`, which NSIS can't parse. This caused the "can't open file" error during the Windows installer build.

Fix: convert `Icon.png` to a multi-resolution `Icon.ico` using ImageMagick (pre-installed on GitHub Windows runners) before running `makensis`. Updated `installer.nsi` to reference the `.ico` file.