### PR TITLE
fix(ci): commit generated Wayland headers to fix GoReleaser dirty state

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,8 +173,10 @@ jobs:
       - name: Generate Wayland protocol headers
         run: ./scripts/generate-wayland-protocols.sh
 
-      - name: Stage generated protocol headers for clean git state
-        run: git add vendor/github.com/go-gl/glfw/v3.4/glfw/glfw/src/*-client-protocol*.h
+      - name: Commit generated protocol headers for clean git state
+        run: |
+          git add vendor/github.com/go-gl/glfw/v3.4/glfw/glfw/src/*-client-protocol*.h
+          git -c user.name="CI" -c user.email="ci@localhost" commit -m "chore: generated wayland protocol headers" --allow-empty
 
       - name: Install syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin


### PR DESCRIPTION
GoReleaser detects staged-but-uncommitted files as a dirty git state and refuses to proceed. The previous approach of `git add` without `git commit` was insufficient.

Replace with a proper commit of the generated Wayland protocol headers so the working tree is clean when GoReleaser runs. The commit is local to the CI job and never pushed.