### PR TITLE
fix: crash when favicon endpoint returns non-image response

### DIFF
--- a/cmd/browser_picker.go
+++ b/cmd/browser_picker.go
@@ -675,9 +675,11 @@ func (picker *BrowserPicker) fetchAndUpdateFavicon(
 		return
 	}
 
-	res := fyne.NewStaticResource("favicon.png", data)
-	img.Resource = res
-	img.Refresh()
+	res := fyne.NewStaticResource("favicon", data)
+	fyne.Do(func() {
+		img.Resource = res
+		img.Refresh()
+	})
 }
 
 func (picker *BrowserPicker) buildRememberCheck(

--- a/internal/favicon/favicon.go
+++ b/internal/favicon/favicon.go
@@ -168,6 +168,8 @@ func (f *Fetcher) fetchGoogle(ctx context.Context, rawURL string) ([]byte, error
 }
 
 // download performs the actual HTTP GET and returns the body bytes.
+// It validates that the response contains image data (by content-type header
+// and magic bytes) to avoid passing HTML or other non-image content to the renderer.
 func (f *Fetcher) download(ctx context.Context, fetchURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, http.NoBody)
 	if err != nil {
@@ -186,6 +188,12 @@ func (f *Fetcher) download(ctx context.Context, fetchURL string) ([]byte, error)
 		return nil, fmt.Errorf("favicon returned HTTP %d", resp.StatusCode)
 	}
 
+	// Reject responses that are clearly not images based on Content-Type
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "" && !isImageContentType(contentType) {
+		return nil, fmt.Errorf("non-image content type: %s", contentType)
+	}
+
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxFaviconBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading favicon: %w", err)
@@ -193,6 +201,11 @@ func (f *Fetcher) download(ctx context.Context, fetchURL string) ([]byte, error)
 
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty favicon response")
+	}
+
+	// Double-check with magic bytes — some servers send wrong Content-Type
+	if !isImageData(data) {
+		return nil, fmt.Errorf("response data is not a recognized image format")
 	}
 
 	return data, nil
@@ -220,7 +233,19 @@ func (f *Fetcher) readCache(host string) ([]byte, error) {
 		return nil, fmt.Errorf("cache expired")
 	}
 
-	return os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate cached data is still a recognized image format
+	// (protects against previously cached invalid responses)
+	if !isImageData(data) {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("cached data is not a valid image, evicting")
+	}
+
+	return data, nil
 }
 
 // writeCache writes favicon bytes to the cache directory.
@@ -257,4 +282,66 @@ func resolveIconURL(href string, base *url.URL) string {
 	}
 
 	return base.ResolveReference(ref).String()
+}
+
+// isImageContentType checks if a Content-Type header value indicates an image.
+func isImageContentType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+
+	// Split on ";" to ignore charset and other parameters
+	if idx := strings.IndexByte(ct, ';'); idx >= 0 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+
+	return strings.HasPrefix(ct, "image/")
+}
+
+// isImageData checks the first bytes of data for known image magic bytes.
+// Supports PNG, JPEG, GIF, ICO, BMP, WebP, and SVG.
+func isImageData(data []byte) bool {
+	if len(data) < 4 { //nolint:mnd
+		return false
+	}
+
+	// PNG: 89 50 4E 47
+	if data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 {
+		return true
+	}
+
+	// JPEG: FF D8 FF
+	if data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
+		return true
+	}
+
+	// GIF: GIF87a or GIF89a
+	if len(data) >= 6 && string(data[:6]) == "GIF87a" || string(data[:6]) == "GIF89a" {
+		return true
+	}
+
+	// ICO: 00 00 01 00
+	if data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x01 && data[3] == 0x00 {
+		return true
+	}
+
+	// BMP: 42 4D
+	if data[0] == 0x42 && data[1] == 0x4D {
+		return true
+	}
+
+	// WebP: RIFF....WEBP
+	if len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP" {
+		return true
+	}
+
+	// SVG: look for an <svg tag in the first 512 bytes (XML preamble may precede it)
+	checkLen := len(data)
+	if checkLen > 512 { //nolint:mnd
+		checkLen = 512
+	}
+	header := strings.ToLower(string(data[:checkLen]))
+	if strings.Contains(header, "<svg") {
+		return true
+	}
+
+	return false
 }

