### PR TITLE
fix: set Windows binary subsystem to GUI

### DIFF
--- a/Taskfile.build.yml
+++ b/Taskfile.build.yml
@@ -11,11 +11,12 @@ tasks:
       OUTPUT: '{{default "linkquisition" .OUTPUT}}'
       TARGET: '{{default "linux" .TARGET}}'
       ARCH: '{{default "" .ARCH}}'
+      EXTRA_LDFLAGS: '{{default "" .EXTRA_LDFLAGS}}'
       VERSION:
         sh: echo ${VERSION:-v0.0.0}
       OPTIONS: '{{default "" .DEVOPTIONS}}'
     cmds:
-      - CGO_ENABLED=1 GOOS={{.TARGET}} {{if .ARCH}}GOARCH={{.ARCH}}{{end}} go build -trimpath -tags release -ldflags '-s -w -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
+      - CGO_ENABLED=1 GOOS={{.TARGET}} {{if .ARCH}}GOARCH={{.ARCH}}{{end}} go build -trimpath -tags release -ldflags '-s -w {{.EXTRA_LDFLAGS}} -X main.version={{.VERSION}} -X main.BuildTimestamp={{now | unixEpoch}}' {{.OPTIONS}} -o bin/{{.OUTPUT}}{{exeExt}} ./cmd/
       - echo "bin/{{.OUTPUT}}{{exeExt}} created successfully"
     sources:
       - ./**/*.go
@@ -63,6 +64,7 @@ tasks:
           OUTPUT: "linkquisition-windows-amd64"
           TARGET: "windows"
           ARCH: "amd64"
+          EXTRA_LDFLAGS: "-H windowsgui"
 
   plugins:
     cmds:


### PR DESCRIPTION
## Summary

The Windows installer produces a binary that fails to launch with a "this is a command-line application" error when opened from shortcuts, URL handlers, or double-click.

## Root cause

The Windows build was missing the `-H windowsgui` linker flag, so the Go compiler produced a PE binary with `IMAGE_SUBSYSTEM_WINDOWS_CUI` (console subsystem) instead of `IMAGE_SUBSYSTEM_WINDOWS_GUI`.

## Changes

- Added an `EXTRA_LDFLAGS` variable to the `binary` task in `Taskfile.build.yml` (defaults to empty, no impact on other platforms)
- Set `EXTRA_LDFLAGS: "-H windowsgui"` for the `windows-amd64` target

## Testing

- CLI subcommands still work (output goes to debugger/is discarded when no console is attached, which is expected for a GUI app)
- The binary should now launch correctly from the Start Menu shortcut, URL handler invocation, and double-click