### PR TITLE
fix: strip instance specific env vars from launched processes

### DIFF
--- a/internal/darwin/browser_service.go
+++ b/internal/darwin/browser_service.go
@@ -15,6 +15,7 @@ import (
 	"howett.net/plist"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/launchenv"
 )
 
 var _ linkquisition.BrowserService = (*BrowserService)(nil)
@@ -187,6 +188,7 @@ func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 
 func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
 	cmd := exec.Command("open", url)
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with default browser: %v", url, err)
 	}
@@ -195,6 +197,7 @@ func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
 
 func (b *BrowserService) OpenUrlWithBrowser(url string, browser *linkquisition.Browser) error {
 	cmd := exec.Command("open", "-b", browser.Command, url)
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with browser `%s`: %v", url, browser.Name, err)
 	}

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -97,6 +97,7 @@ func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 
 func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
 	cmd := exec.Command("xdg-open", url)
+	cmd.Env = sanitizeEnviron(cmd.Environ())
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with default browser: %v", url, err)
@@ -114,6 +115,7 @@ func (b *BrowserService) OpenUrlWithBrowser(u string, browser *linkquisition.Bro
 
 	// now just execute the damn command
 	cmd := exec.Command("sh", "-c", command)
+	cmd.Env = sanitizeEnviron(cmd.Environ())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with browser `%s`: %v", u, browser.Name, err)
 	}

--- a/internal/freedesktop/browser_service.go
+++ b/internal/freedesktop/browser_service.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/alessio/shellescape.v1"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/launchenv"
 )
 
 var _ linkquisition.BrowserService = (*BrowserService)(nil)
@@ -97,7 +98,7 @@ func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 
 func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
 	cmd := exec.Command("xdg-open", url)
-	cmd.Env = sanitizeEnviron(cmd.Environ())
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with default browser: %v", url, err)
@@ -115,7 +116,7 @@ func (b *BrowserService) OpenUrlWithBrowser(u string, browser *linkquisition.Bro
 
 	// now just execute the damn command
 	cmd := exec.Command("sh", "-c", command)
-	cmd.Env = sanitizeEnviron(cmd.Environ())
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with browser `%s`: %v", u, browser.Name, err)
 	}

--- a/internal/freedesktop/launchenv.go
+++ b/internal/freedesktop/launchenv.go
@@ -1,0 +1,30 @@
+package freedesktop
+
+import (
+	"slices"
+	"strings"
+)
+
+var launcherPrivateEnv = []string{
+	"CHROME_DESKTOP",
+	"CHROME_WRAPPER",
+	"CHROME_VERSION_EXTRA",
+	"GIO_LAUNCHED_DESKTOP_FILE",
+	"DESKTOP_STARTUP_ID",
+	"XDG_ACTIVATION_TOKEN",
+	"ELECTRON_RUN_AS_NODE",
+	"ELECTRON_FORCE_IS_PACKAGED",
+}
+
+// Returns a copy of the passed environment stripping some special values that
+// were inherited from linkquistion's own caller.
+//
+// This is done to prevent an edge case where clicking a link in one electron
+// app can cause the one the link should be opened in to retain instance
+// specific env variables.
+func sanitizeEnviron(environ []string) []string {
+	return slices.DeleteFunc(slices.Clone(environ), func(entry string) bool {
+		key, _, _ := strings.Cut(entry, "=")
+		return slices.Contains(launcherPrivateEnv, key)
+	})
+}