--- a/internal/favicon/favicon.go
+++ b/internal/favicon/favicon.go
@@ -4,6 +4,7 @@
 package favicon
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -296,6 +297,16 @@ func isImageContentType(contentType string) bool {
 	return strings.HasPrefix(ct, "image/")
 }
 
+// imageMagic holds known image format signatures for magic byte detection.
+var imageMagic = [][]byte{
+	{0x89, 0x50, 0x4E, 0x47}, // PNG
+	{0xFF, 0xD8, 0xFF},       // JPEG
+	[]byte("GIF87a"),         // GIF87a
+	[]byte("GIF89a"),         // GIF89a
+	{0x00, 0x00, 0x01, 0x00}, // ICO
+	{0x42, 0x4D},             // BMP
+}
+
 // isImageData checks the first bytes of data for known image magic bytes.
 // Supports PNG, JPEG, GIF, ICO, BMP, WebP, and SVG.
 func isImageData(data []byte) bool {
@@ -303,33 +314,14 @@ func isImageData(data []byte) bool {
 		return false
 	}
 
-	// PNG: 89 50 4E 47
-	if data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 {
-		return true
+	for _, magic := range imageMagic {
+		if bytes.HasPrefix(data, magic) {
+			return true
+		}
 	}
 
-	// JPEG: FF D8 FF
-	if data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
-		return true
-	}
-
-	// GIF: GIF87a or GIF89a
-	if len(data) >= 6 && string(data[:6]) == "GIF87a" || string(data[:6]) == "GIF89a" {
-		return true
-	}
-
-	// ICO: 00 00 01 00
-	if data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x01 && data[3] == 0x00 {
-		return true
-	}
-
-	// BMP: 42 4D
-	if data[0] == 0x42 && data[1] == 0x4D {
-		return true
-	}
-
-	// WebP: RIFF....WEBP
-	if len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP" {
+	// WebP: RIFF....WEBP (bytes 8-12 must be "WEBP")
+	if len(data) >= 12 && bytes.HasPrefix(data, []byte("RIFF")) && string(data[8:12]) == "WEBP" {
 		return true
 	}
 
@@ -338,10 +330,6 @@ func isImageData(data []byte) bool {
 	if checkLen > 512 { //nolint:mnd
 		checkLen = 512
 	}
-	header := strings.ToLower(string(data[:checkLen]))
-	if strings.Contains(header, "<svg") {
-		return true
-	}
 
-	return false
+	return strings.Contains(strings.ToLower(string(data[:checkLen])), "<svg")
 }

--- a/internal/favicon/favicon_test.go
+++ b/internal/favicon/favicon_test.go
@@ -20,6 +20,7 @@ func TestFetcher_FetchDirect(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/favicon.ico" {
+			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(faviconData)
 		} else {
@@ -54,9 +55,11 @@ func TestFetcher_FetchParsed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/":
+			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprintf(w, `<html><head><link rel="icon" href="/assets/icon.png"></head></html>`)
 		case "/assets/icon.png":
+			w.Header().Set("Content-Type", "image/x-icon")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(faviconData)
 		default:
@@ -79,9 +82,11 @@ func TestFetcher_FetchParsed_FallbackToDirect(t *testing.T) {
 		switch r.URL.Path {
 		case "/":
 			// HTML without any link icon tag
+			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusOK)
 			_, _ = fmt.Fprint(w, `<html><head><title>No Icon</title></head></html>`)
 		case "/favicon.ico":
+			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(faviconData)
 		default:
@@ -101,6 +106,7 @@ func TestFetcher_FetchGoogle(t *testing.T) {
 	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(faviconData)
 	}))
@@ -128,6 +134,7 @@ func TestFetcher_Cache(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/favicon.ico" {
 			callCount++
+			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(faviconData)
 		} else {
@@ -157,6 +164,7 @@ func TestFetcher_Cache_Expired(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/favicon.ico" {
+			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(faviconData)
 		} else {
@@ -212,6 +220,112 @@ func TestFetcher_ContextCanceled(t *testing.T) {
 
 	_, err := fetcher.Fetch(ctx, server.URL+"/page")
 	assert.Error(t, err)
+}
+
+func TestFetcher_RejectsHTMLResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><body>Not a favicon</body></html>`))
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, "")
+	_, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-image content type")
+}
+
+func TestFetcher_RejectsNonImageData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Server claims it's an image but sends garbage data
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error": "not found"}`))
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, "")
+	_, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not a recognized image format")
+}
+
+func TestFetcher_CacheEvictsInvalidData(t *testing.T) {
+	cacheDir := t.TempDir()
+	faviconData := []byte{0x89, 0x50, 0x4E, 0x47}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(faviconData)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewFetcher(StrategyDirect, cacheDir)
+
+	// Write an invalid (non-image) cache entry manually
+	host := "127.0.0.1"
+	cachePath := filepath.Join(cacheDir, cacheKey(host))
+	require.NoError(t, os.MkdirAll(cacheDir, cacheDirPerms))
+	require.NoError(t, os.WriteFile(cachePath, []byte("<html>not an image</html>"), cacheFilePerms))
+
+	// Should evict the bad cache entry and fetch fresh valid data
+	data, err := fetcher.Fetch(context.Background(), server.URL+"/page")
+	require.NoError(t, err)
+	assert.Equal(t, faviconData, data)
+}
+
+func TestIsImageData(t *testing.T) {
+	for _, tt := range [...]struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{name: "PNG", data: []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A}, expected: true},
+		{name: "JPEG", data: []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10}, expected: true},
+		{name: "GIF87a", data: []byte("GIF87a..."), expected: true},
+		{name: "GIF89a", data: []byte("GIF89a..."), expected: true},
+		{name: "ICO", data: []byte{0x00, 0x00, 0x01, 0x00, 0x01, 0x00}, expected: true},
+		{name: "BMP", data: []byte{0x42, 0x4D, 0x00, 0x00, 0x00, 0x00}, expected: true},
+		{name: "WebP", data: []byte("RIFF\x00\x00\x00\x00WEBP"), expected: true},
+		{name: "SVG", data: []byte(`<?xml version="1.0"?><svg xmlns="..."></svg>`), expected: true},
+		{name: "HTML", data: []byte(`<!DOCTYPE html><html><body></body></html>`), expected: false},
+		{name: "JSON", data: []byte(`{"error": "not found"}`), expected: false},
+		{name: "too short", data: []byte{0x89, 0x50}, expected: false},
+		{name: "empty", data: []byte{}, expected: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isImageData(tt.data))
+		})
+	}
+}
+
+func TestIsImageContentType(t *testing.T) {
+	for _, tt := range [...]struct {
+		name        string
+		contentType string
+		expected    bool
+	}{
+		{name: "image/png", contentType: "image/png", expected: true},
+		{name: "image/x-icon", contentType: "image/x-icon", expected: true},
+		{name: "image/svg+xml", contentType: "image/svg+xml", expected: true},
+		{name: "image/png with charset", contentType: "image/png; charset=utf-8", expected: true},
+		{name: "text/html", contentType: "text/html", expected: false},
+		{name: "text/html with charset", contentType: "text/html; charset=UTF-8", expected: false},
+		{name: "application/json", contentType: "application/json", expected: false},
+		{name: "empty", contentType: "", expected: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isImageContentType(tt.contentType))
+		})
+	}
 }
 
 func TestResolveIconURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a crash (`nil pointer dereference`) when the favicon fetcher receives non-image content (e.g. HTML error pages) from servers that don't serve a proper favicon.

Reproducible with: `linkquisition "https://console.mistral.ai"` (their `/favicon.ico` returns an nginx HTML page).

## Changes

1. **Validate favicon responses** (`internal/favicon/favicon.go`)
   - Reject responses with non-`image/*` Content-Type headers
   - Validate response body against known image magic bytes (PNG, JPEG, GIF, ICO, BMP, WebP, SVG)
   - Validate cached entries on read and evict invalid ones automatically

2. **Fix thread-safety in UI update** (`cmd/browser_picker.go`)
   - Wrap `img.Resource`/`img.Refresh()` in `fyne.Do()` to prevent concurrent access from the favicon goroutine
   - Rename resource from `"favicon.png"` to `"favicon"` to avoid format assumption from extension

3. **Tests** (`internal/favicon/favicon_test.go`)
   - Fix existing tests to set proper `Content-Type` headers on test servers
   - Add tests for HTML rejection, non-image data rejection, cache eviction, magic byte detection, and content-type parsing

## Testing

- All 18 favicon tests pass
- Manual test: `linkquisition "https://console.mistral.ai"` no longer crashes (favicon gracefully falls back to placeholder)