### PR TITLE
fix: Windows Start Menu icon and CLI output

### DIFF
--- a/cmd/console_other.go
+++ b/cmd/console_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+// attachParentConsoleIfCLI is a no-op on non-Windows platforms.
+// On Windows, this attaches to the parent console so CLI output is visible.
+func attachParentConsoleIfCLI() {}

--- a/cmd/console_windows.go
+++ b/cmd/console_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+const attachParentProcess = ^uintptr(0) // ATTACH_PARENT_PROCESS = (DWORD)-1
+
+var (
+	kernel32          = syscall.NewLazyDLL("kernel32.dll")
+	procAttachConsole = kernel32.NewProc("AttachConsole")
+)
+
+// attachParentConsoleIfCLI attaches to the parent process's console so that
+// stdout/stderr are visible when the GUI-subsystem binary is launched from a
+// terminal (PowerShell, cmd). This enables --help, --version, and subcommand
+// output to appear in the calling console.
+//
+// Must be called before any output is written (i.e. at the top of main).
+// No-ops silently if there is no parent console (e.g. launched from Explorer).
+func attachParentConsoleIfCLI() {
+	// Only bother if there are arguments that look like CLI usage.
+	// When launched with no args or a URL arg, skip — we don't need a console.
+	if len(os.Args) <= 1 {
+		return
+	}
+
+	// If the first (and only) arg looks like a URL, skip.
+	if len(os.Args) == 2 && !isFlag(os.Args[1]) {
+		return
+	}
+
+	ret, _, _ := procAttachConsole.Call(attachParentProcess)
+	if ret == 0 {
+		// Failed to attach (no parent console) — nothing to do.
+		return
+	}
+
+	// Reopen stdout and stderr to the attached console.
+	conout, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	if err != nil {
+		return
+	}
+
+	os.Stdout = os.NewFile(uintptr(conout), "CONOUT$")
+	os.Stderr = os.NewFile(uintptr(conout), "CONOUT$")
+}
+
+// isFlag returns true if the argument starts with "-" or "/".
+func isFlag(arg string) bool {
+	if len(arg) == 0 {
+		return false
+	}
+	return arg[0] == '-' || arg[0] == '/'
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ var version = "dev"
 const exitCodePanic = 2
 
 func main() {
+	attachParentConsoleIfCLI()
 	os.Exit(run())
 }
 

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -49,8 +49,9 @@ RequestExecutionLevel admin
 Section "Install"
     SetOutPath $INSTDIR
 
-    ; Install the binary
+    ; Install the binary and icon
     File "dist\linkquisition.exe"
+    File "Icon.ico"
 
     ; Store install directory
     WriteRegStr HKCU "Software\${APPNAME}" "InstallDir" "$INSTDIR"
@@ -58,10 +59,8 @@ Section "Install"
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\uninstall.exe"
 
-    ; Start Menu shortcuts
-    CreateDirectory "$SMPROGRAMS\${APPNAME}"
-    CreateShortCut "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk" "$INSTDIR\linkquisition.exe"
-    CreateShortCut "$SMPROGRAMS\${APPNAME}\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+    ; Start Menu shortcut (directly in Start Menu for Windows 10/11 visibility)
+    CreateShortCut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\linkquisition.exe" "" "$INSTDIR\Icon.ico"
 
     ; Register as URL handler
     ; -- URL Class
@@ -83,6 +82,7 @@ Section "Install"
     ; Add/Remove Programs entry
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" '"$INSTDIR\uninstall.exe"'
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayIcon" "$INSTDIR\Icon.ico"
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$INSTDIR"
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "Publisher" "${COMPANYNAME}"
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayVersion" "${VERSION}"
@@ -95,13 +95,12 @@ SectionEnd
 Section "Uninstall"
     ; Remove files
     Delete "$INSTDIR\linkquisition.exe"
+    Delete "$INSTDIR\Icon.ico"
     Delete "$INSTDIR\uninstall.exe"
     RMDir "$INSTDIR"
 
-    ; Remove Start Menu shortcuts
-    Delete "$SMPROGRAMS\${APPNAME}\${APPNAME}.lnk"
-    Delete "$SMPROGRAMS\${APPNAME}\Uninstall.lnk"
-    RMDir "$SMPROGRAMS\${APPNAME}"
+    ; Remove Start Menu shortcut
+    Delete "$SMPROGRAMS\${APPNAME}.lnk"
 
     ; Remove registry entries
     DeleteRegKey HKCU "Software\Classes\LinkquisitionURL"


### PR DESCRIPTION
## Summary

Two issues with the Windows installer build:

1. **Start Menu shortcut has no icon and may not launch the app** — the shortcut was placed in a subfolder which Windows 10/11 doesn't surface well, had no icon reference, and the .ico file wasn't installed
2. **CLI commands (--help, --version, subcommands) produce no visible output** — with `-H windowsgui`, stdout/stderr are disconnected from the calling terminal

## Changes

### Console attachment (commit 1)
- Added `cmd/console_windows.go`: calls `AttachConsole(ATTACH_PARENT_PROCESS)` at startup when CLI flags are detected, reopens stdout/stderr to CONOUT$
- Added `cmd/console_other.go`: no-op for non-Windows platforms
- Called `attachParentConsoleIfCLI()` at the top of `main()`

### Installer fixes (commit 2)
- Install `Icon.ico` alongside the binary in Program Files
- Place the Start Menu shortcut directly in SMPROGRAMS (not a subfolder) for proper Windows 10/11 visibility
- Reference `Icon.ico` in the shortcut for a proper app icon
- Add `DisplayIcon` registry entry for Add/Remove Programs
- Clean up uninstall section to match

## Testing

- macOS build passes (`go build ./cmd/`)
- All tests pass (`go test ./...`)
- Windows-specific code verified with `go vet` (cross-compilation limited by CGO but Go source is syntactically correct)
- Full Windows CI will validate in the PR checks
