### PR TITLE
fix(ci): skip GoReleaser validate to allow generated Wayland headers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,7 +188,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --clean --skip=publish
+          args: release --clean --skip=publish,validate
         env:
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,5 @@
 version: 2
 
-git:
-  # Allow dirty state because Wayland protocol headers are generated in CI
-  # and not committed to the repository.
-  allow_dirty: true
-
 builds:
   - id: "application"
     binary: "linkquisition"


### PR DESCRIPTION
`git.allow_dirty` does not exist in GoReleaser v2 config schema. Use `--skip=validate` CLI flag instead, which skips both the dirty git check and the tag-against-HEAD check.

Remove the invalid `git.allow_dirty` field from .goreleaser.yaml.