### PR TITLE
fix(ci): allow dirty git state in GoReleaser for generated Wayland headers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,11 +173,6 @@ jobs:
       - name: Generate Wayland protocol headers
         run: ./scripts/generate-wayland-protocols.sh
 
-      - name: Commit generated protocol headers for clean git state
-        run: |
-          git add vendor/github.com/go-gl/glfw/v3.4/glfw/glfw/src/*-client-protocol*.h
-          git -c user.name="CI" -c user.email="ci@localhost" commit -m "chore: generated wayland protocol headers" --allow-empty
-
       - name: Install syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,10 @@
 version: 2
 
+git:
+  # Allow dirty state because Wayland protocol headers are generated in CI
+  # and not committed to the repository.
+  allow_dirty: true
+
 builds:
   - id: "application"
     binary: "linkquisition"


### PR DESCRIPTION
The previous approach of committing generated files moved HEAD away from the tag, causing GoReleaser to fail with "tag was not made against commit".

Instead, use GoReleaser's built-in `git.allow_dirty` option which is designed for projects that generate files during CI. Remove the now-unnecessary commit step from the workflow.