### PR TITLE
chore: upgrade Go from 1.26.5 to 1.26.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install Linux build dependencies (cached)
         if: runner.os == 'Linux'
@@ -168,7 +168,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install build dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Disable Windows Defender real-time scanning
         if: runner.os == 'Windows'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strobotti/linkquisition
 
-go 1.26.5
+go 1.26.6
 
 require (
 	fyne.io/fyne/v2 v2.8.0


### PR DESCRIPTION
Upgrades Go toolchain from 1.26.5 to 1.26.6 across all GitHub Actions workflows and go.mod.