### PR TITLE
fix: NSIS icon path resolution in Windows installer build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           $version = "${{ github.ref_name }}" -replace '^v', ''
           magick Icon.png -define icon:auto-resize=256,128,64,48,32,16 Icon.ico
-          makensis /DVERSION=$version scripts/installer.nsi
+          makensis /NOCD /DVERSION=$version scripts/installer.nsi
         env:
           VERSION: ${{ github.ref_name }}
 


### PR DESCRIPTION
`makensis` by default changes working directory to the script's folder (`scripts/`), so `Icon.ico` (generated in the repo root) couldn't be found. Added `/NOCD` flag to keep the working directory at the repo root where both `Icon.ico` and `dist/` exist.