### PR TITLE
feat: support opening local files via browser picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,18 @@ it for the authoritative list of enabled linters and their settings. The linter 
 - Linux and macOS must stay in sync for shared plugin patterns
 - Windows does NOT support plugins (Go `plugin` package limitation)
 
+### Cross-platform path and URL handling
+
+- Use `filepath.IsAbs()` instead of checking for `/` prefix to detect absolute paths
+  (Windows uses `C:\` style paths)
+- `url.ParseRequestURI` treats Windows drive letters (e.g. `C:`) as URL schemes —
+  reject single-letter schemes when distinguishing paths from URLs
+- Use `filepath.Abs()` + `filepath.Join()` for path construction, never hardcode `/`
+- In tests, use `t.TempDir()` for platform-appropriate temp paths — never hardcode
+  `/tmp/...` (macOS resolves `/tmp` → `/private/tmp`, Windows uses `%TEMP%`)
+- File permissions in tests must be `0600` or less (`gosec` G306 rule)
+- The CI matrix runs tests on Linux, macOS, and Windows — all three must pass
+
 ## The `cmd` package
 
 The `cmd/` directory is `package main` — it cannot be imported by other packages.

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -156,7 +156,7 @@ func (a *Application) RunGUI(_ context.Context, urlToOpen string) error {
 	// of the last things before the process exits in the URL-opening path.
 	defer rotateLogFile(a.SettingsService)
 
-	a.Logger.Debug(fmt.Sprintf("Starting linkquisition with URL: `%s`", urlToOpen))
+	a.Logger.Debug(fmt.Sprintf("Starting linkquisition with input: `%s`", urlToOpen))
 
 	ctx, cancel := context.WithTimeout(context.Background(), pluginProcessTimeout)
 	defer cancel()

--- a/cmd/normalize_url_test.go
+++ b/cmd/normalize_url_test.go
@@ -90,7 +90,7 @@ func TestNormalizeInputURL_RelativePaths(t *testing.T) {
 	// Create a temp file so os.Stat succeeds
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.html")
-	err := os.WriteFile(testFile, []byte("<html></html>"), 0644)
+	err := os.WriteFile(testFile, []byte("<html></html>"), 0600)
 	assert.NoError(t, err)
 
 	// Change to the temp directory so relative path resolves
@@ -149,7 +149,7 @@ func TestIsRelativePath(t *testing.T) {
 func TestIsRelativePath_ExistingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "exists.html")
-	err := os.WriteFile(testFile, []byte("<html></html>"), 0644)
+	err := os.WriteFile(testFile, []byte("<html></html>"), 0600)
 	assert.NoError(t, err)
 
 	// Change to the temp dir so relative stat works

--- a/cmd/normalize_url_test.go
+++ b/cmd/normalize_url_test.go
@@ -61,29 +61,16 @@ func TestNormalizeInputURL_FileURLs(t *testing.T) {
 }
 
 func TestNormalizeInputURL_AbsolutePaths(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "absolute path is converted to file:// URL",
-			input:    "/tmp/test.html",
-			expected: "file:///tmp/test.html",
-		},
-		{
-			name:     "absolute path with spaces is converted",
-			input:    "/tmp/my file.html",
-			expected: "file:///tmp/my file.html",
-		},
-	}
+	// Use a real temp directory to get a valid absolute path on any OS
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.html")
+	spaceFile := filepath.Join(tmpDir, "my file.html")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeInputURL(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	result := normalizeInputURL(testFile)
+	assert.Equal(t, "file://"+testFile, result)
+
+	result = normalizeInputURL(spaceFile)
+	assert.Equal(t, "file://"+spaceFile, result)
 }
 
 func TestNormalizeInputURL_RelativePaths(t *testing.T) {

--- a/cmd/normalize_url_test.go
+++ b/cmd/normalize_url_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeInputURL_HTTPURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "https URL passes through unchanged",
+			input:    "https://www.example.com/path?q=1",
+			expected: "https://www.example.com/path?q=1",
+		},
+		{
+			name:     "http URL passes through unchanged",
+			input:    "http://example.com",
+			expected: "http://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeInputURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeInputURL_FileURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "file:// URL passes through unchanged",
+			input:    "file:///tmp/test.html",
+			expected: "file:///tmp/test.html",
+		},
+		{
+			name:     "file:// URL with spaces passes through unchanged",
+			input:    "file:///tmp/my%20file.html",
+			expected: "file:///tmp/my%20file.html",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeInputURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeInputURL_AbsolutePaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "absolute path is converted to file:// URL",
+			input:    "/tmp/test.html",
+			expected: "file:///tmp/test.html",
+		},
+		{
+			name:     "absolute path with spaces is converted",
+			input:    "/tmp/my file.html",
+			expected: "file:///tmp/my file.html",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeInputURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeInputURL_RelativePaths(t *testing.T) {
+	// Create a temp file so os.Stat succeeds
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.html")
+	err := os.WriteFile(testFile, []byte("<html></html>"), 0644)
+	assert.NoError(t, err)
+
+	// Change to the temp directory so relative path resolves
+	originalDir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	result := normalizeInputURL("test.html")
+
+	// On macOS, filepath.Abs may resolve symlinks (e.g. /var -> /private/var)
+	// so we just verify the result is a valid file:// URL pointing to the file
+	assert.True(t, len(result) > len("file://"), "result should be a file:// URL")
+	assert.True(t, result[:7] == "file://", "result should start with file://")
+	assert.True(t, filepath.Base(result) == "test.html", "result should end with test.html")
+}
+
+func TestNormalizeInputURL_NonExistentRelativePath(t *testing.T) {
+	// A relative path that doesn't exist on disk should be returned as-is
+	result := normalizeInputURL("nonexistent-xyz-12345.html")
+	assert.Equal(t, "nonexistent-xyz-12345.html", result)
+}
+
+func TestIsRelativePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "URL with scheme is not a relative path",
+			input:    "https://example.com",
+			expected: false,
+		},
+		{
+			name:     "file:// URL is not a relative path",
+			input:    "file:///tmp/test.html",
+			expected: false,
+		},
+		{
+			name:     "non-existent file is not detected as relative path",
+			input:    "nonexistent-xyz-99999.html",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRelativePath(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsRelativePath_ExistingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "exists.html")
+	err := os.WriteFile(testFile, []byte("<html></html>"), 0644)
+	assert.NoError(t, err)
+
+	// Change to the temp dir so relative stat works
+	originalDir, err := os.Getwd()
+	assert.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	assert.True(t, isRelativePath("exists.html"))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -52,9 +54,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	}
 
 	if urlToOpen != "" {
-		if _, err := url.ParseRequestURI(urlToOpen); err != nil {
-			return fmt.Errorf("invalid URL: %s", urlToOpen)
-		}
+		urlToOpen = normalizeInputURL(urlToOpen)
 	}
 
 	// GUI path — needs full application with fyne
@@ -72,6 +72,46 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	<-ctx.Done()
 
 	return nil
+}
+
+// normalizeInputURL converts raw file paths to file:// URLs and validates the input.
+// It accepts:
+// - http:// and https:// URLs (passed through)
+// - file:// URLs (passed through)
+// - Absolute file paths (converted to file:// URLs)
+// - Relative file paths (resolved to absolute, then converted to file:// URLs)
+func normalizeInputURL(input string) string {
+	// Already a valid URL with a scheme — pass through
+	if parsed, err := url.ParseRequestURI(input); err == nil && parsed.Scheme != "" {
+		return input
+	}
+
+	// Looks like a file path — convert to file:// URL
+	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, "~") || isRelativePath(input) {
+		absPath, err := filepath.Abs(input)
+		if err != nil {
+			return input
+		}
+		return "file://" + absPath
+	}
+
+	return input
+}
+
+// isRelativePath returns true if the input looks like a relative file path
+// (contains path separators or common file extensions, and doesn't look like a URL).
+func isRelativePath(input string) bool {
+	// If it contains a scheme-like prefix, it's not a path
+	if strings.Contains(input, "://") {
+		return false
+	}
+
+	// If the file exists on disk, it's definitely a path
+	if _, err := os.Stat(input); err == nil {
+		return true
+	}
+
+	return false
 }
 
 func initRootCmd() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func normalizeInputURL(input string) string {
 	}
 
 	// Looks like a file path — convert to file:// URL
-	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, "~") || isRelativePath(input) {
+	if filepath.IsAbs(input) || strings.HasPrefix(input, "~") || isRelativePath(input) {
 		absPath, err := filepath.Abs(input)
 		if err != nil {
 			return input

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,8 +81,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 // - Absolute file paths (converted to file:// URLs)
 // - Relative file paths (resolved to absolute, then converted to file:// URLs)
 func normalizeInputURL(input string) string {
-	// Already a valid URL with a scheme — pass through
-	if parsed, err := url.ParseRequestURI(input); err == nil && parsed.Scheme != "" {
+	// Already a valid URL with a scheme — pass through.
+	// On Windows, drive letters like "C:\path" parse as scheme "C" — reject single-letter schemes.
+	if parsed, err := url.ParseRequestURI(input); err == nil && parsed.Scheme != "" && len(parsed.Scheme) > 1 {
 		return input
 	}
 

--- a/internal/darwin/url_handler.h
+++ b/internal/darwin/url_handler.h
@@ -5,6 +5,7 @@ extern void HandleURL(char*);
 
 @interface GoPasser : NSObject
 + (void)handleGetURLEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
++ (void)handleOpenDocumentEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
 @end
 
 void StartURLHandler(void);

--- a/internal/darwin/url_handler.m
+++ b/internal/darwin/url_handler.m
@@ -9,6 +9,27 @@
     }
 }
 
++ (void)handleOpenDocumentEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
+    NSAppleEventDescriptor *directObject = [event paramDescriptorForKeyword:keyDirectObject];
+    if (directObject == nil) return;
+
+    // The direct object is a list of file descriptors
+    NSInteger count = [directObject numberOfItems];
+    for (NSInteger i = 1; i <= count; i++) {
+        NSAppleEventDescriptor *item = [directObject descriptorAtIndex:i];
+        // Try to get the URL from the file descriptor
+        NSString *urlStr = [item stringValue];
+        if (urlStr != nil) {
+            // Convert file path to file:// URL if it doesn't already have a scheme
+            if (![urlStr hasPrefix:@"file://"] && ![urlStr hasPrefix:@"http://"] && ![urlStr hasPrefix:@"https://"]) {
+                urlStr = [[NSURL fileURLWithPath:urlStr] absoluteString];
+            }
+            HandleURL((char *)[urlStr UTF8String]);
+            break; // Only handle the first document
+        }
+    }
+}
+
 @end
 
 void StartURLHandler(void) {
@@ -17,6 +38,10 @@ void StartURLHandler(void) {
                            andSelector:@selector(handleGetURLEvent:withReplyEvent:)
                          forEventClass:kInternetEventClass
                             andEventID:kAEGetURL];
+    [appleEventManager setEventHandler:[GoPasser class]
+                           andSelector:@selector(handleOpenDocumentEvent:withReplyEvent:)
+                         forEventClass:kCoreEventClass
+                            andEventID:kAEOpenDocuments];
 }
 
 void PumpEvents(double seconds) {

--- a/package/darwin/Info.plist
+++ b/package/darwin/Info.plist
@@ -33,6 +33,24 @@
             <array>
                 <string>http</string>
                 <string>https</string>
+                <string>file</string>
+            </array>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>HTML Document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.html</string>
+                <string>public.xhtml</string>
+                <string>public.url</string>
             </array>
         </dict>
     </array>


### PR DESCRIPTION
Fixes the macOS error "The document test.html could not be opened. Linkquisition cannot open files in the 'html text' format" when running `open test.html`.

## Changes

- Register a `kAEOpenDocuments` Apple Event handler so macOS can deliver file paths when a document is opened with Linkquisition
- Declare `CFBundleDocumentTypes` in `Info.plist` for HTML/XHTML documents (with `LSHandlerRank=Alternate` to avoid aggressively claiming file type ownership)
- Add `file` to `CFBundleURLSchemes` for `file://` URL routing
- Replace the strict `url.ParseRequestURI` validation with `normalizeInputURL()` that accepts file paths and converts them to `file://` URLs
- Add unit tests for the URL normalization logic

## How it works

When `open test.html` is used, macOS now:
1. Recognizes Linkquisition can handle HTML documents (via `CFBundleDocumentTypes`)
2. Delivers the file as a `kAEOpenDocuments` Apple Event (→ converted to `file:///path/to/test.html`)
3. The app normalizes the input and shows the browser picker

Direct CLI usage also works: `linkquisition /path/to/file.html` or `linkquisition test.html` (relative, if the file exists on disk).

## Testing

- `open test.html` → picker appears ✅
- `open -a Linkquisition /tmp/test.html` → picker appears ✅
- `linkquisition "file:///tmp/test.html"` → picker appears ✅
- `linkquisition "https://example.com"` → unchanged behavior ✅
- All existing tests pass ✅