--- a/internal/launchenv/launchenv.go
+++ b/internal/launchenv/launchenv.go
@@ -1,4 +1,4 @@
-package freedesktop
+package launchenv
 
 import (
 	"slices"
@@ -6,14 +6,16 @@ import (
 )
 
 var launcherPrivateEnv = []string{
+	// Cross-platform
+	"ELECTRON_RUN_AS_NODE",
+	"ELECTRON_FORCE_IS_PACKAGED",
+	// Only relevant for linux
 	"CHROME_DESKTOP",
 	"CHROME_WRAPPER",
 	"CHROME_VERSION_EXTRA",
 	"GIO_LAUNCHED_DESKTOP_FILE",
 	"DESKTOP_STARTUP_ID",
 	"XDG_ACTIVATION_TOKEN",
-	"ELECTRON_RUN_AS_NODE",
-	"ELECTRON_FORCE_IS_PACKAGED",
 }
 
 // Returns a copy of the passed environment stripping some special values that
@@ -22,9 +24,11 @@ var launcherPrivateEnv = []string{
 // This is done to prevent an edge case where clicking a link in one electron
 // app can cause the one the link should be opened in to retain instance
 // specific env variables.
-func sanitizeEnviron(environ []string) []string {
+func SanitizeEnviron(environ []string) []string {
 	return slices.DeleteFunc(slices.Clone(environ), func(entry string) bool {
 		key, _, _ := strings.Cut(entry, "=")
-		return slices.Contains(launcherPrivateEnv, key)
+		return slices.ContainsFunc(launcherPrivateEnv, func(uppercaseKey string) bool {
+			return strings.EqualFold(key, uppercaseKey)
+		})
 	})
 }

--- a/internal/launchenv/launchenv.go
+++ b/internal/launchenv/launchenv.go
@@ -19,7 +19,7 @@ var launcherPrivateEnv = []string{
 }
 
 // Returns a copy of the passed environment stripping some special values that
-// were inherited from linkquistion's own caller.
+// were inherited from linkquisition's own caller.
 //
 // This is done to prevent an edge case where clicking a link in one electron
 // app can cause the one the link should be opened in to retain instance

--- a/internal/windows/browser_service.go
+++ b/internal/windows/browser_service.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/strobotti/linkquisition"
+	"github.com/strobotti/linkquisition/internal/launchenv"
 )
 
 var _ linkquisition.BrowserService = (*BrowserService)(nil)
@@ -149,6 +150,7 @@ func (b *BrowserService) GetDefaultBrowser() (linkquisition.Browser, error) {
 func (b *BrowserService) OpenUrlWithDefaultBrowser(url string) error {
 	// Use rundll32 to open with system default — avoids shell injection
 	cmd := exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with default browser: %v", url, err)
 	}
@@ -168,10 +170,12 @@ func (b *BrowserService) OpenUrlWithBrowser(url string, browser *linkquisition.B
 			return fmt.Errorf("empty browser command for %s", browser.Name)
 		}
 		cmd := exec.Command(parts[0], parts[1:]...)
+		cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 		return cmd.Start()
 	}
 
 	cmd := exec.Command(command, url)
+	cmd.Env = launchenv.SanitizeEnviron(cmd.Environ())
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to open URL `%s` with browser `%s`: %v", url, browser.Name, err)
 	}


### PR DESCRIPTION
This fixes a very specific and somewhat obscure bug I encountered while opening a link from `signal-desktop` in `tidal-hifi`. All of the env variables that signal launched with got inherited by linkquisition which in turn passed them down to `tidal-hifi`. As both `tidal-hifi` and `signal` are electron applications, the `CHROME_DESKTOP` variable was still set to the value it received for (and from) signal, which somehow caused `tidal-hifi` to segfault.

At first I just changed my manual entry for `tidal-hifi` to unset the var, which would suffice as a fix if you are against touching the process environment at all. As linkquistion is always going to play the role of a middleman between two apps though, I'd argue that this in scope for what this app should do, as for an (admittedly very specific) edge case like this, it would not be able to fulfill its role in that chain. I'd be interested in your view though :)

I also added this to all platforms as it should apply equally to all of them. I verified that the env also gets inherited on MacOS in the same way that it does on Unix (see also the [`open(1)` man page](https://manp.gs/mac/1/open). I don't currently have a windows install lying around, so those changes are speculative.

Currently, I have not added any test for these changes as I thought their scope to be small enough. I'd be happy to take a crack at building them though, just let me know if a small unit test suffices or if you'd like a full integration test as well :)

Also thanks for building this thing, it solved a very specific problem I had :sweat_smile: 

*full disclosure:* the list of variables was largely picked out by claude opus 5 but went through a lot of source code checks which makes me fairly confident that it holds.