### PR TITLE
fix: Safari detection on macOS and speed up Windows CI builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
 
+      - name: Disable Windows Defender real-time scanning
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Package Windows .zip
         if: matrix.target == 'windows-amd64'
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           go-version: '1.26.5'
 
+      - name: Disable Windows Defender real-time scanning
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+
       - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -69,7 +69,10 @@ func (b *BrowserService) getHTTPHandlers() ([]lsRegisterEntry, error) {
 		}
 
 		for _, entry := range dirEntries {
-			if !entry.IsDir() || !strings.HasSuffix(entry.Name(), ".app") {
+			// Note: we intentionally do NOT check entry.IsDir() here. On modern macOS,
+			// system apps like Safari are "firmlinked" and os.ReadDir reports them as
+			// non-directories despite being valid .app bundles.
+			if !strings.HasSuffix(entry.Name(), ".app") {
 				continue
 			}
 

--- a/internal/darwin/browser_service_test.go
+++ b/internal/darwin/browser_service_test.go
@@ -304,6 +304,28 @@ func TestGetAvailableBrowsers_ReturnsNonEmptyList(t *testing.T) {
 	assert.NotEmpty(t, browsers, "expected at least one browser on macOS")
 }
 
+func TestGetAvailableBrowsers_FindsSafari(t *testing.T) {
+	// Safari.app is a system app that os.ReadDir reports as a non-directory
+	// (firmlinked). Verify the scanner still detects it.
+	if _, err := os.Stat("/Applications/Safari.app/Contents/Info.plist"); err != nil {
+		t.Skip("Safari.app not found — skipping")
+	}
+
+	svc := &BrowserService{}
+	browsers, err := svc.GetAvailableBrowsers()
+	require.NoError(t, err)
+
+	found := false
+	for _, b := range browsers {
+		if b.Command == "com.apple.Safari" {
+			found = true
+			assert.Equal(t, "Safari", b.Name)
+			break
+		}
+	}
+	assert.True(t, found, "Safari should be detected in the browser list")
+}
+
 func TestParseBrowserPlist_CaseInsensitiveSchemes(t *testing.T) {
 	dir := t.TempDir()
 	plistPath := filepath.Join(dir, "Info.plist")


### PR DESCRIPTION
Two unrelated fixes bundled in one branch:

**Safari not detected by browser scan**

On modern macOS (Sequoia+), system apps like Safari are "firmlinked" and `os.ReadDir` reports them with `IsDir()=false`. The scanner was filtering on `IsDir()`, so Safari was silently skipped. Fixed by checking only for the `.app` suffix and the presence of `Contents/Info.plist`.

**Slow Windows builds on GitHub Actions**

Windows Defender real-time scanning was inspecting every temp file produced during Go compilation and package installation. Disabled it at the start of Windows CI jobs in both the publish and PR workflows.