### PR TITLE
fix: Windows crash logging and console flash on file open

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -140,6 +140,8 @@ func (a *Application) RunGUI(_ context.Context, urlToOpen string) error {
 	i18n.Init(a.SettingsService.GetSettings().Locale)
 
 	if urlToOpen == "" {
+		a.Logger.Debug("Starting configurator (no URL argument)")
+
 		// Start watching for URLs arriving via platform events (macOS Apple Events)
 		// while the configurator is open.
 		watchCtx, watchCancel := context.WithCancel(context.Background())
@@ -148,6 +150,8 @@ func (a *Application) RunGUI(_ context.Context, urlToOpen string) error {
 		configurator := NewConfigurator(a.Fapp, a.BrowserService, a.SettingsService, a.Logger)
 		err := configurator.Run()
 		watchCancel()
+
+		a.Logger.Debug("Configurator closed", "error", err)
 
 		return err
 	}

--- a/cmd/configurator.go
+++ b/cmd/configurator.go
@@ -678,7 +678,8 @@ func openFileInEditor(path string) error {
 	case osDarwin:
 		return exec.CommandContext(ctx, "open", "-t", path).Start()
 	case "windows":
-		return exec.CommandContext(ctx, "cmd", "/c", "start", "", path).Start()
+		// Use rundll32 to avoid a console window flash (cmd.exe is a console app).
+		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", path).Start()
 	default: // Linux and other Unix-like systems
 		return exec.CommandContext(ctx, "xdg-open", path).Start()
 	}

--- a/cmd/crashlog_other.go
+++ b/cmd/crashlog_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+// redirectPanicLog is a no-op on non-Windows platforms.
+// On Unix-like systems, stderr is always available for panic output.
+func redirectPanicLog() {}

--- a/cmd/crashlog_windows.go
+++ b/cmd/crashlog_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// redirectPanicLog opens a crash log file in the user's local app data folder
+// and redirects the standard log package output there. This ensures panics and
+// early startup errors are captured even when stdout/stderr are disconnected
+// (GUI-subsystem binary launched from Explorer / Start Menu).
+func redirectPanicLog() {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return
+	}
+
+	logDir := filepath.Join(cacheDir, "linkquisition", "logs")
+	if mkErr := os.MkdirAll(logDir, 0755); mkErr != nil { //nolint:mnd
+		return
+	}
+
+	crashLog := filepath.Join(logDir, "crash.log")
+
+	f, openErr := os.OpenFile(crashLog, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600) //nolint:mnd
+	if openErr != nil {
+		return
+	}
+
+	log.SetOutput(f)
+	log.Printf("linkquisition starting (version=%s, args=%v)", version, os.Args)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ var version = "dev"
 const exitCodePanic = 2
 
 func main() {
+	redirectPanicLog()
 	attachParentConsoleIfCLI()
 	os.Exit(run())
 }


### PR DESCRIPTION
## Summary

Two Windows-specific fixes plus diagnostic tooling to help debug the Start Menu launch issue.

## Problem

1. **"Open log file" button flashes a console window and may fail** — uses `cmd /c start` which creates a visible cmd.exe window
2. **No diagnostic output when the app crashes on startup** — with `-H windowsgui`, panics go to NUL
3. **No log entries for the configurator path** — impossible to tell if the app started when launched from Start Menu

## Changes

### Commit 1: Crash log for Windows
- Redirects Go's `log` package output to `%LOCALAPPDATA%\linkquisition\logs\crash.log`
- Logs startup timestamp and arguments on every launch
- Catches panics that would otherwise vanish into NUL
- Added debug logging to the configurator startup path

### Commit 2: Fix console flash for "Open log file"
- Replaced `cmd /c start "" path` with `rundll32 url.dll,FileProtocolHandler path`
- No console window is created

## Debugging the Start Menu issue

After merging this, please:
1. Reinstall using the new installer (so the new shortcut is created)
2. Click the Start Menu shortcut
3. Check `%LOCALAPPDATA%\linkquisition\logs\crash.log` — it should show a startup line even if the app then fails
4. Check `%LOCALAPPDATA%\linkquisition\logs\linkquisition.log` — should now show "Starting configurator" at debug level
5. Also check the Windows taskbar — the window might be appearing there without coming to the foreground

If `crash.log` shows a startup line but no window appears and no panic is logged, the process is running but the Fyne window isn't being raised. If there's no startup line at all, the shortcut itself is broken.
